### PR TITLE
Centralize HTTP client usage

### DIFF
--- a/app/adapters/avito.py
+++ b/app/adapters/avito.py
@@ -11,7 +11,7 @@ def _is_retryable(status: int) -> bool:
     return status == 429 or 500 <= status < 600
 
 
-async def _access_token(owner_id: Optional[str]) -> str:
+async def _access_token(owner_id: Optional[str], client: httpx.AsyncClient) -> str:
     return await ensure_fresh_access(
         service="avito",
         token_url=settings.AVITO_TOKEN_URL,
@@ -20,21 +20,31 @@ async def _access_token(owner_id: Optional[str]) -> str:
         redirect_uri=settings.AVITO_REDIRECT_URI,
         use_basic_auth=True,
         owner_id=owner_id,
+        http_client=client,
     )
 
 
-async def send_message(negotiation_id: str, text: str, owner_id: Optional[str]) -> None:
-    access = await _access_token(owner_id)
+async def send_message(
+    negotiation_id: str,
+    text: str,
+    owner_id: Optional[str],
+    client: httpx.AsyncClient,
+) -> None:
+    access = await _access_token(owner_id, client)
     url = settings.AVITO_API_BASE.rstrip("/") + settings.AVITO_SEND_MESSAGE_PATH.format(negotiation_id=negotiation_id)
     body = {"message": {"text": text}}
 
     backoff = 0.5
     for _ in range(5):
-        async with httpx.AsyncClient(timeout=30) as x:
-            r = await x.post(url, json=body, headers={
+        r = await client.post(
+            url,
+            json=body,
+            headers={
                 "Authorization": f"Bearer {access}",
                 "Accept": "application/json",
-            })
+            },
+            timeout=30,
+        )
         if r.status_code < 400:
             return
         if _is_retryable(r.status_code):
@@ -45,17 +55,24 @@ async def send_message(negotiation_id: str, text: str, owner_id: Optional[str]) 
     raise AvitoError(f"Avito send_message retry exhausted for {negotiation_id}")
 
 
-async def mark_read(negotiation_id: str, owner_id: Optional[str]) -> None:
-    access = await _access_token(owner_id)
+async def mark_read(
+    negotiation_id: str,
+    owner_id: Optional[str],
+    client: httpx.AsyncClient,
+) -> None:
+    access = await _access_token(owner_id, client)
     url = settings.AVITO_API_BASE.rstrip("/") + settings.AVITO_MARK_READ_PATH.format(negotiation_id=negotiation_id)
 
     backoff = 0.5
     for _ in range(5):
-        async with httpx.AsyncClient(timeout=20) as x:
-            r = await x.post(url, headers={
+        r = await client.post(
+            url,
+            headers={
                 "Authorization": f"Bearer {access}",
                 "Accept": "application/json",
-            })
+            },
+            timeout=20,
+        )
         if r.status_code < 400:
             return
         if _is_retryable(r.status_code):

--- a/app/adapters/hh.py
+++ b/app/adapters/hh.py
@@ -11,7 +11,12 @@ def _is_retryable(status: int) -> bool:
     return status == 429 or 500 <= status < 600
 
 
-async def set_employer_state(response_id: str, target_state: str, employer_id: Optional[str]) -> None:
+async def set_employer_state(
+    response_id: str,
+    target_state: str,
+    employer_id: Optional[str],
+    client: httpx.AsyncClient,
+) -> None:
     """
     Меняет статус отклика (response/negotiation) у конкретного работодателя.
     """
@@ -23,6 +28,7 @@ async def set_employer_state(response_id: str, target_state: str, employer_id: O
         redirect_uri=settings.HH_REDIRECT_URI,
         use_basic_auth=False,
         owner_id=employer_id,
+        http_client=client,
     )
 
     url = settings.HH_API_BASE.rstrip("/") + settings.HH_SET_STATE_PATH.format(response_id=response_id)
