### PR TITLE
Encapsulate RMQ connection with explicit shutdown

### DIFF
--- a/app/adapters/avito.py
+++ b/app/adapters/avito.py
@@ -1,8 +1,8 @@
 import httpx
 from typing import Optional
 
-from app.config import settings
-from app.oauth2 import ensure_fresh_access
+from app.core.config import settings
+from app.api.oauth2 import ensure_fresh_access
 from app.core.retry import with_retry
 
 

--- a/app/adapters/hh.py
+++ b/app/adapters/hh.py
@@ -1,8 +1,8 @@
 import httpx
 from typing import Optional
 
-from app.config import settings
-from app.oauth2 import ensure_fresh_access
+from app.core.config import settings
+from app.api.oauth2 import ensure_fresh_access
 from app.core.retry import with_retry
 
 

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -10,7 +10,7 @@ from app.http_client import get_http_client
 from app.core.config import settings
 from app.services.dedup import cleanup_older_than
 from app.services.hh_mapping import load as hh_map_load, set_all as hh_map_set
-from app.services.queue import publish_task
+from app.services.queue import rmq
 from app.db.token_store import DbTokenStore
 
 router = APIRouter()
@@ -46,7 +46,7 @@ async def put_hh_mapping(payload: dict):
 @admin.post("/rmq-test")
 async def rmq_test(payload: dict | None = None):
     msg = (payload or {}).get("msg", "hi")
-    await publish_task({"platform": "debug", "action": "echo", "msg": msg})
+    await rmq.publish_task({"platform": "debug", "action": "echo", "msg": msg})
     return {"ok": True}
 
 
