### PR TITLE
Refactor Amo webhook handling with dedicated event parsing

### DIFF
--- a/app/api/amo_webhooks.py
+++ b/app/api/amo_webhooks.py
@@ -25,18 +25,9 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
-@router.post("/webhooks/amo")
-async def amo_webhook(
-    request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)
-):
-    raw = await request.body()
-    key = calc_key("amo", raw)
-    if not await check_and_store(key):
-        return {"ok": True, "duplicate": True}
-
-    hh_map_load()
+async def parse_status_events(request: Request) -> list[tuple[int, int]]:
+    """Return list of (lead_id, status_id) pairs from Amo webhook payload."""
     events: list[tuple[int, int]] = []
-
     try:
         data = await request.json()
         if isinstance(data, dict) and data.get("leads", {}).get("status"):
@@ -50,6 +41,84 @@ async def amo_webhook(
     if not events:
         form = await request.form()
         events = events_from_form(form)
+    return events
+
+
+async def handle_hh_event(
+    lead_id: int, status_id: int, link: dict, http_client: httpx.AsyncClient
+):
+    ext_id = link.get("external_id")
+    owner_id = link.get("owner_id")
+    state = hh_map_get(status_id)
+    if not (state and ext_id):
+        return
+
+    final_state = state
+    if is_refusal_code(state) and settings.AMO_CF_REFUSAL_REASON_ID:
+        try:
+            amo = await AmoClient.create(http_client)
+            lead = await amo.get_lead(lead_id)
+            cfv = lead.get("custom_fields_values") or []
+            reason_text = None
+            for f in cfv:
+                if int(f.get("field_id") or 0) == int(settings.AMO_CF_REFUSAL_REASON_ID):
+                    vals = f.get("values") or []
+                    if vals:
+                        v = vals[0].get("value")
+                        if isinstance(v, dict):
+                            reason_text = v.get("value") or v.get("text") or ""
+                        else:
+                            reason_text = v or ""
+                    break
+            mapped = REFUSAL_TEXT_TO_HH.get(norm_reason(reason_text))
+            if mapped:
+                final_state = mapped
+            elif reason_text is None or not reason_text.strip():
+                try:
+                    pretty = refusal_text(state) or state
+                    await amo.update_lead_custom_fields(
+                        lead_id, {settings.AMO_CF_REFUSAL_REASON_ID: pretty}
+                    )
+                except Exception:
+                    logger.warning("Failed to copy refusal text")
+        except Exception:
+            logger.exception("Failed to map refusal reason")
+
+    await publish_task(
+        {
+            "platform": "hh",
+            "action": "set_state",
+            "external_id": ext_id,
+            "target_state": final_state,
+            "owner_id": owner_id,
+        }
+    )
+
+
+async def handle_avito_event(lead_id: int, status_id: int, link: dict):
+    ext_id = link.get("external_id")
+    owner_id = link.get("owner_id")
+    await publish_task(
+        {
+            "platform": "avito",
+            "action": "mark_read",
+            "external_id": ext_id,
+            "owner_id": owner_id,
+        }
+    )
+
+
+@router.post("/webhooks/amo")
+async def amo_webhook(
+    request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)
+):
+    raw = await request.body()
+    key = calc_key("amo", raw)
+    if not await check_and_store(key):
+        return {"ok": True, "duplicate": True}
+
+    hh_map_load()
+    events = await parse_status_events(request)
 
     for lead_id, status_id in events:
         link = await find_link(lead_id)