@@ -30,11 +36,15 @@ async def set_employer_state(response_id: str, target_state: str, employer_id: O
 
     backoff = 0.5
     for _ in range(5):
-        async with httpx.AsyncClient(timeout=30) as x:
-            r = await x.post(url, json=payload, headers={
+        r = await client.post(
+            url,
+            json=payload,
+            headers={
                 "Authorization": f"Bearer {access}",
                 "Accept": "application/json",
-            })
+            },
+            timeout=30,
+        )
         if r.status_code < 400:
             return
         if _is_retryable(r.status_code):
@@ -46,7 +56,12 @@ async def set_employer_state(response_id: str, target_state: str, employer_id: O
     raise HHError(f"HH set_state retry exhausted for {response_id}->{target_state}")
 
 
-async def send_message(response_id: str, text: str, employer_id: Optional[str]) -> None:
+async def send_message(
+    response_id: str,
+    text: str,
+    employer_id: Optional[str],
+    client: httpx.AsyncClient,
+) -> None:
     access = await ensure_fresh_access(
         service="hh",
         token_url=settings.HH_TOKEN_URL,
@@ -55,17 +70,22 @@ async def send_message(response_id: str, text: str, employer_id: Optional[str]) 
         redirect_uri=settings.HH_REDIRECT_URI,
         use_basic_auth=False,
         owner_id=employer_id,
+        http_client=client,
     )
     url = settings.HH_API_BASE.rstrip("/") + f"/negotiations/{response_id}/messages"
     payload = {"message": {"text": text}}
 
     backoff = 0.5
     for _ in range(5):
-        async with httpx.AsyncClient(timeout=30) as x:
-            r = await x.post(url, json=payload, headers={
+        r = await client.post(
+            url,
+            json=payload,
+            headers={
                 "Authorization": f"Bearer {access}",
                 "Accept": "application/json",
-            })
+            },
+            timeout=30,
+        )
         if r.status_code < 400:
             return
         if _is_retryable(r.status_code):
@@ -74,7 +94,11 @@ async def send_message(response_id: str, text: str, employer_id: Optional[str]) 
     raise HHError(f"HH send_message retry exhausted for {response_id}")
 
 
-async def fetch_applicant_details(response_id: str, employer_id: Optional[str]) -> dict:
+async def fetch_applicant_details(
+    response_id: str,
+    employer_id: Optional[str],
+    client: httpx.AsyncClient,
+) -> dict:
     access = await ensure_fresh_access(
         service="hh",
         token_url=settings.HH_TOKEN_URL,
@@ -83,40 +107,40 @@ async def fetch_applicant_details(response_id: str, employer_id: Optional[str]) 
         redirect_uri=settings.HH_REDIRECT_URI,
         use_basic_auth=False,
         owner_id=employer_id,
+        http_client=client,
     )
 
     h = {"Authorization": f"Bearer {access}", "Accept": "application/json"}
     base = settings.HH_API_BASE.rstrip("/")
 
-    async with httpx.AsyncClient(timeout=30) as x:
-        # 1) negotiation -> resume id
-        r1 = await x.get(f"{base}/negotiations/{response_id}", headers=h)
-        if r1.status_code >= 400:
-            return {}
-        js1 = r1.json()
-        resume_id = (js1.get("resume") or {}).get("id")
-        if not resume_id:
-            return {}
+    # 1) negotiation -> resume id
+    r1 = await client.get(f"{base}/negotiations/{response_id}", headers=h, timeout=30)
+    if r1.status_code >= 400:
+        return {}
+    js1 = r1.json()
+    resume_id = (js1.get("resume") or {}).get("id")
+    if not resume_id:
+        return {}
 
-        # 2) resume -> phone, city, full name
-        r2 = await x.get(f"{base}/resumes/{resume_id}", headers=h)
-        if r2.status_code >= 400:
-            return {}
+    # 2) resume -> phone, city, full name
+    r2 = await client.get(f"{base}/resumes/{resume_id}", headers=h, timeout=30)
+    if r2.status_code >= 400:
+        return {}
 
-        j = r2.json()
-        city = ((j.get("area") or {}).get("name")) or None
-        # В разных схемах контакт может отличаться, разбираем безопасно:
-        phone = None
-        contact = j.get("contact") or {}
-        phones = contact.get("phones") or contact.get("phone") or []
-        if isinstance(phones, list) and phones:
-            phone = (phones[0].get("formatted") or phones[0].get("value") or None)
-        elif isinstance(phones, dict):
-            phone = phones.get("formatted") or phones.get("value") or None
+    j = r2.json()
+    city = ((j.get("area") or {}).get("name")) or None
+    # В разных схемах контакт может отличаться, разбираем безопасно:
+    phone = None
+    contact = j.get("contact") or {}
+    phones = contact.get("phones") or contact.get("phone") or []
+    if isinstance(phones, list) and phones:
+        phone = (phones[0].get("formatted") or phones[0].get("value") or None)
+    elif isinstance(phones, dict):
+        phone = phones.get("formatted") or phones.get("value") or None
 
-        name = " ".join([
-            (j.get("first_name") or "").strip(),
-            (j.get("last_name") or "").strip()
-        ]).strip() or (j.get("title") or None)
+    name = " ".join([
+        (j.get("first_name") or "").strip(),
+        (j.get("last_name") or "").strip()
+    ]).strip() or (j.get("title") or None)
 
-        return {"name": name, "city": city, "phone": phone}
+    return {"name": name, "city": city, "phone": phone}

--- a/app/amo_client.py
+++ b/app/amo_client.py
@@ -1,4 +1,6 @@
 import time, httpx
+import time
+import httpx
 from app.config import settings
 from app.token_store import TokenData, DbTokenStore
 
@@ -8,18 +10,19 @@ class ReauthRequired(Exception):
 
 
 class AmoClient:
-    def __init__(self, tokens: TokenData, store: DbTokenStore):
+    def __init__(self, tokens: TokenData, store: DbTokenStore, client: httpx.AsyncClient):
         self.base = settings.AMO_BASE_URL.rstrip("/")
         self.store = store
         self._access = tokens["access_token"]
         self._refresh = tokens["refresh_token"]
         self._expires_at = tokens["expires_at"]
+        self.client = client
 
     @classmethod
-    async def create(cls):
+    async def create(cls, client: httpx.AsyncClient):
         store = DbTokenStore("amo")
         tokens = await store.load()
-        return cls(tokens, store)
+        return cls(tokens, store, client)
 
     @property
     def headers(self):
@@ -34,8 +37,7 @@ class AmoClient:
             "refresh_token": self._refresh,
             "redirect_uri": settings.AMO_REDIRECT_URI,
         }
-        async with httpx.AsyncClient(timeout=30) as x:
-            r = await x.post(url, json=payload)
+        r = await self.client.post(url, json=payload, timeout=30)
         if r.status_code in (400, 401) and "invalid_grant" in (r.text or "").lower():
             raise ReauthRequired("Amo refresh_token invalid_grant")
         r.raise_for_status()
@@ -59,12 +61,10 @@ class AmoClient:
 
     async def _request(self, method: str, url: str, **kw):
         await self._ensure_token()
-        async with httpx.AsyncClient(timeout=30) as x:
-            r = await x.request(method, url, headers=self.headers, **kw)
+        r = await self.client.request(method, url, headers=self.headers, timeout=30, **kw)
         if r.status_code == 401:
             await self._refresh_token()
-            async with httpx.AsyncClient(timeout=30) as x:
-                r = await x.request(method, url, headers=self.headers, **kw)
+            r = await self.client.request(method, url, headers=self.headers, timeout=30, **kw)
         if r.is_error:
             print("AMO ERROR:", r.status_code, r.text)
             r.raise_for_status()
@@ -113,5 +113,5 @@ class AmoClient:
         return await self._request("PATCH", url, json=body)
 
     async def get_lead(self, lead_id: int):
-              url = f"{self.base}/api/v4/leads/{lead_id}"
-              return await self._request("GET", url)
+        url = f"{self.base}/api/v4/leads/{lead_id}"
+        return await self._request("GET", url)

--- a/app/amochats.py
+++ b/app/amochats.py
@@ -30,7 +30,7 @@ def _build_headers(secret: str, method: str, path: str, body: bytes) -> dict:
     return h
 
 
-async def connect_channel() -> dict:
+async def connect_channel(client: httpx.AsyncClient) -> dict:
     """Одноразовое подключение канала (hook_api_version=v2). Можно вызывать повторно — безопасно."""
     if not (settings.AMO_CHATS_CHANNEL_ID and settings.AMO_CHATS_ACCOUNT_ID and settings.AMO_CHATS_SECRET):
         raise AmoChatsError("AmoChats connect: env not configured")
@@ -43,19 +43,18 @@ async def connect_channel() -> dict:
         "title": getattr(settings, "AMOCHATS_INTEGRATION_NAME", "tg-bridge"),
     })
     headers = _build_headers(settings.AMO_CHATS_SECRET, "POST", path, body)
