### PR TITLE
Introduce pydantic models for incoming payloads

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field, ConfigDict
+
+
+class Applicant(BaseModel):
+    """Applicant details parsed from incoming payload."""
+
+    id: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1)
+    phone: str | None = None
+    city: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+class IncomingPayload(BaseModel):
+    """Normalized incoming payload from external platforms."""
+
+    platform: str
+    owner_id: str | None = None
+    vacancy_id: str | None = None
+    vacancy_title: str = ""
+    vacancy_desc: str = ""
+    applicant: Applicant
+    raw_text: str | None = None
+    kind: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+__all__ = ["IncomingPayload", "Applicant"]

--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -9,43 +9,45 @@ from app.services.queue import publish_task
 from app.store import save_link
 from app.api.utils import route_kind
 from app.services import amo_lead_enrichment
+from app.models import IncomingPayload
 
 logger = logging.getLogger(__name__)
 
 
-async def enrich_applicant(payload: dict, http_client: httpx.AsyncClient) -> dict:
+async def enrich_applicant(
+    payload: IncomingPayload, http_client: httpx.AsyncClient
+) -> IncomingPayload:
     """Enrich applicant data from HeadHunter if possible."""
-    if payload.get("platform") == "hh" and payload.get("applicant", {}).get("id"):
-        owner_id = payload.get("owner_id")
+    if payload.platform == "hh" and payload.applicant.id:
+        owner_id = payload.owner_id
         try:
             extra = await hh_adapt.fetch_applicant_details(
-                payload["applicant"]["id"], owner_id, http_client
+                payload.applicant.id, owner_id, http_client
             )
             if extra:
-                app = payload.setdefault("applicant", {})
-                app["phone"] = app.get("phone") or extra.get("phone")
-                app["city"] = app.get("city") or extra.get("city")
-                app["name"] = (
-                    app.get("name")
-                    if app.get("name") and app.get("name") != "кандидат"
-                    else extra.get("name") or app.get("name")
+                payload.applicant.phone = payload.applicant.phone or extra.get("phone")
+                payload.applicant.city = payload.applicant.city or extra.get("city")
+                payload.applicant.name = (
+                    payload.applicant.name
+                    if payload.applicant.name and payload.applicant.name != "кандидат"
+                    else extra.get("name") or payload.applicant.name
                 )
         except Exception as e:  # pragma: no cover - log only
             logger.warning("HH enrich failed: %s", e)
     return payload
 
 
-async def create_lead(payload: dict, client) -> tuple[int | None, str]:
+async def create_lead(payload: IncomingPayload, client) -> tuple[int | None, str]:
     """Create lead in AmoCRM and return (lead_id, kind)."""
-    title = payload.get("vacancy_title") or ""
-    desc = payload.get("vacancy_desc") or ""
-    raw = payload.get("raw_text") or ""
+    title = payload.vacancy_title or ""
+    desc = payload.vacancy_desc or ""
+    raw = payload.raw_text or ""
     kind = route_kind(desc=desc, raw=raw)
-    payload["kind"] = kind
+    payload.kind = kind
 
-    phone = (payload.get("applicant", {}) or {}).get("phone")
-    city = (payload.get("applicant", {}) or {}).get("city")
-    name = (payload.get("applicant", {}) or {}).get("name")
+    phone = payload.applicant.phone
+    city = payload.applicant.city
+    name = payload.applicant.name
 
     if kind == "ignore":
         logger.info("routing: ignore (no hashtags) title=%r", title)
@@ -62,7 +64,7 @@ async def create_lead(payload: dict, client) -> tuple[int | None, str]:
 
     logger.info(
         "lead:create platform=%s -> name=%s pipeline=%s stage=%s",
-        payload.get("platform"),
+        payload.platform,
         lead_name,
         pipeline_id,
         stage_id,
@@ -74,7 +76,7 @@ async def create_lead(payload: dict, client) -> tuple[int | None, str]:
     except ReauthRequired:
         await publish_task(
             {
-                "platform": payload.get("platform", "unknown"),
+                "platform": payload.platform or "unknown",
                 "action": "amo_create_lead",
                 "lead_body": body,
                 "ts": int(time.time()),
@@ -90,25 +92,25 @@ async def create_lead(payload: dict, client) -> tuple[int | None, str]:
         applicant_name=name,
         phone=phone,
         city=city,
-        vacancy_title=payload.get("vacancy_title"),
+        vacancy_title=payload.vacancy_title,
     )
 
     await save_link(
         lead_id=lead_id,
-        platform=payload.get("platform", "unknown"),
-        owner_id=payload.get("owner_id"),
-        vacancy_id=str(payload.get("vacancy_id", "")),
-        external_id=str(payload.get("applicant", {}).get("id") or "") or None,
+        platform=payload.platform or "unknown",
+        owner_id=payload.owner_id,
+        vacancy_id=str(payload.vacancy_id or ""),
+        external_id=str(payload.applicant.id or "") or None,
     )
 
     return lead_id, kind
 
 
-async def send_invite(payload: dict, lead_id: int) -> str:
+async def send_invite(payload: IncomingPayload, lead_id: int) -> str:
     """Send invite link to applicant via platform-specific channels."""
-    kind = payload.get("kind") or route_kind(
-        desc=payload.get("vacancy_desc") or "",
-        raw=payload.get("raw_text") or "",
+    kind = payload.kind or route_kind(
+        desc=payload.vacancy_desc or "",
+        raw=payload.raw_text or "",
     )
     bot_username = (
         settings.TELEGRAM_MASTER_BOT_USERNAME
@@ -121,8 +123,8 @@ async def send_invite(payload: dict, lead_id: int) -> str:
         f" {deep_link}"
     )
 
-    platform = payload.get("platform")
-    applicant_id = (payload.get("applicant", {}) or {}).get("id")
+    platform = payload.platform
+    applicant_id = payload.applicant.id
     if platform == "avito" and applicant_id:
         await publish_task(
             {
@@ -130,7 +132,7 @@ async def send_invite(payload: dict, lead_id: int) -> str:
                 "action": "send_message",
                 "external_id": applicant_id,
                 "text": invite_text,
-                "owner_id": payload.get("owner_id"),
+                "owner_id": payload.owner_id,
             }
         )
     if platform == "hh" and applicant_id:
@@ -140,7 +142,7 @@ async def send_invite(payload: dict, lead_id: int) -> str:
                 "action": "send_message",
                 "external_id": applicant_id,
                 "text": invite_text,
-                "owner_id": payload.get("owner_id"),
+                "owner_id": payload.owner_id,
             }
         )
     return deep_link

--- a/app/services/payload_parsers.py
+++ b/app/services/payload_parsers.py
@@ -1,11 +1,14 @@
 import json
 import logging
-from typing import Any, Dict
+
+from pydantic import ValidationError
+
+from app.models import Applicant, IncomingPayload
 
 logger = logging.getLogger(__name__)
 
 
-def parse_hh_payload(raw: bytes) -> Dict[str, Any]:
+def parse_hh_payload(raw: bytes) -> IncomingPayload:
     """Parse raw HeadHunter webhook data into normalized payload.
 
     Args:
@@ -41,7 +44,7 @@ def parse_hh_payload(raw: bytes) -> Dict[str, Any]:
     vacancy = obj.get("vacancy") or {}
     applicant = obj.get("applicant") or obj.get("resume", {}).get("owner", {}) or {}
 
-    vacancy_id = str(vacancy.get("id") or data.get("vacancy_id") or "")
+    vacancy_id = str(vacancy.get("id") or data.get("vacancy_id") or "") or None
     vacancy_title = vacancy.get("name") or data.get("vacancy_title") or ""
     vacancy_desc = vacancy.get("description") or data.get("vacancy_description") or ""
     applicant_name = (
@@ -57,20 +60,20 @@ def parse_hh_payload(raw: bytes) -> Dict[str, Any]:
         or None
     )
 
-    if not response_id:
-        raise ValueError("missing response_id")
+    try:
+        return IncomingPayload(
+            platform="hh",
+            owner_id=owner_id,
+            vacancy_id=vacancy_id,
+            vacancy_title=vacancy_title,
+            vacancy_desc=vacancy_desc,
+            applicant=Applicant(id=response_id, name=applicant_name),
+        )
+    except ValidationError as exc:
+        raise exc
 
-    return {
-        "platform": "hh",
-        "owner_id": owner_id,
-        "vacancy_id": vacancy_id,
-        "vacancy_title": vacancy_title,
-        "vacancy_desc": vacancy_desc,
-        "applicant": {"id": response_id, "name": applicant_name},
-    }
 
-
-def parse_avito_payload(raw: bytes) -> Dict[str, Any]:
+def parse_avito_payload(raw: bytes) -> IncomingPayload:
     """Parse raw Avito webhook data into normalized payload.
 
     Args:
@@ -92,14 +95,12 @@ def parse_avito_payload(raw: bytes) -> Dict[str, Any]:
     val = payload_root.get("value") or {}
 
     chat_id = str(val.get("chat_id") or "")
-    if not chat_id:
-        raise ValueError("missing chat_id")
 
     text = (val.get("content") or {}).get("text") or ""
     item = val.get("item") or {}
     ctx = val.get("context") or {}
 
-    item_id = str(item.get("id") or ctx.get("item_id") or "")
+    item_id = str(item.get("id") or ctx.get("item_id") or "") or None
     vacancy_title = item.get("title") or val.get("title") or "Отклик Avito"
     vacancy_desc = item.get("description") or ctx.get("description") or ""
     applicant_id = str(val.get("user_id") or val.get("author_id") or "")
@@ -114,15 +115,20 @@ def parse_avito_payload(raw: bytes) -> Dict[str, Any]:
         or None
     )
 
-    return {
-        "platform": "avito",
-        "owner_id": owner_id,
-        "vacancy_id": item_id,
-        "vacancy_title": vacancy_title,
-        "vacancy_desc": vacancy_desc,
-        "applicant": {"id": chat_id, "name": f'user:{applicant_id or "unknown"}'},
-        "raw_text": text,
-    }
+    try:
+        return IncomingPayload(
+            platform="avito",
+            owner_id=owner_id,
+            vacancy_id=item_id,
+            vacancy_title=vacancy_title,
+            vacancy_desc=vacancy_desc,
+            applicant=Applicant(
+                id=chat_id, name=f'user:{applicant_id or "unknown"}'
+            ),
+            raw_text=text,
+        )
+    except ValidationError as exc:
+        raise exc
 
 
 __all__ = ["parse_hh_payload", "parse_avito_payload"]

--- a/tests/test_lead_processor.py
+++ b/tests/test_lead_processor.py
@@ -1,11 +1,16 @@
 import pytest
 
+from app.models import Applicant, IncomingPayload
 from app.services import lead_processor
 
 
 @pytest.mark.asyncio
 async def test_enrich_applicant(monkeypatch):
-    payload = {"platform": "hh", "owner_id": "o1", "applicant": {"id": "1", "name": "кандидат"}}
+    payload = IncomingPayload(
+        platform="hh",
+        owner_id="o1",
+        applicant=Applicant(id="1", name="кандидат"),
+    )
 
     async def fake_fetch(applicant_id, owner_id, http_client):
         return {"phone": "123", "city": "Moscow", "name": "Ivan"}
@@ -13,22 +18,22 @@ async def test_enrich_applicant(monkeypatch):
     monkeypatch.setattr(lead_processor.hh_adapt, "fetch_applicant_details", fake_fetch)
 
     result = await lead_processor.enrich_applicant(payload, None)
-    assert result["applicant"]["phone"] == "123"
-    assert result["applicant"]["city"] == "Moscow"
-    assert result["applicant"]["name"] == "Ivan"
+    assert result.applicant.phone == "123"
+    assert result.applicant.city == "Moscow"
+    assert result.applicant.name == "Ivan"
 
 
 @pytest.mark.asyncio
 async def test_create_lead(monkeypatch):
-    payload = {
-        "platform": "hh",
-        "vacancy_title": "Title",
-        "vacancy_desc": "",
-        "raw_text": "",
-        "applicant": {"id": "1", "name": "John"},
-        "owner_id": "own",
-        "vacancy_id": "vac",
-    }
+    payload = IncomingPayload(
+        platform="hh",
+        vacancy_title="Title",
+        vacancy_desc="",
+        raw_text="",
+        applicant=Applicant(id="1", name="John"),
+        owner_id="own",
+        vacancy_id="vac",
+    )
 
     monkeypatch.setattr(lead_processor, "route_kind", lambda **kw: "master")
 
@@ -62,12 +67,12 @@ async def test_send_invite(monkeypatch):
 
     monkeypatch.setattr(lead_processor, "publish_task", fake_publish)
 
-    payload = {
-        "platform": "hh",
-        "owner_id": "o1",
-        "applicant": {"id": "resp"},
-        "kind": "master",
-    }
+    payload = IncomingPayload(
+        platform="hh",
+        owner_id="o1",
+        applicant=Applicant(id="resp", name="name"),
+        kind="master",
+    )
 
     link = await lead_processor.send_invite(payload, 555)
     assert "start=555" in link

--- a/tests/test_payload_parsers.py
+++ b/tests/test_payload_parsers.py
@@ -1,6 +1,8 @@
 import json
 import pytest
+from pydantic import ValidationError
 
+from app.models import IncomingPayload
 from app.services.payload_parsers import parse_hh_payload, parse_avito_payload
 
 
@@ -17,15 +19,17 @@ def test_parse_hh_payload_ok():
     ).encode()
 
     payload = parse_hh_payload(raw)
