### PR TITLE
Refactor module imports for new structure

### DIFF
--- a/app/adapters/avito.py
+++ b/app/adapters/avito.py
@@ -1,8 +1,8 @@
 import httpx
 from typing import Optional
 
-from app.config import settings
-from app.oauth2 import ensure_fresh_access
+from app.core.config import settings
+from app.api.oauth2 import ensure_fresh_access
 from app.core.retry import with_retry
 
 

--- a/app/adapters/hh.py
+++ b/app/adapters/hh.py
@@ -1,8 +1,8 @@
 import httpx
 from typing import Optional
 
-from app.config import settings
-from app.oauth2 import ensure_fresh_access
+from app.core.config import settings
+from app.api.oauth2 import ensure_fresh_access
 from app.core.retry import with_retry
 
 

--- a/app/services/worker_rmq.py
+++ b/app/services/worker_rmq.py
@@ -3,13 +3,13 @@ import asyncio, os, logging
 from aiogram import Bot
 from httpx import HTTPStatusError, TimeoutException, ConnectError
 
-from app.amochats import send_text_from_manager, ensure_chat_created, send_text_from_client
-from app.config import settings
-from app.dedup import check_and_store, calc_key
-from app.queue import consume, publish_retry, publish_dlq
+from app.adapters.amochats import send_text_from_manager, ensure_chat_created, send_text_from_client
+from app.core.config import settings
+from app.services.dedup import check_and_store, calc_key
+from app.services.queue import consume, publish_retry, publish_dlq
 from app.adapters import hh as hh_adapt, avito as avito_adapt
-from app.amo_client import AmoClient, ReauthRequired
-from app.logging_setup import setup_logging
+from app.adapters.amo_client import AmoClient, ReauthRequired
+from app.core.logging_setup import setup_logging
 from app.store_chat import set_conversation
 from app.services import tg_send_with_retry
 from app.core.retry import with_retry


### PR DESCRIPTION
## Summary
- update hh and avito adapters to use new config and oauth2 modules
- adjust worker_rmq imports to new adapters, services, and core paths

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a835f274a8832185772e56ed334a72