-    async with httpx.AsyncClient(timeout=30) as x:
-        r = await x.post(url, content=body, headers=headers)
+    r = await client.post(url, content=body, headers=headers, timeout=30)
     if r.status_code >= 400:
         raise AmoChatsError(f"connect failed {r.status_code}: {r.text}")
     return r.json() if r.content else {}
 
 
-async def ensure_amo_chats_connected(logger) -> None:
+async def ensure_amo_chats_connected(logger, client: httpx.AsyncClient) -> None:
     if not settings.AMO_CHATS_AUTOCONNECT:
         logger.info("AmoChats autoconnect disabled")
         return
     try:
-        await connect_channel()
+        await connect_channel(client)
         logger.info("AmoChats channel connected (v2)")
     except AmoChatsError as e:
         # если уже подключён — Amo обычно вернёт 200/204; на всякий логируем warning
@@ -66,6 +65,7 @@ async def send_text_from_client(
         *, lead_id: int, text: str,
         tg_user_id: int, tg_user_name: str | None = None,
         conversation_id: str | None = None,
+        client: httpx.AsyncClient,
 ) -> str | None:
     need = [settings.AMO_CHATS_SCOPE_ID, settings.AMO_CHATS_SECRET, settings.AMO_CHATS_ACCOUNT_ID]
     if not all(need):
