### PR TITLE
Make HH mapping cache thread-safe

### DIFF
--- a/app/hh_mapping.py
+++ b/app/hh_mapping.py
@@ -1,8 +1,10 @@
 import json, os
+from threading import Lock
 from typing import Optional
 
 PATH = "data/hh_mapping.json"
 _cache: dict[str, str] = {}
+_lock = Lock()
 
 
 def _ensure_dir():
@@ -10,24 +12,26 @@ def _ensure_dir():
 
 
 def load() -> dict[str, str]:
-    global _cache
     _ensure_dir()
     if os.path.exists(PATH):
         with open(PATH, "r", encoding="utf-8") as f:
-            _cache = json.load(f) or {}
-    else:
-        _cache = {}
-    return _cache
+            return json.load(f) or {}
+    return {}
 
 
 def get(status_id: int) -> Optional[str]:
-    if not _cache:
-        load()
-    return _cache.get(str(status_id))
+    with _lock:
+        if not _cache:
+            _cache.update(load())
+        return _cache.get(str(status_id))
 
 
 def set_all(mapping: dict[str, str]) -> dict[str, str]:
     _ensure_dir()
     with open(PATH, "w", encoding="utf-8") as f:
         json.dump(mapping, f, ensure_ascii=False, indent=2)
-    return load()
+    new_data = mapping.copy()
+    with _lock:
+        _cache.clear()
+        _cache.update(new_data)
+    return new_data


### PR DESCRIPTION
## Summary
- avoid mutating cache in `load` and return new mapping
- protect cache access with a `Lock` for thread-safe `get` and `set_all`

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a82359cf9c8321a2e537a01c08787f