### PR TITLE
Split webhook endpoints into dedicated routers

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -5,14 +5,22 @@ from fastapi import APIRouter, Depends
 from app.core.guards import require_admin
 
 # Import submodules before defining routers to avoid name clashes
-from . import oauth, webhooks, admin as admin_module  # noqa: E402
+from . import (
+    oauth,
+    admin as admin_module,
+    hh_incoming,
+    avito_incoming,
+    amo_webhooks,
+)  # noqa: E402
 
 # Base routers for public and admin endpoints
 router = APIRouter()
 admin = APIRouter(prefix="/admin", dependencies=[Depends(require_admin)])
 
 router.include_router(oauth.router)
-router.include_router(webhooks.router)
+router.include_router(hh_incoming.router)
+router.include_router(avito_incoming.router)
+router.include_router(amo_webhooks.router)
 router.include_router(admin_module.router)
 admin.include_router(admin_module.admin)
 

--- a/app/api/amo_webhooks.py
+++ b/app/api/amo_webhooks.py
@@ -1,0 +1,123 @@
+"""Endpoints handling incoming AmoCRM webhooks."""
+
+import logging
+import httpx
+from fastapi import APIRouter, Depends, Request
+
+from app.adapters.amo_client import AmoClient
+from app.core.config import settings
+from app.http_client import get_http_client
+from app.services.dedup import calc_key, check_and_store
+from app.services.hh_mapping import get as hh_map_get, load as hh_map_load
+from app.services.queue import publish_task
+from app.store import find_link
+
+from .utils import (
+    REFUSAL_TEXT_TO_HH,
+    events_from_form,
+    is_refusal_code,
+    norm_reason,
+    refusal_text,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.post("/webhooks/amo")
+async def amo_webhook(
+    request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)
+):
+    raw = await request.body()
+    key = calc_key("amo", raw)
+    if not await check_and_store(key):
+        return {"ok": True, "duplicate": True}
+
+    hh_map_load()
+    events: list[tuple[int, int]] = []
+
+    try:
+        data = await request.json()
+        if isinstance(data, dict) and data.get("leads", {}).get("status"):
+            for it in data["leads"]["status"]:
+                lead_id = int(it["id"])
+                status_id = int(it.get("new_status_id") or it.get("status_id"))
+                events.append((lead_id, status_id))
+    except Exception:
+        pass
+
+    if not events:
+        form = await request.form()
+        events = events_from_form(form)
+
+    for lead_id, status_id in events:
+        link = await find_link(lead_id)
+        if not link:
+            logger.warning("NO LINK FOR LEAD %s", lead_id)
+            continue
+
+        platform = link.get("platform")
+        ext_id = link.get("external_id")
+        owner_id = link.get("owner_id")
+
+        if platform == "hh":
+            state = hh_map_get(status_id)
+            if state and ext_id:
+                final_state = state
+                if is_refusal_code(state) and settings.AMO_CF_REFUSAL_REASON_ID:
+                    try:
+                        amo = await AmoClient.create(http_client)
+                        lead = await amo.get_lead(lead_id)
+                        cfv = lead.get("custom_fields_values") or []
+                        reason_text = None
+                        for f in cfv:
+                            if int(f.get("field_id") or 0) == int(
+                                settings.AMO_CF_REFUSAL_REASON_ID
+                            ):
+                                vals = f.get("values") or []
+                                if vals:
+                                    v = vals[0].get("value")
+                                    if isinstance(v, dict):
+                                        reason_text = v.get("value") or v.get("text") or ""
+                                    else:
+                                        reason_text = v or ""
+
+                                break
+                        mapped = REFUSAL_TEXT_TO_HH.get(norm_reason(reason_text))
+                        if mapped:
+                            final_state = mapped
+                        elif reason_text is None or not reason_text.strip():
+                            try:
+                                pretty = refusal_text(state) or state
+                                await amo.update_lead_custom_fields(
+                                    lead_id,
+                                    {settings.AMO_CF_REFUSAL_REASON_ID: pretty},
+                                )
+                            except Exception:
+                                logger.warning("Failed to copy refusal text")
+                    except Exception:
+                        logger.exception("Failed to map refusal reason")
+                await publish_task(
+                    {
+                        "platform": "hh",
+                        "action": "set_state",
+                        "external_id": ext_id,
+                        "target_state": final_state,
+                        "owner_id": owner_id,
+                    }
+                )
+        if platform == "avito":
+            await publish_task(
+                {
+                    "platform": "avito",
+                    "action": "mark_read",
+                    "external_id": ext_id,
+                    "owner_id": owner_id,
+                }
+            )
+
+    return {"ok": True, "events": len(events)}
+
+
+__all__ = ["router"]