@@ -87,7 +87,7 @@ async def hh_states(
 
 @admin.post("/hh-autofill")
 async def hh_autofill_admin():
-    await publish_task({"platform": "system", "action": "hh_autofill"})
+    await rmq.publish_task({"platform": "system", "action": "hh_autofill"})
     return {"ok": True, "queued": True}
 
 

--- a/app/api/api_amochats.py
+++ b/app/api/api_amochats.py
@@ -8,7 +8,7 @@ from app.services.dedup import calc_key, check_and_store
 from app.core.guards import require_admin
 from app.store_chat import get_by_lead, get_by_conversation, set_conversation, get_by_user
 from app.core.config import settings
-from app.services.queue import publish_task
+from app.services.queue import rmq
 
 logger = logging.getLogger(__name__)
 router_amo_chats = APIRouter()
@@ -123,7 +123,7 @@ async def amochats_in(request: Request, scope_id: str | None = None):
         user_id = ln.user_id
         # надёжный ключ против дублей
         key_src = f"amo:{conv_ref_id}:{msg_id or hashlib.sha256((text or '').encode()).hexdigest()[:16]}"
-        await publish_task({
+          await rmq.publish_task({
             "platform": "mirror",
             "action": "amo_to_tg",
             "bot_kind": bot_kind,

--- a/app/api/oauth.py
+++ b/app/api/oauth.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import RedirectResponse
 
 from app.core.config import settings
-from app.services.queue import publish_task
+from app.services.queue import rmq
 from app.db.token_store import DbTokenStore, TokenData
 from app.http_client import get_http_client
 
@@ -307,7 +307,7 @@ async def amo_callback(
         )
 
         try:
-            await publish_task({"platform": "system", "action": "hh_autofill"})
+            await rmq.publish_task({"platform": "system", "action": "hh_autofill"})
             logger.info("Queued hh_autofill after amo oauth")
         except Exception:
             logger.exception("Failed to queue hh_autofill after amo oauth")

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -11,7 +11,7 @@ from app.adapters.amo_client import AmoClient, ReauthRequired
 from app.core.config import settings
 from app.services.dedup import calc_key, check_and_store
 from app.services.hh_mapping import get as hh_map_get, load as hh_map_load
-from app.services.queue import publish_task
+from app.services.queue import rmq
 from app.store import find_link, save_link
 from app.http_client import get_http_client
 
@@ -189,7 +189,7 @@ async def _process_incoming(payload: dict, http_client: httpx.AsyncClient):
     try:
         created = await amo.create_leads(body)
     except ReauthRequired:
-        await publish_task(
+        await rmq.publish_task(
             {
                 "platform": payload.get("platform", "unknown"),
                 "action": "amo_create_lead",
@@ -238,7 +238,7 @@ async def _process_incoming(payload: dict, http_client: httpx.AsyncClient):
     )
 
     if payload.get("platform") == "avito" and payload.get("applicant", {}).get("id"):
-        await publish_task(
+        await rmq.publish_task(
             {
                 "platform": "avito",
                 "action": "send_message",
@@ -249,7 +249,7 @@ async def _process_incoming(payload: dict, http_client: httpx.AsyncClient):
         )
 
     if payload.get("platform") == "hh" and payload.get("applicant", {}).get("id"):
-        await publish_task(
+        await rmq.publish_task(
             {
                 "platform": "hh",
                 "action": "send_message",
@@ -399,7 +399,7 @@ async def amo_webhook(request: Request, http_client: httpx.AsyncClient = Depends
                                 logger.warning("Failed to copy refusal text")
                     except Exception:
                         logger.exception("Failed to map refusal reason")
-                await publish_task(
+                await rmq.publish_task(
                     {
                         "platform": "hh",
                         "action": "set_state",
@@ -409,7 +409,7 @@ async def amo_webhook(request: Request, http_client: httpx.AsyncClient = Depends
                     }
                 )
         if platform == "avito":
-            await publish_task(
+            await rmq.publish_task(
                 {
                     "platform": "avito",
                     "action": "mark_read",

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -8,6 +8,7 @@ class Settings(BaseSettings):
     RMQ_RETRY_QUEUE: str = "bridge.tasks.retry"
     RMQ_RETRY_TTL_MS: int = 5000
     RMQ_ENABLE_CONSUMER: bool = True
+    RMQ_PREFETCH: int = 32
     # DB
     DATABASE_URL: str = "postgresql+asyncpg://hr:hr@localhost:5432/hr"
 

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -1,105 +1,120 @@
-import json, os
-import aio_pika
+import json
 import logging
+from typing import Any, Awaitable, Callable
+
+import aio_pika
+
 from app.core.config import settings
 
+
 logger = logging.getLogger(__name__)
-_conn = _chan = _exch = None
 
 
-def _int(name: str, default: int) -> int:
-    try:
-        return int(os.getenv(name, str(default)))
-    except Exception:
-        return default
+Handler = Callable[[dict, int], Awaitable[Any]]
 
 
-RMQ_PREFETCH = _int("RMQ_PREFETCH", 32)
+class RMQ:
+    def __init__(self) -> None:
+        self._conn: aio_pika.RobustConnection | None = None
+        self._chan: aio_pika.RobustChannel | None = None
+        self._exch: aio_pika.Exchange | None = None
 
+    async def _ensure(self) -> None:
+        if self._conn and not self._conn.is_closed:
+            return
 
-async def _ensure():
-    global _conn, _chan, _exch
-    if _conn and not _conn.is_closed:
-        return
-    _conn = await aio_pika.connect_robust(settings.RABBITMQ_URL)
-    _chan = await _conn.channel(publisher_confirms=True)
-    await _chan.set_qos(prefetch_count=RMQ_PREFETCH)
+        self._conn = await aio_pika.connect_robust(settings.RABBITMQ_URL)
+        self._chan = await self._conn.channel(publisher_confirms=True)
+        await self._chan.set_qos(prefetch_count=settings.RMQ_PREFETCH)
 
-    _exch = await _chan.declare_exchange(settings.RMQ_EXCHANGE, aio_pika.ExchangeType.DIRECT, durable=True)
+        self._exch = await self._chan.declare_exchange(
+            settings.RMQ_EXCHANGE, aio_pika.ExchangeType.DIRECT, durable=True
+        )
 
-    await _chan.declare_queue(settings.RMQ_TASK_QUEUE, durable=True)
-    await _chan.declare_queue(
-        settings.RMQ_RETRY_QUEUE,
-        durable=True,
-        arguments={
-            "x-message-ttl": settings.RMQ_RETRY_TTL_MS,
-            "x-dead-letter-exchange": settings.RMQ_EXCHANGE,
-            "x-dead-letter-routing-key": "tasks",
-        },
-    )
-    await _chan.declare_queue(settings.RMQ_DLQ_QUEUE, durable=True)
+        await self._chan.declare_queue(settings.RMQ_TASK_QUEUE, durable=True)
+        await self._chan.declare_queue(
+            settings.RMQ_RETRY_QUEUE,
+            durable=True,
+            arguments={
+                "x-message-ttl": settings.RMQ_RETRY_TTL_MS,
+                "x-dead-letter-exchange": settings.RMQ_EXCHANGE,
+                "x-dead-letter-routing-key": "tasks",
+            },
+        )
+        await self._chan.declare_queue(settings.RMQ_DLQ_QUEUE, durable=True)
 
-    q_main = await _chan.get_queue(settings.RMQ_TASK_QUEUE)
-    await q_main.bind(_exch, routing_key="tasks")
+        q_main = await self._chan.get_queue(settings.RMQ_TASK_QUEUE)
+        await q_main.bind(self._exch, routing_key="tasks")
 
-    q_dlq = await _chan.get_queue(settings.RMQ_DLQ_QUEUE)
-    await q_dlq.bind(_exch, routing_key="tasks.dlq")
+        q_dlq = await self._chan.get_queue(settings.RMQ_DLQ_QUEUE)
+        await q_dlq.bind(self._exch, routing_key="tasks.dlq")
 
+    async def close(self) -> None:
+        if self._chan and not self._chan.is_closed:
+            await self._chan.close()
+        if self._conn and not self._conn.is_closed:
+            await self._conn.close()
+        self._conn = self._chan = self._exch = None
 
-async def publish_task(payload: dict, attempts: int = 0):
-    await _ensure()
-    body = json.dumps({"payload": payload, "attempts": attempts}, ensure_ascii=False).encode()
-    msg = aio_pika.Message(body=body, delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
-    await _exch.publish(msg, routing_key="tasks")
+    async def publish_task(self, payload: dict, attempts: int = 0) -> None:
+        await self._ensure()
+        body = json.dumps({"payload": payload, "attempts": attempts}, ensure_ascii=False).encode()
+        msg = aio_pika.Message(body=body, delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
+        assert self._exch
+        await self._exch.publish(msg, routing_key="tasks")
 
+    async def publish_retry(self, payload: dict, attempts: int) -> None:
+        await self._ensure()
+        body = json.dumps({"payload": payload, "attempts": attempts}, ensure_ascii=False).encode()
+        msg = aio_pika.Message(body=body, delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
+        assert self._chan
+        await self._chan.default_exchange.publish(msg, routing_key=settings.RMQ_RETRY_QUEUE)
 
-async def publish_retry(payload: dict, attempts: int):
-    await _ensure()
-    body = json.dumps({"payload": payload, "attempts": attempts}, ensure_ascii=False).encode()
-    msg = aio_pika.Message(body=body, delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
-    await _chan.default_exchange.publish(msg, routing_key=settings.RMQ_RETRY_QUEUE)
+    async def publish_dlq(self, payload: dict, attempts: int, error: str | None = None) -> None:
+        await self._ensure()
+        obj = {"payload": payload, "attempts": attempts, "error": error}
+        body = json.dumps(obj, ensure_ascii=False).encode()
+        msg = aio_pika.Message(body=body, delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
+        assert self._exch
+        await self._exch.publish(msg, routing_key="tasks.dlq")
 
-
-async def publish_dlq(payload: dict, attempts: int, error: str | None = None):
-    await _ensure()
-    obj = {"payload": payload, "attempts": attempts, "error": error}
-    body = json.dumps(obj, ensure_ascii=False).encode()
-    msg = aio_pika.Message(body=body, delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
-    await _exch.publish(msg, routing_key="tasks.dlq")
-
-
-async def consume(handler, max_attempts: int = 10):
-    await _ensure()
-    q = await _chan.get_queue(settings.RMQ_TASK_QUEUE)
-    async with q.iterator() as it:
-        async for message in it:
-            obj = None
-            attempts = 0
-            payload = {}
-            try:
-                obj = json.loads(message.body.decode("utf-8"))
-                payload = obj.get("payload") or {}
+    async def consume(self, handler: Handler, max_attempts: int = 10) -> None:
+        await self._ensure()
+        assert self._chan
+        q = await self._chan.get_queue(settings.RMQ_TASK_QUEUE)
+        async with q.iterator() as it:
+            async for message in it:
+                obj: dict[str, Any] | None = None
+                attempts = 0
+                payload: dict = {}
                 try:
-                    attempts = int(obj.get("attempts") or 0)
-                except Exception:
-                    attempts = 0
+                    obj = json.loads(message.body.decode("utf-8"))
+                    payload = obj.get("payload") or {}
+                    try:
+                        attempts = int(obj.get("attempts") or 0)
+                    except Exception:
+                        attempts = 0
 
-                # запустим обработчик
-                await handler(payload, attempts)
+                    await handler(payload, attempts)
+                    await message.ack()
 
-                # успех
-                await message.ack()
+                except Exception as e:  # noqa: BLE001
+                    await message.ack()
+                    try:
+                        cur_attempts = attempts + 1
+                        if cur_attempts >= max_attempts:
+                            await self.publish_dlq(payload, cur_attempts, str(e))
+                            logger.exception("sent to DLQ after attempts=%s", cur_attempts)
+                        else:
+                            await self.publish_retry(payload, cur_attempts)
+                            logger.exception(
+                                "requeued to retry, attempt=%s", cur_attempts
+                            )
+                    except Exception:  # noqa: BLE001
+                        logger.exception("failed to republish to retry/DLQ")
 
-            except Exception as e:
-                # не оставляем в очереди — ACK и перекидываем в retry/DLQ
-                await message.ack()
-                try:
-                    cur_attempts = attempts + 1
-                    if cur_attempts >= max_attempts:
-                        await publish_dlq(payload, cur_attempts, str(e))
-                        logger.exception("sent to DLQ after attempts=%s", cur_attempts)
-                    else:
-                        await publish_retry(payload, cur_attempts)
-                        logger.exception("requeued to retry, attempt=%s", cur_attempts)
-                except Exception:
-                    logger.exception("failed to republish to retry/DLQ")
+
+rmq = RMQ()
+
+__all__ = ["rmq", "RMQ"]
+

--- a/app/services/survey.py
+++ b/app/services/survey.py
@@ -1,7 +1,7 @@
 from aiogram.types import Message
 
 from app.core.config import settings
-from app.services.queue import publish_task
+from app.services.queue import rmq
 
 
 def parse_start_arg(text: str) -> int | None:
@@ -39,13 +39,13 @@ def pretty_tg_identity(m: Message) -> str:
 
 async def mark_went_to_bot_async(lead_id: int, bot_kind: str, identity: str):
     # переносим на воркер: добавляем заметку и тег через RMQ
-    await publish_task({
+    await rmq.publish_task({
         "platform": "amo",
         "action": "amo_add_note",
         "lead_id": lead_id,
         "text": f"[{bot_kind}] Кандидат перешёл в бота (TG {identity}).",
     })
-    await publish_task({
+    await rmq.publish_task({
         "platform": "amo",
         "action": "amo_add_tags",
         "lead_id": lead_id,

--- a/app/services/worker_rmq.py
+++ b/app/services/worker_rmq.py
@@ -3,13 +3,17 @@ import asyncio, os, logging
 from aiogram import Bot
 from httpx import HTTPStatusError, TimeoutException, ConnectError
 
-from app.amochats import send_text_from_manager, ensure_chat_created, send_text_from_client
-from app.config import settings
-from app.dedup import check_and_store, calc_key
-from app.queue import consume, publish_retry, publish_dlq
+from app.adapters.amochats import (
+    send_text_from_manager,
+    ensure_chat_created,
+    send_text_from_client,
+)
+from app.core.config import settings
+from app.services.dedup import check_and_store, calc_key
+from app.services.queue import rmq
 from app.adapters import hh as hh_adapt, avito as avito_adapt
-from app.amo_client import AmoClient, ReauthRequired
-from app.logging_setup import setup_logging
+from app.adapters.amo_client import AmoClient, ReauthRequired
+from app.core.logging_setup import setup_logging
 from app.store_chat import set_conversation
 from app.services import tg_send_with_retry
 from app.core.retry import with_retry
@@ -218,18 +222,18 @@ async def handle(payload: dict, attempts: int):
 
     except ReauthRequired as e:
         logger.warning("ReauthRequired: %s", e)
-        await publish_dlq(payload, attempts + 1, f"ReauthRequired: {e}")
+        await rmq.publish_dlq(payload, attempts + 1, f"ReauthRequired: {e}")
 
     except Exception as e:
         if _is_transient(e) and attempts + 1 < WORKER_MAX_ATTEMPTS:
-            await publish_retry(payload, attempts + 1)
+            await rmq.publish_retry(payload, attempts + 1)
         else:
             logger.exception("Task failed terminally")
-            await publish_dlq(payload, attempts + 1, str(e))
+            await rmq.publish_dlq(payload, attempts + 1, str(e))
 
 
 async def run_forever():
-    await consume(handle)
+    await rmq.consume(handle)
 
 
 if __name__ == "__main__":

--- a/app/tg_router.py
+++ b/app/tg_router.py
@@ -8,7 +8,7 @@ from app.store_chat import upsert_tg_link, get_by_user
 from app.store_survey import (
     start_or_reset_survey, get_survey, store_answer_and_advance, delete_survey
 )
-from app.services.queue import publish_task
+from app.services.queue import rmq
 from app.services.survey import (
     parse_start_arg,
     survey_prompt,
@@ -27,7 +27,7 @@ def make_router(bot_kind: str) -> Dispatcher:
         await m.answer(text)
         # 2) отправляем в AmoChats через RMQ (воркер создаст чат при необходимости)
         msg_key = f"bot_to_amo:{lead_id}:{m.message_id}"
-        await publish_task({
+        await rmq.publish_task({
             "platform": "mirror",
             "action": "bot_to_amo",
             "text": text,
@@ -76,7 +76,7 @@ def make_router(bot_kind: str) -> Dispatcher:
 
         # TG -> Amo (заметка + AmoChats) целиком через воркер
         msg_key = f"tg:{m.chat.id}:{m.message_id}"
-        await publish_task({
+        await rmq.publish_task({
             "platform": "mirror",
             "action": "tg_to_amo",
             "lead_id": lead_id,
@@ -100,13 +100,13 @@ def make_router(bot_kind: str) -> Dispatcher:
             else:
                 summary = survey_summary(survey.city, survey.experience, survey.time_pref)
                 # ставим тег и заметку — тоже через воркер
-                await publish_task({
+                await rmq.publish_task({
                     "platform": "amo",
                     "action": "amo_add_tags",
                     "lead_id": lead_id,
                     "tags": [settings.AMO_TAG_SURVEY_DONE],
                 })
-                await publish_task({
+                  await rmq.publish_task({
                     "platform": "amo",
                     "action": "amo_add_note",
                     "lead_id": lead_id,

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from app.db import init_db
 import time
 from app.services.hh_mapping import load
 from app.api.hh_webhooks import ensure_hh_webhook
-from app.services.queue import publish_task, consume
+from app.services.queue import rmq
 from app.http_client import get_http_client, close_http_client
 from app.api.tg_webhooks import router as tg_wh_router
 from app.core.logging_setup import setup_logging
@@ -92,14 +92,14 @@ async def on_startup():
         amo_tok = await DbTokenStore("amo").load()
         if amo_tok and amo_tok.get("access_token") and int(amo_tok.get("expires_at", 0)) > int(time.time()) + 30:
             if not load_hh_mapping():
-                await publish_task({"platform": "system", "action": "hh_autofill"})
+                await rmq.publish_task({"platform": "system", "action": "hh_autofill"})
                 log.info("Queued hh_autofill on startup")
     except Exception:
         log.info("Amo token not ready on startup — hh_autofill will be queued after OAuth")
 
         # стартуем RMQ consumer
     try:
-        app.state.rmq_task = asyncio.create_task(consume(_handle_task, max_attempts=10))
+        app.state.rmq_task = asyncio.create_task(rmq.consume(_handle_task, max_attempts=10))
         log.info("RMQ consumer started")
     except Exception:
         log.exception("Failed to start RMQ consumer")
@@ -117,6 +117,7 @@ async def on_shutdown():
         t.cancel()
         with contextlib.suppress(Exception):
             await t
+    await rmq.close()
     await close_http_client()
 
 


### PR DESCRIPTION
## Summary
- move `RMQ_PREFETCH` into `Settings`
- encapsulate RabbitMQ connection/channel/exchange into `RMQ` class with close
- update call sites to use `rmq` instance and close on shutdown

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8360ce2c883219e02c8b96e28dea0