### PR TITLE
Add async tests for queue and external adapters

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import types
+import pytest
+import pytest_asyncio
+
+# Ensure project root is on sys.path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Map configuration and oauth modules that are missing in repo
+import app.core.config as core_config
+sys.modules.setdefault('app.config', core_config)
+
+# Provide lightweight proxy for oauth2 to avoid heavy imports during test collection
+oauth2_stub = types.ModuleType('app.oauth2')
+
+async def _ensure_fresh_access(*args, **kwargs):
+    from app.api.oauth2 import ensure_fresh_access as real
+    return await real(*args, **kwargs)
+
+async def _refresh_tokens(*args, **kwargs):
+    from app.api.oauth2 import refresh_tokens as real
+    return await real(*args, **kwargs)
+
+oauth2_stub.ensure_fresh_access = _ensure_fresh_access
+oauth2_stub.refresh_tokens = _refresh_tokens
+sys.modules.setdefault('app.oauth2', oauth2_stub)
+
+# Stub missing app.amochats module with async no-op functions
+stub = types.ModuleType('app.amochats')
+async def _noop(*args, **kwargs):
+    return None
+stub.send_text_from_manager = _noop
+stub.ensure_chat_created = _noop
+stub.send_text_from_client = _noop
+sys.modules.setdefault('app.amochats', stub)
+
+# Map dedup module used via deprecated import path
+import app.services.dedup as dedup_module
+sys.modules.setdefault('app.dedup', dedup_module)
+
+# Map queue module for worker_rmq
+import app.services.queue as queue_module
+sys.modules.setdefault('app.queue', queue_module)
+
+# Map amo_client for worker_rmq
+import app.adapters.amo_client as amo_client_module
+sys.modules.setdefault('app.amo_client', amo_client_module)
+
+# Map logging_setup module
+import app.core.logging_setup as logging_setup_module
+sys.modules.setdefault('app.logging_setup', logging_setup_module)
+
+# In-memory database fixture
+from sqlalchemy.ext.asyncio import create_async_engine, async_sessionmaker, AsyncSession
+from sqlalchemy.pool import StaticPool
+import app.db.db as db_module
+from app.db.db import Base
+
+
+@pytest_asyncio.fixture
+async def in_memory_db(monkeypatch):
+    """Provide a fresh in-memory database for each test."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False, class_=AsyncSession)
+    monkeypatch.setattr(db_module, "engine", engine, raising=False)
+    monkeypatch.setattr(db_module, "SessionLocal", SessionLocal, raising=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    try:
+        yield
+    finally:
+        await engine.dispose()

--- a/tests/test_adapters_avito.py
+++ b/tests/test_adapters_avito.py
@@ -1,0 +1,74 @@
+import json
+import pytest
+import httpx
+
+from app.adapters import avito
+
+
+@pytest.mark.asyncio
+async def test_avito_send_message(monkeypatch):
+    async def fake_ensure_fresh_access(**kwargs):
+        return "token"
+
+    async def fake_with_retry(coro, attempts, is_retryable):
+        return await coro()
+
+    monkeypatch.setattr(avito, "ensure_fresh_access", fake_ensure_fresh_access)
+    monkeypatch.setattr(avito, "with_retry", fake_with_retry)
+
+    captured = {}
+
+    def handler(request):
+        captured["url"] = str(request.url)
+        captured["json"] = json.loads(request.content.decode())
+        assert request.headers["Authorization"] == "Bearer token"
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await avito.send_message("neg1", "hi", "owner1", client)
+
+    assert captured["url"].endswith("/messenger/v1/accounts/me/chats/neg1/messages")
+    assert captured["json"] == {"message": {"text": "hi"}}
+
+
+@pytest.mark.asyncio
+async def test_avito_send_message_error(monkeypatch):
+    async def fake_ensure_fresh_access(**kwargs):
+        return "token"
+
+    async def fake_with_retry(coro, attempts, is_retryable):
+        return await coro()
+
+    monkeypatch.setattr(avito, "ensure_fresh_access", fake_ensure_fresh_access)
+    monkeypatch.setattr(avito, "with_retry", fake_with_retry)
+
+    def handler(request):
+        return httpx.Response(500, json={"error": "fail"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(avito.AvitoError):
+            await avito.send_message("neg1", "hi", None, client)
+
+
+@pytest.mark.asyncio
+async def test_avito_mark_read(monkeypatch):
+    async def fake_ensure_fresh_access(**kwargs):
+        return "token"
+
+    async def fake_with_retry(coro, attempts, is_retryable):
+        return await coro()
+
+    monkeypatch.setattr(avito, "ensure_fresh_access", fake_ensure_fresh_access)
+    monkeypatch.setattr(avito, "with_retry", fake_with_retry)
+
+    captured = {}
+
+    def handler(request):
+        captured["url"] = str(request.url)
+        assert request.headers["Authorization"] == "Bearer token"
+        return httpx.Response(200)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await avito.mark_read("neg1", "owner1", client)
+
+    assert captured["url"].endswith("/messenger/v1/accounts/me/chats/neg1/read")

--- a/tests/test_adapters_hh.py
+++ b/tests/test_adapters_hh.py
@@ -1,0 +1,79 @@
+import json
+import pytest
+import httpx
+
+from app.adapters import hh
+
+
+@pytest.mark.asyncio
+async def test_hh_send_message(monkeypatch):
+    async def fake_ensure_fresh_access(**kwargs):
+        return "token"
+
+    async def fake_with_retry(coro, attempts, is_retryable):
+        return await coro()
+
+    monkeypatch.setattr(hh, "ensure_fresh_access", fake_ensure_fresh_access)
+    monkeypatch.setattr(hh, "with_retry", fake_with_retry)
+
+    captured = {}
+
+    def handler(request):
+        captured["url"] = str(request.url)
+        captured["json"] = json.loads(request.content.decode())
+        assert request.headers["Authorization"] == "Bearer token"
+        assert request.headers["Accept"] == "application/json"
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await hh.send_message("resp1", "hello", "emp1", client)
+
+    assert captured["url"].endswith("/negotiations/resp1/messages")
+    assert captured["json"] == {"message": {"text": "hello"}}
+
+
+@pytest.mark.asyncio
+async def test_hh_send_message_error(monkeypatch):
+    async def fake_ensure_fresh_access(**kwargs):
+        return "token"
+
+    async def fake_with_retry(coro, attempts, is_retryable):
+        return await coro()
+
+    monkeypatch.setattr(hh, "ensure_fresh_access", fake_ensure_fresh_access)
+    monkeypatch.setattr(hh, "with_retry", fake_with_retry)
+
+    def handler(request):
+        return httpx.Response(500, json={"error": "fail"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with pytest.raises(hh.HHError):
+            await hh.send_message("resp1", "hello", None, client)
+
+
+@pytest.mark.asyncio
+async def test_hh_fetch_applicant_details(monkeypatch):
+    async def fake_ensure_fresh_access(**kwargs):
+        return "token"
+
+    monkeypatch.setattr(hh, "ensure_fresh_access", fake_ensure_fresh_access)
+
+    def handler(request):
+        if request.url.path.endswith("/negotiations/resp1"):
+            return httpx.Response(200, json={"resume": {"id": "res1"}})
+        elif request.url.path.endswith("/resumes/res1"):
+            return httpx.Response(
+                200,
+                json={
+                    "area": {"name": "Moscow"},
+                    "contact": {"phones": [{"formatted": "+1"}]},
+                    "first_name": "John",
+                    "last_name": "Doe",
+                },
+            )
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        data = await hh.fetch_applicant_details("resp1", "emp1", client)
+
+    assert data == {"name": "John Doe", "city": "Moscow", "phone": "+1"}

--- a/tests/test_oauth_token_store.py
+++ b/tests/test_oauth_token_store.py
@@ -1,0 +1,133 @@
+import time
+import json
+import pytest
+import httpx
+
+from app.api import oauth2
+from app.db.token_store import DbTokenStore
+from app.db.db import get_session
+from app.db import models
+from sqlalchemy import insert
+
+
+@pytest.mark.asyncio
+async def test_refresh_tokens_saves_to_db(in_memory_db):
+    async with get_session() as s:
+        await s.execute(
+            insert(models.Token).values(
+                id=1,
+                service="svc",
+                owner_id=None,
+                access_token="old",
+                refresh_token="oldr",
+                expires_at=0,
+            )
+        )
+        await s.commit()
+
+    def handler(request):
+        assert request.url == httpx.URL("https://example.com/token")
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "new_token",
+                "refresh_token": "new_refresh",
+                "expires_in": 100,
+                "server_time": 1000,
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        data = await oauth2.refresh_tokens(
+            service="svc",
+            token_url="https://example.com/token",
+            client_id="id",
+            client_secret="secret",
+            refresh_token="old_refresh",
+            http_client=client,
+        )
+
+    assert data["access_token"] == "new_token"
+    store = DbTokenStore("svc")
+    loaded = await store.load()
+    assert loaded["refresh_token"] == "new_refresh"
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_access_refreshes_when_expired(in_memory_db):
+    store = DbTokenStore("svc")
+    now = int(time.time())
+    async with get_session() as s:
+        await s.execute(
+            insert(models.Token).values(
+                id=1,
+                service="svc",
+                owner_id=None,
+                access_token="old",
+                refresh_token="r1",
+                expires_at=now - 10,
+            )
+        )
+        await s.commit()
+
+    def handler(request):
+        return httpx.Response(
+            200,
+            json={
+                "access_token": "new",
+                "refresh_token": "r2",
+                "expires_in": 200,
+                "server_time": now,
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        token = await oauth2.ensure_fresh_access(
+            service="svc",
+            token_url="https://example.com/token",
+            client_id="id",
+            client_secret="secret",
+            owner_id=None,
+            http_client=client,
+        )
+
+    assert token == "new"
+    loaded = await store.load()
+    assert loaded["access_token"] == "new" and loaded["refresh_token"] == "r2"
+
+
+@pytest.mark.asyncio
+async def test_ensure_fresh_access_uses_cached_token(in_memory_db, monkeypatch):
+    store = DbTokenStore("svc")
+    now = int(time.time())
+    async with get_session() as s:
+        await s.execute(
+            insert(models.Token).values(
+                id=1,
+                service="svc",
+                owner_id=None,
+                access_token="cached",
+                refresh_token="r1",
+                expires_at=now + 1000,
+            )
+        )
+        await s.commit()
+
+    called = False
+
+    async def fake_refresh_tokens(**kwargs):
+        nonlocal called
+        called = True
+        return {"access_token": "new", "refresh_token": "r2", "expires_at": now + 1000}
+
+    monkeypatch.setattr(oauth2, "refresh_tokens", fake_refresh_tokens)
+
+    token = await oauth2.ensure_fresh_access(
+        service="svc",
+        token_url="https://example.com/token",
+        client_id="id",
+        client_secret="secret",
+    )
+
+    assert token == "cached"
+    assert called is False

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,0 +1,69 @@
+import json
+import types
+import pytest
+
+from app.services import queue
+
+
+@pytest.mark.asyncio
+async def test_publish_task(monkeypatch):
+    published = []
+
+    class DummyExchange:
+        async def publish(self, msg, routing_key):
+            published.append((json.loads(msg.body.decode()), routing_key))
+
+    dummy_exch = DummyExchange()
+
+    class DummyChan:
+        def __init__(self):
+            self.default_exchange = DummyExchange()
+
+    dummy_chan = DummyChan()
+
+    async def fake_ensure():
+        queue._exch = dummy_exch
+        queue._chan = dummy_chan
+
+    monkeypatch.setattr(queue, "_ensure", fake_ensure)
+
+    await queue.publish_task({"foo": "bar"}, attempts=2)
+    assert published == [({"payload": {"foo": "bar"}, "attempts": 2}, "tasks")]
+
+
+@pytest.mark.asyncio
+async def test_publish_retry(monkeypatch):
+    published = []
+
+    class DummyExchange:
+        async def publish(self, msg, routing_key):
+            published.append((json.loads(msg.body.decode()), routing_key))
+
+    dummy_chan = types.SimpleNamespace(default_exchange=DummyExchange())
+
+    async def fake_ensure():
+        queue._chan = dummy_chan
+
+    monkeypatch.setattr(queue, "_ensure", fake_ensure)
+
+    await queue.publish_retry({"a": 1}, attempts=3)
+    assert published == [({"payload": {"a": 1}, "attempts": 3}, queue.settings.RMQ_RETRY_QUEUE)]
+
+
+@pytest.mark.asyncio
+async def test_publish_dlq(monkeypatch):
+    published = []
+
+    class DummyExchange:
+        async def publish(self, msg, routing_key):
+            published.append((json.loads(msg.body.decode()), routing_key))
+
+    dummy_exch = DummyExchange()
+
+    async def fake_ensure():
+        queue._exch = dummy_exch
+
+    monkeypatch.setattr(queue, "_ensure", fake_ensure)
+
+    await queue.publish_dlq({"a": 1}, attempts=4, error="boom")
+    assert published == [({"payload": {"a": 1}, "attempts": 4, "error": "boom"}, "tasks.dlq")]


### PR DESCRIPTION
## Summary
- add unit tests for RabbitMQ queue publish and retry logic
- cover HH and Avito adapters with mocked AsyncClient requests
- add OAuth/token store integration tests using in-memory DB

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a83609930c832195ac9ed44aebcdd9