@@ -98,8 +98,7 @@ async def send_text_from_client(
         body = _dump(payload)
         headers = _build_headers(settings.AMO_CHATS_SECRET, "POST", path, body)
         logger.debug("send_from_client POST %s -> %s bytes", route, len(body))
-        async with httpx.AsyncClient(timeout=30) as x:
-            r = await x.post(url, content=body, headers=headers)
+        r = await client.post(url, content=body, headers=headers, timeout=30)
         logger.debug("send_from_client %s response %s %s", route, r.status_code, r.text[:200])
         return r
 
@@ -137,6 +136,7 @@ async def send_text_from_manager(
         *, conversation_id: str,  # здесь нужен уже существующий uuid/id чата
         user_id: int, user_name: str | None, avatar: str | None,
         text: str,
+        client: httpx.AsyncClient,
 ) -> None:
     """
     Сообщение 'от менеджера' — используем sender.ref_id = AMO_CHATS_SENDER_USER_AMOJO_ID,
@@ -173,13 +173,18 @@ async def send_text_from_manager(
     body = _dump(payload)
     headers = _build_headers(settings.AMO_CHATS_SECRET, "POST", path, body)
 
-    async with httpx.AsyncClient(timeout=30) as x:
-        r = await x.post(url, content=body, headers=headers)
+    r = await client.post(url, content=body, headers=headers, timeout=30)
     if r.status_code >= 400:
         raise AmoChatsError(f"send_text_from_manager failed {r.status_code}: {r.text}")
 
 
-async def ensure_chat_created(*, lead_id: int, tg_user_id: int, tg_user_name: str | None) -> str:
+async def ensure_chat_created(
+        *,
+        lead_id: int,
+        tg_user_id: int,
+        tg_user_name: str | None,
+        client: httpx.AsyncClient,
+) -> str:
     """
     Форсирует создание/поиск чата в AmoChats по conversation_ref_id='lead:<id>'.
     Возвращает conversation_id (uuid). Сообщение-системка видно только в чате Amo.
@@ -210,8 +215,7 @@ async def ensure_chat_created(*, lead_id: int, tg_user_id: int, tg_user_name: st
     }
     body = _dump(payload)
     headers = _build_headers(settings.AMO_CHATS_SECRET, "POST", path, body)
-    async with httpx.AsyncClient(timeout=30) as x:
-        r = await x.post(url, content=body, headers=headers)
+    r = await client.post(url, content=body, headers=headers, timeout=30)
     if r.status_code >= 400:
         raise AmoChatsError(f"ensure_chat_created failed {r.status_code}: {r.text}")
 

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -4,7 +4,8 @@ import logging
 import time
 
 import httpx
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
+from app.http_client import get_http_client
 
 from app.config import settings
 from app.dedup import cleanup_older_than
@@ -57,20 +58,23 @@ async def dedup_clean(hours: int = 72):
 
 
 @admin.get("/hh-states")
-async def hh_states(owner_id: str | None = None):
+async def hh_states(
+    owner_id: str | None = None,
+    http_client: httpx.AsyncClient = Depends(get_http_client),
+):
     try:
         tok = await DbTokenStore("hh", owner_id).load()
     except Exception as e:
         return {"ok": False, "error": f"no hh token: {e}"}
 
-    async with httpx.AsyncClient(timeout=15) as x:
-        r = await x.get(
-            f"{settings.HH_API_BASE.rstrip('/')}/dictionaries",
-            headers={
-                "Authorization": f"Bearer {tok['access_token']}",
-                "Accept": "application/json",
-            },
-        )
+    r = await http_client.get(
+        f"{settings.HH_API_BASE.rstrip('/')}/dictionaries",
+        headers={
+            "Authorization": f"Bearer {tok['access_token']}",
+            "Accept": "application/json",
+        },
+        timeout=15,
+    )
     if r.status_code >= 400:
         return {"ok": False, "status": r.status_code, "body": r.text}
 

--- a/app/api/oauth.py
+++ b/app/api/oauth.py
@@ -7,12 +7,13 @@ import time
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter
+from fastapi import APIRouter, Depends
 from fastapi.responses import RedirectResponse
 
 from app.config import settings
 from app.queue import publish_task
 from app.token_store import DbTokenStore, TokenData
+from app.http_client import get_http_client
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,11 @@ def hh_start():
 
 
 @router.get("/oauth/hh/callback")
-async def hh_callback(code: str | None = None, state: str | None = None):
+async def hh_callback(
+    code: str | None = None,
+    state: str | None = None,
+    http_client: httpx.AsyncClient = Depends(get_http_client),
+):
     if not code:
         return {"ok": False, "error": "no code"}
 
@@ -44,12 +49,12 @@ async def hh_callback(code: str | None = None, state: str | None = None):
         "redirect_uri": settings.HH_REDIRECT_URI,
     }
     try:
-        async with httpx.AsyncClient(timeout=30) as x:
-            r = await x.post(
-                "https://api.hh.ru/token",
-                data=data,
-                headers={"Accept": "application/json"},
-            )
+        r = await http_client.post(
+            "https://api.hh.ru/token",
+            data=data,
+            headers={"Accept": "application/json"},
+            timeout=30,
+        )
         if r.status_code >= 400:
             return {
                 "ok": False,
@@ -69,20 +74,20 @@ async def hh_callback(code: str | None = None, state: str | None = None):
 
     # employer_id
     try:
-        async with httpx.AsyncClient(timeout=15) as x:
-            me = await x.get(
-                "https://api.hh.ru/me",
-                headers={"Authorization": f"Bearer {d['access_token']}"},
-            )
-            me.raise_for_status()
-            employer_id = str(me.json().get("employer", {}).get("id") or "")
-            if not employer_id:
-                return {
-                    "ok": False,
-                    "provider": "hh",
-                    "step": "me",
-                    "error": "no employer.id",
-                }
+        me = await http_client.get(
+            "https://api.hh.ru/me",
+            headers={"Authorization": f"Bearer {d['access_token']}"},
+            timeout=15,
+        )
+        me.raise_for_status()
+        employer_id = str(me.json().get("employer", {}).get("id") or "")
+        if not employer_id:
+            return {
+                "ok": False,
+                "provider": "hh",
+                "step": "me",
+                "error": "no employer.id",
+            }
     except Exception as e:
         return {"ok": False, "provider": "hh", "step": "me", "error": str(e)}
 
@@ -134,7 +139,11 @@ def avito_start():
 
 
 @router.get("/oauth/avito/callback")
-async def avito_callback(code: str | None = None, state: str | None = None):
+async def avito_callback(
+    code: str | None = None,
+    state: str | None = None,
+    http_client: httpx.AsyncClient = Depends(get_http_client),
+):
     if not code:
         return {"ok": False, "error": "no code"}
     if not (
@@ -151,8 +160,12 @@ async def avito_callback(code: str | None = None, state: str | None = None):
     }
     try:
         auth = httpx.BasicAuth(settings.AVITO_CLIENT_ID, settings.AVITO_CLIENT_SECRET)
-        async with httpx.AsyncClient(timeout=30) as x:
-            r = await x.post(settings.AVITO_TOKEN_URL, data=data, auth=auth)
+        r = await http_client.post(
+            settings.AVITO_TOKEN_URL,
+            data=data,
+            auth=auth,
+            timeout=30,
+        )
         if r.status_code >= 400:
             return {
                 "ok": False,
@@ -181,23 +194,23 @@ async def avito_callback(code: str | None = None, state: str | None = None):
 
     # 👉 автоматически узнаём account_id
     try:
-        async with httpx.AsyncClient(timeout=15) as x:
-            me = await x.get(
-                "https://api.avito.ru/core/v1/accounts/self",
-                headers={
-                    "Authorization": f"Bearer {access}",
-                    "Accept": "application/json",
-                },
-            )
-            me.raise_for_status()
-            account_id = str(me.json().get("id") or "")
-            if not account_id:
-                return {
-                    "ok": False,
-                    "provider": "avito",
-                    "step": "self",
-                    "error": "no account id",
-                }
+        me = await http_client.get(
+            "https://api.avito.ru/core/v1/accounts/self",
+            headers={
+                "Authorization": f"Bearer {access}",
+                "Accept": "application/json",
+            },
+            timeout=15,
+        )
+        me.raise_for_status()
+        account_id = str(me.json().get("id") or "")
+        if not account_id:
+            return {
+                "ok": False,
+                "provider": "avito",
+                "step": "self",
+                "error": "no account id",
+            }
     except Exception as e:
         return {"ok": False, "provider": "avito", "step": "self", "error": str(e)}
 
@@ -237,7 +250,11 @@ def amo_start():
 
 
 @router.get("/oauth/amo/callback")
-async def amo_callback(code: str | None = None, state: str | None = None):
+async def amo_callback(
+    code: str | None = None,
+    state: str | None = None,
+    http_client: httpx.AsyncClient = Depends(get_http_client),
+):
     if not code:
         return {"ok": False, "provider": "amo", "step": "callback", "error": "no code"}
 
@@ -251,8 +268,12 @@ async def amo_callback(code: str | None = None, state: str | None = None):
     }
 
     try:
-        async with httpx.AsyncClient(timeout=30) as x:
-            r = await x.post(url, json=payload, headers={"Accept": "application/json"})
+        r = await http_client.post(
+            url,
+            json=payload,
+            headers={"Accept": "application/json"},
+            timeout=30,
+        )
         if r.status_code >= 400:
             return {
                 "ok": False,

--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -6,6 +6,7 @@ from app.adapters import avito as avito_adapt, hh as hh_adapt
 from app.amo_client import AmoClient
 from app.hh_autofill import autofill_hh_mapping
 from app.token_store import DbTokenStore
+from app.http_client import get_http_client
 
 
 async def handle_task(p: dict):
@@ -19,29 +20,34 @@ async def handle_task(p: dict):
         ):
             raise RuntimeError("amo token missing/expired")
 
-        await autofill_hh_mapping()
+        await autofill_hh_mapping(get_http_client())
         return
 
     if p["platform"] == "hh" and p["action"] == "set_state":
+        client = get_http_client()
         await hh_adapt.set_employer_state(
             response_id=p["external_id"],
             target_state=p["target_state"],
             employer_id=p.get("owner_id"),
+            client=client,
         )
         return
 
     if p["platform"] == "avito" and p["action"] == "mark_read":
-        await avito_adapt.mark_read(p["external_id"], owner_id=p.get("owner_id"))
+        await avito_adapt.mark_read(p["external_id"], owner_id=p.get("owner_id"), client=get_http_client())
         return
 
     if p["platform"] == "avito" and p["action"] == "send_message":
         await avito_adapt.send_message(
-            p["external_id"], p.get("text") or "", owner_id=p.get("owner_id")
+            p["external_id"],
+            p.get("text") or "",
+            owner_id=p.get("owner_id"),
+            client=get_http_client(),
         )
         return
 
     if p["platform"] == "amo" and p["action"] == "amo_create_lead":
-        amo = await AmoClient.create()
+        amo = await AmoClient.create(get_http_client())
         await amo.create_leads(p["lead_body"])
         return
 

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -2,8 +2,9 @@
 
 import logging
 import time
+import httpx
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Request, Depends
 
 from app.adapters import avito as avito_adapt, hh as hh_adapt
 from app.amo_client import AmoClient, ReauthRequired
@@ -12,6 +13,7 @@ from app.dedup import calc_key, check_and_store
 from app.hh_mapping import get as hh_map_get, load as hh_map_load
 from app.queue import publish_task
 from app.store import find_link, save_link
+from app.http_client import get_http_client
 
 from .utils import (
     REFUSAL_TEXT_TO_HH,
@@ -28,7 +30,7 @@ router = APIRouter()
 
 
 @router.post("/webhooks/hh")
-async def webhook_hh(request: Request):
+async def webhook_hh(request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)):
     raw = await request.body()
     try:
         data = await request.json()
@@ -83,11 +85,11 @@ async def webhook_hh(request: Request):
         "vacancy_desc": vacancy_desc,
         "applicant": {"id": response_id, "name": applicant_name},
     }
-    return await _process_incoming(payload)
+    return await _process_incoming(payload, http_client)
 
 
 @router.post("/webhooks/avito")
-async def webhook_avito(request: Request):
+async def webhook_avito(request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)):
     raw = await request.body()
     try:
         data = await request.json()
@@ -133,10 +135,10 @@ async def webhook_avito(request: Request):
         "applicant": {"id": chat_id, "name": f"user:{applicant_id or 'unknown'}"},
         "raw_text": text,
     }
-    return await _process_incoming(internal)
+    return await _process_incoming(internal, http_client)
 
 
-async def _process_incoming(payload: dict):
+async def _process_incoming(payload: dict, http_client: httpx.AsyncClient):
     title = payload.get("vacancy_title") or ""
     desc = payload.get("vacancy_desc") or ""
     raw = payload.get("raw_text") or ""