-    assert payload["platform"] == "hh"
-    assert payload["owner_id"] == "emp1"
-    assert payload["vacancy_id"] == "vac1"
-    assert payload["applicant"] == {"id": "resp1", "name": "John"}
+    assert isinstance(payload, IncomingPayload)
+    assert payload.platform == "hh"
+    assert payload.owner_id == "emp1"
+    assert payload.vacancy_id == "vac1"
+    assert payload.applicant.id == "resp1"
+    assert payload.applicant.name == "John"
 
 
 def test_parse_hh_payload_missing_id():
     raw = json.dumps({"response": {}}).encode()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         parse_hh_payload(raw)
 
 
@@ -50,16 +54,18 @@ def test_parse_avito_payload_ok():
     ).encode()
 
     payload = parse_avito_payload(raw)
-    assert payload["platform"] == "avito"
-    assert payload["owner_id"] == "acc1"
-    assert payload["vacancy_id"] == "item1"
-    assert payload["applicant"] == {"id": "chat1", "name": "user:u1"}
-    assert payload["raw_text"] == "hi"
+    assert isinstance(payload, IncomingPayload)
+    assert payload.platform == "avito"
+    assert payload.owner_id == "acc1"
+    assert payload.vacancy_id == "item1"
+    assert payload.applicant.id == "chat1"
+    assert payload.applicant.name == "user:u1"
+    assert payload.raw_text == "hi"
 
 
 def test_parse_avito_payload_missing_chat_id():
     raw = json.dumps({"payload": {"value": {}}}).encode()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValidationError):
         parse_avito_payload(raw)
 
 


### PR DESCRIPTION
## Summary
- Add `IncomingPayload` and `Applicant` pydantic models
- Parse webhook payloads into typed models
- Refactor lead processing services to use models
- Test that invalid payloads trigger validation errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b2f60bb0832183e22f41f6b3ad80