--- a/app/api/avito_incoming.py
+++ b/app/api/avito_incoming.py
@@ -1,0 +1,68 @@
+"""Endpoints handling incoming Avito webhooks."""
+
+import logging
+import httpx
+from fastapi import APIRouter, Depends, Request
+
+from app.http_client import get_http_client
+from app.services.dedup import calc_key, check_and_store
+
+from .webhooks import _process_incoming
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.post("/webhooks/avito")
+async def webhook_avito(
+    request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)
+):
+    raw = await request.body()
+    try:
+        data = await request.json()
+    except Exception:
+        data = {}
+
+    key = calc_key("avito", raw)
+    if not await check_and_store(key):
+        return {"ok": True, "duplicate": True}
+
+    payload_root = data.get("payload") or {}
+    val = payload_root.get("value") or {}
+
+    chat_id = str(val.get("chat_id") or "")
+    text = (val.get("content") or {}).get("text") or ""
+
+    item = val.get("item") or {}
+    ctx = val.get("context") or {}
+    item_id = str(item.get("id") or ctx.get("item_id") or "")
+    vacancy_title = item.get("title") or val.get("title") or "Отклик Avito"
+    vacancy_desc = item.get("description") or ctx.get("description") or ""
+
+    applicant_id = str(val.get("user_id") or val.get("author_id") or "")
+
+    owner_id = str(
+        data.get("account_id")
+        or payload_root.get("account_id")
+        or val.get("account_id")
+        or ""
+    ) or None
+
+    if not chat_id:
+        logger.warning("Avito webhook: no chat_id, payload=%s", data)
+        return {"ok": True, "skipped": True}
+
+    internal = {
+        "platform": "avito",
+        "owner_id": owner_id,
+        "vacancy_id": item_id,
+        "vacancy_title": vacancy_title,
+        "vacancy_desc": vacancy_desc,
+        "applicant": {"id": chat_id, "name": f'user:{applicant_id or "unknown"}'},
+        "raw_text": text,
+    }
+    return await _process_incoming(internal, http_client)
+
+
+__all__ = ["router"]

--- a/app/api/hh_incoming.py
+++ b/app/api/hh_incoming.py
@@ -1,0 +1,77 @@
+"""Endpoints handling incoming HeadHunter webhooks."""
+
+import logging
+import httpx
+from fastapi import APIRouter, Depends, Request
+
+from app.http_client import get_http_client
+from app.services.dedup import calc_key, check_and_store
+
+from .webhooks import _process_incoming
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.post("/webhooks/hh")
+async def webhook_hh(
+    request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)
+):
+    raw = await request.body()
+    try:
+        data = await request.json()
+    except Exception:
+        data = {}
+
+    key = calc_key("hh", raw)
+    if not await check_and_store(key):
+        return {"ok": True, "duplicate": True}
+
+    obj = (
+        data.get("object")
+        or data.get("negotiation")
+        or data.get("response")
+        or data.get("payload")
+        or {}
+    )
+
+    response_id = str(
+        obj.get("id")
+        or data.get("response_id")
+        or obj.get("negotiation_id")
+        or ""
+    )
+
+    vacancy = obj.get("vacancy") or {}
+    applicant = (obj.get("applicant") or obj.get("resume", {}).get("owner", {}) or {})
+
+    vacancy_id = str(vacancy.get("id") or data.get("vacancy_id") or "")
+    vacancy_title = vacancy.get("name") or data.get("vacancy_title") or ""
+    vacancy_desc = vacancy.get("description") or data.get("vacancy_description") or ""
+    applicant_name = (
+        applicant.get("name") or applicant.get("first_name") or ""
+    ).strip() or "кандидат"
+
+    owner_id = str(
+        data.get("employer", {}).get("id")
+        or obj.get("employer", {}).get("id")
+        or ""
+    ) or None
+
+    if not response_id:
+        logger.warning("HH webhook: no response_id; payload=%s", data)
+        return {"ok": True, "skipped": True}
+
+    payload = {
+        "platform": "hh",
+        "owner_id": owner_id,
+        "vacancy_id": vacancy_id,
+        "vacancy_title": vacancy_title,
+        "vacancy_desc": vacancy_desc,
+        "applicant": {"id": response_id, "name": applicant_name},
+    }
+    return await _process_incoming(payload, http_client)
+
+
+__all__ = ["router"]