@@ -149,7 +151,7 @@ async def _process_incoming(payload: dict):
     if payload.get("platform") == "hh" and payload.get("applicant", {}).get("id"):
         try:
             extra = await hh_adapt.fetch_applicant_details(
-                payload["applicant"]["id"], owner_id
+                payload["applicant"]["id"], owner_id, http_client
             )
             if extra:
                 phone = phone or extra.get("phone")
@@ -164,7 +166,7 @@ async def _process_incoming(payload: dict):
         logger.info("routing: ignore (no hashtags) title=%r", title)
         return {"ok": True, "ignored": True, "reason": "no-keywords"}
 
-    amo = await AmoClient.create()
+    amo = await AmoClient.create(http_client)
 
     if kind == "master":
         pipeline_id = settings.AMO_PIPELINE_ID_MASTER
@@ -327,7 +329,7 @@ async def _enrich_lead(
 
 
 @router.post("/webhooks/amo")
-async def amo_webhook(request: Request):
+async def amo_webhook(request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)):
     raw = await request.body()
     key = calc_key("amo", raw)
     if not await check_and_store(key):
@@ -366,7 +368,7 @@ async def amo_webhook(request: Request):
                 final_state = state
                 if is_refusal_code(state) and settings.AMO_CF_REFUSAL_REASON_ID:
                     try:
-                        amo = await AmoClient.create()
+                        amo = await AmoClient.create(http_client)
                         lead = await amo.get_lead(lead_id)
                         cfv = lead.get("custom_fields_values") or []
                         reason_text = None

--- a/app/api_amochats.py
+++ b/app/api_amochats.py
@@ -1,7 +1,9 @@
 import logging, hmac, hashlib, secrets
+import httpx
 from fastapi import APIRouter, Request, Response, Depends
 
 from app.amochats import connect_channel
+from app.http_client import get_http_client
 from app.dedup import calc_key, check_and_store
 from app.guards import require_admin
 from app.store_chat import get_by_lead, get_by_conversation, set_conversation, get_by_user
@@ -126,6 +128,6 @@ from fastapi import APIRouter as _APIRouter  # avoid shadow
 amo_admin = _APIRouter(prefix="/admin/amo-chats", dependencies=[Depends(require_admin)])
 
 @amo_admin.post("/connect")
-async def admin_connect():
-    resp = await connect_channel()
+async def admin_connect(http_client: httpx.AsyncClient = Depends(get_http_client)):
+    resp = await connect_channel(http_client)
     return {"ok": True, "response": resp}

--- a/app/hh_autofill.py
+++ b/app/hh_autofill.py
@@ -26,7 +26,10 @@ _STAGE_NAME_TO_HH = {
 }
 
 
-async def _fetch_pipeline_statuses(pipeline_id: int) -> list[dict]:
+async def _fetch_pipeline_statuses(
+    pipeline_id: int,
+    client: httpx.AsyncClient,
+) -> list[dict]:
     try:
         tok = await DbTokenStore("amo").load()
     except Exception as e:
@@ -35,20 +38,23 @@ async def _fetch_pipeline_statuses(pipeline_id: int) -> list[dict]:
 
     url = settings.AMO_BASE_URL.rstrip("/") + f"/api/v4/leads/pipelines/{pipeline_id}"
     try:
-        async with httpx.AsyncClient(timeout=20) as x:
-            r = await x.get(url, headers={
+        r = await client.get(
+            url,
+            headers={
                 "Authorization": f"Bearer {tok['access_token']}",
                 "Accept": "application/json",
-            })
-            r.raise_for_status()
-            pj = r.json() or {}
-            return (pj.get("_embedded") or {}).get("statuses") or []
+            },
+            timeout=20,
+        )
+        r.raise_for_status()
+        pj = r.json() or {}
+        return (pj.get("_embedded") or {}).get("statuses") or []
     except Exception as e:
         log.warning("hh-autofill: cannot fetch pipeline %s: %s", pipeline_id, e)
         return []
 
 
