### PR TITLE
Add payload parsers for HH and Avito webhooks

### DIFF
--- a/app/api/avito_incoming.py
+++ b/app/api/avito_incoming.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, Request
 
 from app.http_client import get_http_client
 from app.services.dedup import calc_key, check_and_store
+from app.services.payload_parsers import parse_avito_payload
 
 from .webhooks import _process_incoming
 
@@ -19,50 +20,18 @@ async def webhook_avito(
     request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)
 ):
     raw = await request.body()
-    try:
-        data = await request.json()
-    except Exception:
-        data = {}
 
     key = calc_key("avito", raw)
     if not await check_and_store(key):
         return {"ok": True, "duplicate": True}
 
-    payload_root = data.get("payload") or {}
-    val = payload_root.get("value") or {}
-
-    chat_id = str(val.get("chat_id") or "")
-    text = (val.get("content") or {}).get("text") or ""
-
-    item = val.get("item") or {}
-    ctx = val.get("context") or {}
-    item_id = str(item.get("id") or ctx.get("item_id") or "")
-    vacancy_title = item.get("title") or val.get("title") or "Отклик Avito"
-    vacancy_desc = item.get("description") or ctx.get("description") or ""
-
-    applicant_id = str(val.get("user_id") or val.get("author_id") or "")
-
-    owner_id = str(
-        data.get("account_id")
-        or payload_root.get("account_id")
-        or val.get("account_id")
-        or ""
-    ) or None
-
-    if not chat_id:
-        logger.warning("Avito webhook: no chat_id, payload=%s", data)
+    try:
+        payload = parse_avito_payload(raw)
+    except ValueError as exc:
+        logger.warning("Avito webhook: %s; payload=%s", exc, raw)
         return {"ok": True, "skipped": True}
 
-    internal = {
-        "platform": "avito",
-        "owner_id": owner_id,
-        "vacancy_id": item_id,
-        "vacancy_title": vacancy_title,
-        "vacancy_desc": vacancy_desc,
-        "applicant": {"id": chat_id, "name": f'user:{applicant_id or "unknown"}'},
-        "raw_text": text,
-    }
-    return await _process_incoming(internal, http_client)
+    return await _process_incoming(payload, http_client)
 
 
 __all__ = ["router"]

--- a/app/api/hh_incoming.py
+++ b/app/api/hh_incoming.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, Request
 
 from app.http_client import get_http_client
 from app.services.dedup import calc_key, check_and_store
+from app.services.payload_parsers import parse_hh_payload
 
 from .webhooks import _process_incoming
 
@@ -19,58 +20,17 @@ async def webhook_hh(
     request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)
 ):
     raw = await request.body()
-    try:
-        data = await request.json()
-    except Exception:
-        data = {}
 
     key = calc_key("hh", raw)
     if not await check_and_store(key):
         return {"ok": True, "duplicate": True}
 
-    obj = (
-        data.get("object")
-        or data.get("negotiation")
-        or data.get("response")
-        or data.get("payload")
-        or {}
-    )
-
-    response_id = str(
-        obj.get("id")
-        or data.get("response_id")
-        or obj.get("negotiation_id")
-        or ""
-    )
-
-    vacancy = obj.get("vacancy") or {}
-    applicant = (obj.get("applicant") or obj.get("resume", {}).get("owner", {}) or {})
-
-    vacancy_id = str(vacancy.get("id") or data.get("vacancy_id") or "")
-    vacancy_title = vacancy.get("name") or data.get("vacancy_title") or ""
-    vacancy_desc = vacancy.get("description") or data.get("vacancy_description") or ""
-    applicant_name = (
-        applicant.get("name") or applicant.get("first_name") or ""
-    ).strip() or "кандидат"
-
-    owner_id = str(
-        data.get("employer", {}).get("id")
-        or obj.get("employer", {}).get("id")
-        or ""
-    ) or None
-
-    if not response_id:
-        logger.warning("HH webhook: no response_id; payload=%s", data)
+    try:
+        payload = parse_hh_payload(raw)
+    except ValueError as exc:
+        logger.warning("HH webhook: %s; payload=%s", exc, raw)
         return {"ok": True, "skipped": True}
 
-    payload = {
-        "platform": "hh",
-        "owner_id": owner_id,
-        "vacancy_id": vacancy_id,
-        "vacancy_title": vacancy_title,
-        "vacancy_desc": vacancy_desc,
-        "applicant": {"id": response_id, "name": applicant_name},
-    }
     return await _process_incoming(payload, http_client)
 
 