--- a/app/api/webhooks.py
+++ b/app/api/webhooks.py
@@ -1,144 +1,22 @@
-"""Endpoints handling external webhooks."""
+"""Shared utilities for processing incoming webhooks."""
 
 import logging
 import time
 import httpx
 
-from fastapi import APIRouter, Request, Depends
-
-from app.adapters import avito as avito_adapt, hh as hh_adapt
+from app.adapters import hh as hh_adapt
 from app.adapters.amo_client import AmoClient, ReauthRequired
 from app.core.config import settings
-from app.services.dedup import calc_key, check_and_store
-from app.services.hh_mapping import get as hh_map_get, load as hh_map_load
 from app.services.queue import publish_task
-from app.store import find_link, save_link
-from app.http_client import get_http_client
+from app.store import save_link
 
-from .utils import (
-    REFUSAL_TEXT_TO_HH,
-    events_from_form,
-    is_refusal_code,
-    norm_reason,
-    refusal_text,
-    route_kind,
-)
+from .utils import route_kind
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
-
-
-@router.post("/webhooks/hh")
-async def webhook_hh(request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)):
-    raw = await request.body()
-    try:
-        data = await request.json()
-    except Exception:
-        data = {}
-
-    key = calc_key("hh", raw)
-    if not await check_and_store(key):
-        return {"ok": True, "duplicate": True}
-
-    obj = (
-        data.get("object")
-        or data.get("negotiation")
-        or data.get("response")
-        or data.get("payload")
-        or {}
-    )
-
-    # response/negotiation id — КЛЮЧЕВОЕ
-    response_id = str(
-        obj.get("id")
-        or data.get("response_id")
-        or obj.get("negotiation_id")
-        or ""
-    )
-
-    vacancy = obj.get("vacancy") or {}
-
-    applicant = (obj.get("applicant") or obj.get("resume", {}).get("owner", {}) or {})
-
-    vacancy_id = str(vacancy.get("id") or data.get("vacancy_id") or "")
-    vacancy_title = (vacancy.get("name") or data.get("vacancy_title") or "")
-    vacancy_desc = (vacancy.get("description") or data.get("vacancy_description") or "")
-    applicant_name = (applicant.get("name") or applicant.get("first_name") or "").strip() or "кандидат"
-
-    # employer_id (владалец токена)
-    owner_id = str(
-        data.get("employer", {}).get("id")
-        or obj.get("employer", {}).get("id")
-        or ""
-    ) or None
-
-    if not response_id:
-        logger.warning("HH webhook: no response_id; payload=%s", data)
-        return {"ok": True, "skipped": True}
-
-    payload = {
-        "platform": "hh",
-        "owner_id": owner_id,
-        "vacancy_id": vacancy_id,
-        "vacancy_title": vacancy_title,
-        "vacancy_desc": vacancy_desc,
-        "applicant": {"id": response_id, "name": applicant_name},
-    }
-    return await _process_incoming(payload, http_client)
-
-
-@router.post("/webhooks/avito")
-async def webhook_avito(request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)):
-    raw = await request.body()
-    try:
-        data = await request.json()
-    except Exception:
-        data = {}
-
-    key = calc_key("avito", raw)
-    if not await check_and_store(key):
-        return {"ok": True, "duplicate": True}
-
-    payload_root = data.get("payload") or {}
-    val = payload_root.get("value") or {}
-
-    chat_id = str(val.get("chat_id") or "")
-    text = (val.get("content") or {}).get("text") or ""
-
-    # Пытаемся вытащить ID и заголовок объявления
-    item = val.get("item") or {}
-    ctx = val.get("context") or {}
-    item_id = str(item.get("id") or ctx.get("item_id") or "")
-    vacancy_title = (item.get("title") or val.get("title") or "Отклик Avito")
-    vacancy_desc = (item.get("description") or ctx.get("description") or "")
-
-    applicant_id = str(val.get("user_id") or val.get("author_id") or "")
-
-    owner_id = str(
-        data.get("account_id")
-        or payload_root.get("account_id")
-        or val.get("account_id")
-        or ""
-    ) or None
-
-    if not chat_id:
-        logger.warning("Avito webhook: no chat_id, payload=%s", data)
-        return {"ok": True, "skipped": True}
-
-    internal = {
-        "platform": "avito",
-        "owner_id": owner_id,
-        "vacancy_id": item_id,
-        "vacancy_title": vacancy_title,
-        "vacancy_desc": vacancy_desc,
-        "applicant": {"id": chat_id, "name": f"user:{applicant_id or 'unknown'}"},
-        "raw_text": text,
-    }
-    return await _process_incoming(internal, http_client)
-
 
 async def _process_incoming(payload: dict, http_client: httpx.AsyncClient):