-async def autofill_hh_mapping() -> dict[str, str]:
+async def autofill_hh_mapping(client: httpx.AsyncClient) -> dict[str, str]:
     """
     Строит {amo_status_id: hh_code} по названиям стадий двух воронок (master/operator)
     и сохраняет в data/hh_mapping.json.
@@ -66,7 +72,7 @@ async def autofill_hh_mapping() -> dict[str, str]:
             log.info("hh-autofill: pipeline %s is not configured — skip", label)
             continue
 
-        statuses = await _fetch_pipeline_statuses(int(pid))
+        statuses = await _fetch_pipeline_statuses(int(pid), client)
         if not statuses:
             log.info("hh-autofill: no statuses for pipeline %s (%s)", label, pid)
             continue

--- a/app/hh_webhooks.py
+++ b/app/hh_webhooks.py
@@ -21,7 +21,7 @@ def _events() -> list[str]:
     return ["negotiation_created"]
 
 
-async def ensure_hh_webhook() -> None:
+async def ensure_hh_webhook(client: httpx.AsyncClient) -> None:
     url = _target_url()
     if not url:
         log.info("HH webhook: HH_WEBHOOK_URL пуст — пропускаю регистрацию")
@@ -41,38 +41,42 @@ async def ensure_hh_webhook() -> None:
     want_events = _events()
 
     try:
-        async with httpx.AsyncClient(timeout=20) as x:
-            r = await x.get(HH_SUBS_URL, headers=headers)
-            r.raise_for_status()
-            js = r.json()
-            items = js if isinstance(js, list) else js.get("items", [])
+        r = await client.get(HH_SUBS_URL, headers=headers, timeout=20)
+        r.raise_for_status()
+        js = r.json()
+        items = js if isinstance(js, list) else js.get("items", [])
 
-            current = None
-            for it in items:
-                if str(it.get("url", "")).strip() == url:
-                    current = it
-                    break
+        current = None
+        for it in items:
+            if str(it.get("url", "")).strip() == url:
+                current = it
+                break
 
-            if not current:
-                body = {"url": url, "events": want_events}
-                cr = await x.post(HH_SUBS_URL, json=body, headers=headers)
-                if cr.status_code in (401, 403, 404):
-                    log.warning("HH webhook: %s — нет прав/токен/фича недоступна", cr.status_code)
-                    return
-                cr.raise_for_status()
-                log.info("HH webhook: создано -> %s [%s]", url, ",".join(want_events))
+        if not current:
+            body = {"url": url, "events": want_events}
+            cr = await client.post(HH_SUBS_URL, json=body, headers=headers, timeout=20)
+            if cr.status_code in (401, 403, 404):
+                log.warning("HH webhook: %s — нет прав/токен/фича недоступна", cr.status_code)
                 return
+            cr.raise_for_status()
+            log.info("HH webhook: создано -> %s [%s]", url, ",".join(want_events))
+            return
 
-            have_events = sorted([e.strip() for e in current.get("events", [])])
-            if sorted(want_events) != have_events:
-                del_id = current.get("id") or current.get("subscription_id")
-                if del_id:
-                    await x.delete(f"{HH_SUBS_URL}/{del_id}", headers=headers)
-                cr = await x.post(HH_SUBS_URL, json={"url": url, "events": want_events}, headers=headers)
-                cr.raise_for_status()
-                log.info("HH webhook: обновлено -> %s [%s]", url, ",".join(want_events))
-            else:
-                log.info("HH webhook: уже настроено -> %s [%s]", url, ",".join(want_events))
+        have_events = sorted([e.strip() for e in current.get("events", [])])
+        if sorted(want_events) != have_events:
+            del_id = current.get("id") or current.get("subscription_id")
+            if del_id:
+                await client.delete(f"{HH_SUBS_URL}/{del_id}", headers=headers, timeout=20)
+            cr = await client.post(
+                HH_SUBS_URL,
+                json={"url": url, "events": want_events},
+                headers=headers,
+                timeout=20,
+            )
+            cr.raise_for_status()
+            log.info("HH webhook: обновлено -> %s [%s]", url, ",".join(want_events))
+        else:
+            log.info("HH webhook: уже настроено -> %s [%s]", url, ",".join(want_events))
 
     except httpx.HTTPStatusError as e:
         log.exception("HH webhook: HTTP error (%s): %s", e.response.status_code, e.response.text)

--- a/app/http_client.py
+++ b/app/http_client.py
@@ -1,0 +1,17 @@
+import httpx
+
+_http_client: httpx.AsyncClient | None = httpx.AsyncClient()
+
+
+def get_http_client() -> httpx.AsyncClient:
+    """Return a singleton AsyncClient instance."""
+    assert _http_client is not None
+    return _http_client
+
+
+async def close_http_client() -> None:
+    """Close the shared AsyncClient instance."""
+    global _http_client
+    if _http_client is not None:
+        await _http_client.aclose()
+        _http_client = None

--- a/app/oauth2.py
+++ b/app/oauth2.py
@@ -3,6 +3,7 @@ import time
 import httpx
 from typing import Optional
 from app.token_store import DbTokenStore, TokenData
+from app.http_client import get_http_client
 
 
 class OAuth2RefreshError(Exception):
@@ -19,6 +20,7 @@ async def refresh_tokens(
     redirect_uri: Optional[str] = None,
     use_basic_auth: bool = False,
     owner_id: Optional[str] = None,
+    http_client: httpx.AsyncClient | None = None,
 ) -> TokenData:
     """
     Универсальный refresh_token.
