### PR TITLE
Add AmoCRM lead enrichment service and tests

### DIFF
--- a/app/services/amo_lead_enrichment.py
+++ b/app/services/amo_lead_enrichment.py
@@ -1,0 +1,64 @@
+import logging
+
+from app.core.config import settings
+
+
+logger = logging.getLogger(__name__)
+
+
+async def enrich_lead(
+    amo,
+    lead_id: int,
+    *,
+    applicant_name: str | None,
+    phone: str | None,
+    city: str | None,
+    vacancy_title: str | None,
+) -> None:
+    """Attach extra data to a newly created lead."""
+    contact_id = None
+    if applicant_name or phone:
+        try:
+            cr = await amo.create_contact(applicant_name or "Кандидат", phone)
+            contact_id = cr["_embedded"]["contacts"][0]["id"]
+            await amo.link_contact_to_lead(lead_id, contact_id)
+        except Exception as e:  # pragma: no cover - log only
+            logger.warning("create/link contact failed: %s", e)
+
+    cf: dict[int, str] = {}
+    if settings.AMO_CF_LEAD_CITY_ID:
+        cf[settings.AMO_CF_LEAD_CITY_ID] = city or ""
+    if settings.AMO_CF_LEAD_VACANCY_TITLE_ID:
+        cf[settings.AMO_CF_LEAD_VACANCY_TITLE_ID] = vacancy_title or ""
+    if settings.AMO_CF_LEAD_APPLICANT_PHONE_ID:
+        cf[settings.AMO_CF_LEAD_APPLICANT_PHONE_ID] = phone or ""
+    if settings.AMO_CF_LEAD_APPLICANT_NAME_ID:
+        cf[settings.AMO_CF_LEAD_APPLICANT_NAME_ID] = applicant_name or ""
+    try:
+        await amo.update_lead_custom_fields(lead_id, cf)
+    except Exception as e:  # pragma: no cover - log only
+        logger.warning("update lead CF failed: %s", e)
+
+    if not any(
+        [
+            settings.AMO_CF_LEAD_CITY_ID,
+            settings.AMO_CF_LEAD_VACANCY_TITLE_ID,
+            settings.AMO_CF_LEAD_APPLICANT_PHONE_ID,
+            settings.AMO_CF_LEAD_APPLICANT_NAME_ID,
+        ]
+    ):
+        try:
+            note = (
+                "Данные кандидата:\n"
+                f"• Имя: {applicant_name or '-'}\n"
+                f"• Телефон: {phone or '-'}\n"
+                f"• Город: {city or '-'}\n"
+                f"• Вакансия: {vacancy_title or '-'}"
+            )
+            await amo.add_note(lead_id, note)
+        except Exception as e:  # pragma: no cover - log only
+            logger.warning("add note (candidate data) error: %s", e)
+
+
+__all__ = ["enrich_lead"]
+

--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -8,6 +8,7 @@ from app.core.config import settings
 from app.services.queue import publish_task
 from app.store import save_link
 from app.api.utils import route_kind
+from app.services import amo_lead_enrichment
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +84,7 @@ async def create_lead(payload: dict, client) -> tuple[int | None, str]:
 
     lead_id = created["_embedded"]["leads"][0]["id"]
 