+    """Create a lead in AmoCRM from an incoming webhook payload."""
     title = payload.get("vacancy_title") or ""
     desc = payload.get("vacancy_desc") or ""
     raw = payload.get("raw_text") or ""
@@ -159,7 +37,7 @@ async def _process_incoming(payload: dict, http_client: httpx.AsyncClient):
                 name = (
                     name if name and name != "кандидат" else (extra.get("name") or name)
                 )
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - log only
             logger.warning("HH enrich failed: %s", e)
 
     if kind == "ignore":
@@ -175,7 +53,7 @@ async def _process_incoming(payload: dict, http_client: httpx.AsyncClient):
         pipeline_id = settings.AMO_PIPELINE_ID_OPERATOR
         stage_id = settings.AMO_STAGE_ID_OPERATOR_NEW
 
-    lead_name = f'{title} — {name or "кандидат"}'.strip(" —")
+    lead_name = f"{title} — {name or 'кандидат'}".strip(" —")
 
     logger.info(
         "lead:create platform=%s -> name=%s pipeline=%s stage=%s",
@@ -262,14 +140,14 @@ async def _process_incoming(payload: dict, http_client: httpx.AsyncClient):
     await amo.add_tags(
         lead_id,
         [
-            f'source:{payload.get("platform", "") or "unknown"}',
-            f'type:{"мастер" if kind == "master" else "оператор"}',
+            f"source:{payload.get('platform', '') or 'unknown'}",
+            f"type:{'мастер' if kind == 'master' else 'оператор'}",
         ],
     )
 
     try:
         await amo.add_note(lead_id, f"Отправлена ссылка на TG-бота: {deep_link}")
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - log only
         logger.warning("add note (link sent) error: %s", e)
 
     return {"ok": True, "lead_id": lead_id}
@@ -284,13 +162,14 @@ async def _enrich_lead(
     city: str | None,
     vacancy_title: str | None,
 ):
+    """Attach extra data to a newly created lead."""
     contact_id = None
     if applicant_name or phone:
         try:
             cr = await amo.create_contact(applicant_name or "Кандидат", phone)
             contact_id = cr["_embedded"]["contacts"][0]["id"]
             await amo.link_contact_to_lead(lead_id, contact_id)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - log only
             logger.warning("create/link contact failed: %s", e)
 
     cf: dict[int, str] = {}
@@ -304,7 +183,7 @@ async def _enrich_lead(
         cf[settings.AMO_CF_LEAD_APPLICANT_NAME_ID] = applicant_name or ""
     try:
         await amo.update_lead_custom_fields(lead_id, cf)
-    except Exception as e:
+    except Exception as e:  # pragma: no cover - log only
         logger.warning("update lead CF failed: %s", e)
 
     if not any(
@@ -324,102 +203,8 @@ async def _enrich_lead(
                 f"• Вакансия: {vacancy_title or '-'}"
             )
             await amo.add_note(lead_id, note)
-        except Exception as e:
+        except Exception as e:  # pragma: no cover - log only
             logger.warning("add note (candidate data) error: %s", e)
 
 
-@router.post("/webhooks/amo")
-async def amo_webhook(request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)):
-    raw = await request.body()
-    key = calc_key("amo", raw)
-    if not await check_and_store(key):
-        return {"ok": True, "duplicate": True}
-
-    hh_map_load()
-    events: list[tuple[int, int]] = []
-
-    try:
-        data = await request.json()
-        if isinstance(data, dict) and data.get("leads", {}).get("status"):
-            for it in data["leads"]["status"]:
-                lead_id = int(it["id"])
-                status_id = int(it.get("new_status_id") or it.get("status_id"))
-                events.append((lead_id, status_id))
-    except Exception:
-        pass
-
-    if not events:
-        form = await request.form()
-        events = events_from_form(form)
-
-    for lead_id, status_id in events:
-        link = await find_link(lead_id)
-        if not link:
-            logger.warning("NO LINK FOR LEAD %s", lead_id)
-            continue
-
-        platform = link.get("platform")
-        ext_id = link.get("external_id")
-        owner_id = link.get("owner_id")
-
-        if platform == "hh":
-            state = hh_map_get(status_id)
-            if state and ext_id:
-                final_state = state
-                if is_refusal_code(state) and settings.AMO_CF_REFUSAL_REASON_ID:
-                    try:
-                        amo = await AmoClient.create(http_client)
-                        lead = await amo.get_lead(lead_id)
-                        cfv = lead.get("custom_fields_values") or []
-                        reason_text = None
-                        for f in cfv:
-                            if int(f.get("field_id") or 0) == int(
-                                settings.AMO_CF_REFUSAL_REASON_ID
-                            ):
-                                vals = f.get("values") or []
-                                if vals:
-                                    v = vals[0].get("value")
-                                    if isinstance(v, dict):
-                                        reason_text = v.get("value") or v.get("text") or ""
-                                    else:
-                                        reason_text = v or ""
-
-                                break
-                        mapped = REFUSAL_TEXT_TO_HH.get(norm_reason(reason_text))
-                        if mapped:
-                            final_state = mapped
-                        elif reason_text is None or not reason_text.strip():
-                            try:
-                                pretty = refusal_text(state) or state
-                                await amo.update_lead_custom_fields(
-                                    lead_id,
-                                    {settings.AMO_CF_REFUSAL_REASON_ID: pretty},
-                                )
-                            except Exception:
-                                logger.warning("Failed to copy refusal text")
-                    except Exception:
-                        logger.exception("Failed to map refusal reason")
-                await publish_task(
-                    {
-                        "platform": "hh",
-                        "action": "set_state",
-                        "external_id": ext_id,
-                        "target_state": final_state,
-                        "owner_id": owner_id,
-                    }
-                )
-        if platform == "avito":
-            await publish_task(
-                {
-                    "platform": "avito",
-                    "action": "mark_read",
-                    "external_id": ext_id,
-                    "owner_id": owner_id,
-                }
-            )
-
-    return {"ok": True, "events": len(events)}
-
-
-__all__ = ["router"]
-
+__all__ = ["_process_incoming", "_enrich_lead"]


### PR DESCRIPTION
## Summary
- refactor webhook utilities
- add dedicated HH, Avito and AmoCRM webhook handlers
- wire new routers into API package

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8ab83319083219ee9d504af6ec11b