--- a/app/services/payload_parsers.py
+++ b/app/services/payload_parsers.py
@@ -1,0 +1,128 @@
+import json
+import logging
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+
+def parse_hh_payload(raw: bytes) -> Dict[str, Any]:
+    """Parse raw HeadHunter webhook data into normalized payload.
+
+    Args:
+        raw: Raw HTTP body bytes.
+
+    Returns:
+        Normalized payload dictionary suitable for `_process_incoming`.
+
+    Raises:
+        ValueError: If the JSON is malformed or required identifiers are missing.
+    """
+    try:
+        data = json.loads(raw.decode() or "{}")
+    except Exception as exc:  # pragma: no cover - log only
+        logger.warning("HH payload parse error: %s", exc)
+        raise ValueError("invalid json") from exc
+
+    obj = (
+        data.get("object")
+        or data.get("negotiation")
+        or data.get("response")
+        or data.get("payload")
+        or {}
+    )
+
+    response_id = str(
+        obj.get("id")
+        or data.get("response_id")
+        or obj.get("negotiation_id")
+        or ""
+    )
+
+    vacancy = obj.get("vacancy") or {}
+    applicant = obj.get("applicant") or obj.get("resume", {}).get("owner", {}) or {}
+
+    vacancy_id = str(vacancy.get("id") or data.get("vacancy_id") or "")
+    vacancy_title = vacancy.get("name") or data.get("vacancy_title") or ""
+    vacancy_desc = vacancy.get("description") or data.get("vacancy_description") or ""
+    applicant_name = (
+        applicant.get("name") or applicant.get("first_name") or ""
+    ).strip() or "кандидат"
+
+    owner_id = (
+        str(
+            data.get("employer", {}).get("id")
+            or obj.get("employer", {}).get("id")
+            or ""
+        )
+        or None
+    )
+
+    if not response_id:
+        raise ValueError("missing response_id")
+
+    return {
+        "platform": "hh",
+        "owner_id": owner_id,
+        "vacancy_id": vacancy_id,
+        "vacancy_title": vacancy_title,
+        "vacancy_desc": vacancy_desc,
+        "applicant": {"id": response_id, "name": applicant_name},
+    }
+
+
+def parse_avito_payload(raw: bytes) -> Dict[str, Any]:
+    """Parse raw Avito webhook data into normalized payload.
+
+    Args:
+        raw: Raw HTTP body bytes.
+
+    Returns:
+        Normalized payload dictionary suitable for `_process_incoming`.
+
+    Raises:
+        ValueError: If the JSON is malformed or required identifiers are missing.
+    """
+    try:
+        data = json.loads(raw.decode() or "{}")
+    except Exception as exc:  # pragma: no cover - log only
+        logger.warning("Avito payload parse error: %s", exc)
+        raise ValueError("invalid json") from exc
+
+    payload_root = data.get("payload") or {}
+    val = payload_root.get("value") or {}
+
+    chat_id = str(val.get("chat_id") or "")
+    if not chat_id:
+        raise ValueError("missing chat_id")
+
+    text = (val.get("content") or {}).get("text") or ""
+    item = val.get("item") or {}
+    ctx = val.get("context") or {}
+
+    item_id = str(item.get("id") or ctx.get("item_id") or "")
+    vacancy_title = item.get("title") or val.get("title") or "Отклик Avito"
+    vacancy_desc = item.get("description") or ctx.get("description") or ""
+    applicant_id = str(val.get("user_id") or val.get("author_id") or "")
+
+    owner_id = (
+        str(
+            data.get("account_id")
+            or payload_root.get("account_id")
+            or val.get("account_id")
+            or ""
+        )
+        or None
+    )
+
+    return {
+        "platform": "avito",
+        "owner_id": owner_id,
+        "vacancy_id": item_id,
+        "vacancy_title": vacancy_title,
+        "vacancy_desc": vacancy_desc,
+        "applicant": {"id": chat_id, "name": f'user:{applicant_id or "unknown"}'},
+        "raw_text": text,
+    }
+
+
+__all__ = ["parse_hh_payload", "parse_avito_payload"]

--- a/tests/test_payload_parsers.py
+++ b/tests/test_payload_parsers.py
@@ -1,0 +1,68 @@
+import json
+import pytest
+
+from app.services.payload_parsers import parse_hh_payload, parse_avito_payload
+
+
+def test_parse_hh_payload_ok():
+    raw = json.dumps(
+        {
+            "response": {
+                "id": "resp1",
+                "vacancy": {"id": "vac1", "name": "Vac", "description": "Desc"},
+                "applicant": {"name": "John"},
+            },
+            "employer": {"id": "emp1"},
+        }
+    ).encode()
+
+    payload = parse_hh_payload(raw)
+    assert payload["platform"] == "hh"
+    assert payload["owner_id"] == "emp1"
+    assert payload["vacancy_id"] == "vac1"
+    assert payload["applicant"] == {"id": "resp1", "name": "John"}
+
+
+def test_parse_hh_payload_missing_id():
+    raw = json.dumps({"response": {}}).encode()
+    with pytest.raises(ValueError):
+        parse_hh_payload(raw)
+
+
+def test_parse_hh_payload_bad_json():
+    with pytest.raises(ValueError):
+        parse_hh_payload(b"{bad json")
+
+
+def test_parse_avito_payload_ok():
+    raw = json.dumps(
+        {
+            "payload": {
+                "value": {
+                    "chat_id": "chat1",
+                    "content": {"text": "hi"},
+                    "item": {"id": "item1", "title": "Vac", "description": "Desc"},
+                    "user_id": "u1",
+                },
+                "account_id": "acc1",
+            }
+        }
+    ).encode()
+
+    payload = parse_avito_payload(raw)
+    assert payload["platform"] == "avito"
+    assert payload["owner_id"] == "acc1"
+    assert payload["vacancy_id"] == "item1"
+    assert payload["applicant"] == {"id": "chat1", "name": "user:u1"}
+    assert payload["raw_text"] == "hi"
+
+
+def test_parse_avito_payload_missing_chat_id():
+    raw = json.dumps({"payload": {"value": {}}}).encode()
+    with pytest.raises(ValueError):
+        parse_avito_payload(raw)
+
+
+def test_parse_avito_payload_bad_json():
+    with pytest.raises(ValueError):
+        parse_avito_payload(b"not json")


### PR DESCRIPTION
## Summary
- add `parse_hh_payload` and `parse_avito_payload` helpers to normalize raw webhook data
- update HH and Avito webhook endpoints to use new parsers
- test payload parsers with valid data and edge cases

## Testing
- `pytest tests/test_payload_parsers.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8ad6e1e9083219e564508429ef6f2