### PR TITLE
Normalize msg_key format across router and worker

### DIFF
--- a/app/dedup.py
+++ b/app/dedup.py
@@ -6,7 +6,9 @@ from app.db import get_session
 from app.models import EventDedup
 
 
-def calc_key(source: str, payload: bytes) -> str:
+def calc_key(source: str, payload: str | bytes) -> str:
+    if isinstance(payload, str):
+        payload = payload.encode("utf-8")
     return f"{source}:{hashlib.sha256(payload).hexdigest()}"
 
 

--- a/app/tg_router.py
+++ b/app/tg_router.py
@@ -26,7 +26,7 @@ def make_router(bot_kind: str) -> Dispatcher:
         # 1) отвечаем в TG
         await m.answer(text)
         # 2) отправляем в AmoChats через RMQ (воркер создаст чат при необходимости)
-        msg_key = f"bot_to_amo:{lead_id}:{m.message_id}".encode("utf-8")
+        msg_key = f"bot_to_amo:{lead_id}:{m.message_id}"
         await publish_task({
             "platform": "mirror",
             "action": "bot_to_amo",
@@ -35,7 +35,7 @@ def make_router(bot_kind: str) -> Dispatcher:
             "user_name": m.from_user.username,
             "conversation_id": conv_id,
             "lead_id": lead_id,
-            "msg_key": msg_key.decode("utf-8"),
+            "msg_key": msg_key,
         })
 
     @dp.message(CommandStart())

--- a/app/worker_rmq.py
+++ b/app/worker_rmq.py
@@ -90,7 +90,7 @@ async def handle_amo_add_tags(payload: dict):
 
 
 async def handle_mirror_amo_to_tg(payload: dict):
-    msg_key = (payload.get("msg_key") or "").encode("utf-8")
+    msg_key = payload.get("msg_key") or ""
     if msg_key:
         dedup = calc_key("mirror", msg_key)
         if not await check_and_store(dedup):
@@ -106,7 +106,7 @@ async def handle_mirror_amo_to_tg(payload: dict):
 
 
 async def handle_mirror_tg_to_amo(payload: dict):
-    msg_key = (payload.get("msg_key") or "").encode("utf-8")
+    msg_key = payload.get("msg_key") or ""
     if msg_key:
         dedup = calc_key("mirror", msg_key)
         if not await check_and_store(dedup):
@@ -133,7 +133,7 @@ async def handle_mirror_tg_to_amo(payload: dict):
 
 
 async def handle_mirror_bot_to_amo(payload: dict):
-    msg_key = (payload.get("msg_key") or "").encode("utf-8")
+    msg_key = payload.get("msg_key") or ""
     if msg_key:
         dedup = calc_key("mirror", msg_key)
         if not await check_and_store(dedup):


### PR DESCRIPTION
## Summary
- Standardize `msg_key` as string at creation time
- Allow dedup `calc_key` to accept str directly
- Update workers to handle `msg_key` without encode/decode

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8244068ac832180c7578aa50b5b9c