-    await _enrich_lead(
+    await amo_lead_enrichment.enrich_lead(
         client,
         lead_id,
         applicant_name=name,
@@ -153,58 +154,6 @@ async def tag_lead(lead_id: int, kind: str, amo_client) -> None:
     )
 
 
-async def _enrich_lead(
-    amo,
-    lead_id: int,
-    *,
-    applicant_name: str | None,
-    phone: str | None,
-    city: str | None,
-    vacancy_title: str | None,
-):
-    """Attach extra data to a newly created lead."""
-    contact_id = None
-    if applicant_name or phone:
-        try:
-            cr = await amo.create_contact(applicant_name or "Кандидат", phone)
-            contact_id = cr["_embedded"]["contacts"][0]["id"]
-            await amo.link_contact_to_lead(lead_id, contact_id)
-        except Exception as e:  # pragma: no cover - log only
-            logger.warning("create/link contact failed: %s", e)
-
-    cf: dict[int, str] = {}
-    if settings.AMO_CF_LEAD_CITY_ID:
-        cf[settings.AMO_CF_LEAD_CITY_ID] = city or ""
-    if settings.AMO_CF_LEAD_VACANCY_TITLE_ID:
-        cf[settings.AMO_CF_LEAD_VACANCY_TITLE_ID] = vacancy_title or ""
-    if settings.AMO_CF_LEAD_APPLICANT_PHONE_ID:
-        cf[settings.AMO_CF_LEAD_APPLICANT_PHONE_ID] = phone or ""
-    if settings.AMO_CF_LEAD_APPLICANT_NAME_ID:
-        cf[settings.AMO_CF_LEAD_APPLICANT_NAME_ID] = applicant_name or ""
-    try:
-        await amo.update_lead_custom_fields(lead_id, cf)
-    except Exception as e:  # pragma: no cover - log only
-        logger.warning("update lead CF failed: %s", e)
-
-    if not any(
-        [
-            settings.AMO_CF_LEAD_CITY_ID,
-            settings.AMO_CF_LEAD_VACANCY_TITLE_ID,
-            settings.AMO_CF_LEAD_APPLICANT_PHONE_ID,
-            settings.AMO_CF_LEAD_APPLICANT_NAME_ID,
-        ]
-    ):
-        try:
-            note = (
-                "Данные кандидата:\n"
-                f"• Имя: {applicant_name or '-'}\n"
-                f"• Телефон: {phone or '-'}\n"
-                f"• Город: {city or '-'}\n"
-                f"• Вакансия: {vacancy_title or '-'}"
-            )
-            await amo.add_note(lead_id, note)
-        except Exception as e:  # pragma: no cover - log only
-            logger.warning("add note (candidate data) error: %s", e)
 
 
 __all__ = [

--- a/tests/test_amo_lead_enrichment.py
+++ b/tests/test_amo_lead_enrichment.py
@@ -1,0 +1,71 @@
+import pytest
+
+from app.services import amo_lead_enrichment
+from app.core.config import settings
+
+
+class DummyAmo:
+    def __init__(self):
+        self.calls = {}
+
+    async def create_contact(self, name, phone):
+        self.calls["create_contact"] = (name, phone)
+        return {"_embedded": {"contacts": [{"id": 1}]}}
+
+    async def link_contact_to_lead(self, lead_id, contact_id):
+        self.calls["link_contact_to_lead"] = (lead_id, contact_id)
+
+    async def update_lead_custom_fields(self, lead_id, cf):
+        self.calls["update_lead_custom_fields"] = (lead_id, cf)
+
+    async def add_note(self, lead_id, note):
+        self.calls["add_note"] = (lead_id, note)
+
+
+@pytest.mark.asyncio
+async def test_enrich_lead_updates_fields(monkeypatch):
+    amo = DummyAmo()
+
+    monkeypatch.setattr(settings, "AMO_CF_LEAD_CITY_ID", 1)
+    monkeypatch.setattr(settings, "AMO_CF_LEAD_VACANCY_TITLE_ID", 2)
+    monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_PHONE_ID", 3)
+    monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_NAME_ID", 4)
+
+    await amo_lead_enrichment.enrich_lead(
+        amo,
+        10,
+        applicant_name="Ivan",
+        phone="123",
+        city="Moscow",
+        vacancy_title="Plumber",
+    )
+
+    assert amo.calls["update_lead_custom_fields"] == (
+        10,
+        {1: "Moscow", 2: "Plumber", 3: "123", 4: "Ivan"},
+    )
+    assert "add_note" not in amo.calls
+
+
+@pytest.mark.asyncio
+async def test_enrich_lead_creates_note_when_no_cfs(monkeypatch):
+    amo = DummyAmo()
+
+    monkeypatch.setattr(settings, "AMO_CF_LEAD_CITY_ID", 0)
+    monkeypatch.setattr(settings, "AMO_CF_LEAD_VACANCY_TITLE_ID", 0)
+    monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_PHONE_ID", 0)
+    monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_NAME_ID", 0)
+
+    await amo_lead_enrichment.enrich_lead(
+        amo,
+        20,
+        applicant_name="Anna",
+        phone="456",
+        city="SPb",
+        vacancy_title="Operator",
+    )
+
+    assert "add_note" in amo.calls
+    lead_id, note = amo.calls["add_note"]
+    assert lead_id == 20
+    assert "Anna" in note and "456" in note and "SPb" in note and "Operator" in note

--- a/tests/test_lead_processor.py
+++ b/tests/test_lead_processor.py
@@ -45,7 +45,7 @@ async def test_create_lead(monkeypatch):
     async def fake_save_link(**kwargs):
         return None
 
-    monkeypatch.setattr(lead_processor, "_enrich_lead", fake_enrich)
+    monkeypatch.setattr(lead_processor.amo_lead_enrichment, "enrich_lead", fake_enrich)
     monkeypatch.setattr(lead_processor, "save_link", fake_save_link)
 
     lead_id, kind = await lead_processor.create_lead(payload, DummyClient())


### PR DESCRIPTION
## Summary
- extract lead enrichment logic into `amo_lead_enrichment` service
- integrate service into lead processor
- cover lead enrichment with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b04754ac8321800c2bb8e9140bf5