@@ -58,66 +127,12 @@ async def amo_webhook(
             continue
 
         platform = link.get("platform")
-        ext_id = link.get("external_id")
-        owner_id = link.get("owner_id")
-
         if platform == "hh":
-            state = hh_map_get(status_id)
-            if state and ext_id:
-                final_state = state
-                if is_refusal_code(state) and settings.AMO_CF_REFUSAL_REASON_ID:
-                    try:
-                        amo = await AmoClient.create(http_client)
-                        lead = await amo.get_lead(lead_id)
-                        cfv = lead.get("custom_fields_values") or []
-                        reason_text = None
-                        for f in cfv:
-                            if int(f.get("field_id") or 0) == int(
-                                settings.AMO_CF_REFUSAL_REASON_ID
-                            ):
-                                vals = f.get("values") or []
-                                if vals:
-                                    v = vals[0].get("value")
-                                    if isinstance(v, dict):
-                                        reason_text = v.get("value") or v.get("text") or ""
-                                    else:
-                                        reason_text = v or ""
-
-                                break
-                        mapped = REFUSAL_TEXT_TO_HH.get(norm_reason(reason_text))
-                        if mapped:
-                            final_state = mapped
-                        elif reason_text is None or not reason_text.strip():
-                            try:
-                                pretty = refusal_text(state) or state
-                                await amo.update_lead_custom_fields(
-                                    lead_id,
-                                    {settings.AMO_CF_REFUSAL_REASON_ID: pretty},
-                                )
-                            except Exception:
-                                logger.warning("Failed to copy refusal text")
-                    except Exception:
-                        logger.exception("Failed to map refusal reason")
-                await publish_task(
-                    {
-                        "platform": "hh",
-                        "action": "set_state",
-                        "external_id": ext_id,
-                        "target_state": final_state,
-                        "owner_id": owner_id,
-                    }
-                )
-        if platform == "avito":
-            await publish_task(
-                {
-                    "platform": "avito",
-                    "action": "mark_read",
-                    "external_id": ext_id,
-                    "owner_id": owner_id,
-                }
-            )
+            await handle_hh_event(lead_id, status_id, link, http_client)
+        elif platform == "avito":
+            await handle_avito_event(lead_id, status_id, link)
 
     return {"ok": True, "events": len(events)}
 
 
-__all__ = ["router"]
+__all__ = ["router", "parse_status_events"]

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -11,7 +11,7 @@ def events_from_form(form) -> list[tuple[int, int]]:
     keys = list(form.keys())
     idxs: set[int] = set()
     for k in keys:
-        m = re.match(r"leads\\[status\\]\\[(\\d+)\\]\\[id\\]$", k)
+        m = re.match(r"leads\[status\]\[(\d+)\]\[id\]$", k)
         if m:
             idxs.add(int(m.group(1)))
     events: list[tuple[int, int]] = []

--- a/tests/test_amo_webhooks.py
+++ b/tests/test_amo_webhooks.py
@@ -1,0 +1,59 @@
+import json
+from urllib.parse import urlencode
+
+import pytest
+from starlette.requests import Request
+
+from app.api.amo_webhooks import parse_status_events
+
+
+def _json_request(data: dict) -> Request:
+    body = json.dumps(data).encode()
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": [(b"content-type", b"application/json")],
+    }
+    return Request(scope, receive)
+
+
+def _form_request(data: dict) -> Request:
+    body = urlencode(data).encode()
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": [(b"content-type", b"application/x-www-form-urlencoded")],
+    }
+    return Request(scope, receive)
+
+
+@pytest.mark.asyncio
+async def test_parse_status_events_json():
+    payload = {
+        "leads": {
+            "status": [
+                {"id": "1", "status_id": "10"},
+                {"id": "2", "new_status_id": "20"},
+            ]
+        }
+    }
+    req = _json_request(payload)
+    events = await parse_status_events(req)
+    assert events == [(1, 10), (2, 20)]
+
+
+@pytest.mark.asyncio
+async def test_parse_status_events_form():
+    form_data = {
+        "leads[status][0][id]": "3",
+        "leads[status][0][status_id]": "30",
+        "leads[status][1][id]": "4",
+        "leads[status][1][status_id]": "40",
+    }
+    req = _form_request(form_data)
+    events = await parse_status_events(req)
+    assert events == [(3, 30), (4, 40)]


### PR DESCRIPTION
## Summary
- add `parse_status_events` helper to extract lead/status pairs
- split platform logic into `handle_hh_event` and `handle_avito_event`
- fix form-event regex and orchestrate Amo webhook flow
- test status event parsing for JSON and form payloads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b129dba883218416ca0f4c4fa3f2