@@ -32,8 +34,14 @@ async def refresh_tokens(
     if redirect_uri:
         data["redirect_uri"] = redirect_uri
 
-    async with httpx.AsyncClient(timeout=30) as x:
-        r = await x.post(token_url, data=data, headers={"Accept": "application/json"}, auth=auth)
+    client = http_client or get_http_client()
+    r = await client.post(
+        token_url,
+        data=data,
+        headers={"Accept": "application/json"},
+        auth=auth,
+        timeout=30,
+    )
     if r.status_code >= 400:
         raise OAuth2RefreshError(f"{service} refresh failed {r.status_code}: {r.text}")
 
@@ -60,6 +68,7 @@ async def ensure_fresh_access(
     use_basic_auth: bool = False,
     margin_sec: int = 120,
     owner_id: Optional[str] = None,
+    http_client: httpx.AsyncClient | None = None,
 ) -> str:
     """
     Возвращает свежий access_token, обновляя при необходимости.
@@ -77,5 +86,6 @@ async def ensure_fresh_access(
             redirect_uri=redirect_uri,
             use_basic_auth=use_basic_auth,
             owner_id=owner_id,
+            http_client=http_client,
         )
     return data["access_token"]

--- a/app/worker_rmq.py
+++ b/app/worker_rmq.py
@@ -12,6 +12,7 @@ from app.amo_client import AmoClient, ReauthRequired
 from app.logging_setup import setup_logging
 from app.store_chat import set_conversation
 from app.services import tg_send_with_retry, with_backoff
+from app.http_client import get_http_client
 
 setup_logging("INFO")
 logger = logging.getLogger(__name__)
@@ -33,10 +34,12 @@ def _is_transient(e: Exception) -> bool:
 
 async def handle_hh_send_message(payload: dict):
     logger.info("hh.send_message: %s", payload.get("external_id"))
+    client = get_http_client()
     await hh_adapt.send_message(
         payload["external_id"],
         payload["text"],
         employer_id=payload.get("owner_id"),
+        client=client,
     )
 
 
@@ -46,10 +49,12 @@ async def handle_hh_set_state(payload: dict):
         payload.get("external_id"),
         payload.get("target_state"),
     )
+    client = get_http_client()
     await hh_adapt.set_employer_state(
         payload["external_id"],
         payload["target_state"],
         employer_id=payload.get("owner_id"),
+        client=client,
     )
 
 
@@ -59,33 +64,39 @@ async def handle_debug_echo(payload: dict):
 
 async def handle_avito_send_message(payload: dict):
     logger.info("avito.send_message: %s", payload.get("external_id"))
+    client = get_http_client()
     await avito_adapt.send_message(
         payload["external_id"],
         payload["text"],
         owner_id=payload.get("owner_id"),
+        client=client,
     )
 
 
 async def handle_avito_mark_read(payload: dict):
     logger.info("avito.mark_read: %s", payload.get("external_id"))
-    await avito_adapt.mark_read(payload["external_id"], owner_id=payload.get("owner_id"))
+    await avito_adapt.mark_read(
+        payload["external_id"],
+        owner_id=payload.get("owner_id"),
+        client=get_http_client(),
+    )
 
 
 async def handle_amo_create_lead(payload: dict):
     logger.info("amo.create_lead")
-    amo = await AmoClient.create()
+    amo = await AmoClient.create(get_http_client())
     await amo.create_leads(payload["lead_body"])
 
 
 async def handle_amo_add_note(payload: dict):
     logger.info("amo.add_note: %s", payload.get("lead_id"))
-    amo = await AmoClient.create()
+    amo = await AmoClient.create(get_http_client())
     await amo.add_note(int(payload["lead_id"]), payload["text"])
 
 
 async def handle_amo_add_tags(payload: dict):
     logger.info("amo.add_tags: %s", payload.get("lead_id"))
-    amo = await AmoClient.create()
+    amo = await AmoClient.create(get_http_client())
     await amo.add_tags(int(payload["lead_id"]), list(payload.get("tags") or []))
 
 
@@ -118,8 +129,9 @@ async def handle_mirror_tg_to_amo(payload: dict):
     tg_user_name = payload.get("tg_user_name")
     conv_id = payload.get("conversation_id")
     bot_kind = payload.get("bot_kind")
-    amo = await AmoClient.create()
+    amo = await AmoClient.create(get_http_client())
     await with_backoff(amo.add_note, lead_id, f"[TG->{bot_kind}] {text}")
+    client = get_http_client()
     new_cid = await with_backoff(
         send_text_from_client,
         lead_id=lead_id,
@@ -127,6 +139,7 @@ async def handle_mirror_tg_to_amo(payload: dict):
         tg_user_id=tg_user_id,
         tg_user_name=tg_user_name,
         conversation_id=conv_id,
+        client=client,
     )
     if new_cid and new_cid != conv_id:
         await set_conversation(tg_user_id, bot_kind, new_cid)
@@ -150,6 +163,7 @@ async def handle_mirror_bot_to_amo(payload: dict):
             lead_id=int(lead_id),
             tg_user_id=user_id,
             tg_user_name=user_name,
+            client=get_http_client(),
         )
     if not conv_id:
         raise RuntimeError("bot_to_amo: no conversation_id and no lead_id to create one")
@@ -160,6 +174,7 @@ async def handle_mirror_bot_to_amo(payload: dict):
         user_name=user_name,
         avatar=None,
         text=text,
+        client=get_http_client(),
     )
 
 

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ import time
 from app.hh_mapping import load
 from app.hh_webhooks import ensure_hh_webhook
 from app.queue import publish_task, consume
+from app.http_client import get_http_client, close_http_client
 from app.tg_webhooks import router as tg_wh_router
 from app.logging_setup import setup_logging
 from app.token_store import DbTokenStore
@@ -80,6 +81,8 @@ async def auto_register_telegram_webhooks() -> None:
 
 @app.on_event("startup")
 async def on_startup():
+    app.state.http_client = get_http_client()
+
     await init_db()
     await ensure_tokens()
     try:
@@ -101,9 +104,10 @@ async def on_startup():
     except Exception:
         log.exception("Failed to start RMQ consumer")
 
-    await ensure_hh_webhook()
+    client = app.state.http_client
+    await ensure_hh_webhook(client)
     await auto_register_telegram_webhooks()
-    await ensure_amo_chats_connected(log)
+    await ensure_amo_chats_connected(log, client)
 
 
 @app.on_event("shutdown")
@@ -113,6 +117,7 @@ async def on_shutdown():
         t.cancel()
         with contextlib.suppress(Exception):
             await t
+    await close_http_client()
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary
- add singleton AsyncClient with lifecycle helpers
- wire shared client into app state and replace ad-hoc clients with dependency injection
- update adapters, services and endpoints to use shared client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a822bf16a48321b51839acf4dc3353