### PR TITLE
Handle invalid Telegram ext_id in AmoChats webhook

### DIFF
--- a/app/api/api_amochats.py
+++ b/app/api/api_amochats.py
@@ -100,8 +100,10 @@ async def amochats_in(request: Request, scope_id: str | None = None):
         if isinstance(ext_id, str) and ext_id.startswith("tg:"):
             try:
                 tg_uid = int(ext_id.split(":", 1)[1])
-            except:
-                pass
+            except ValueError:
+                logger.debug("amo-chats bad tg ext_id: %r", ext_id)
+                logger.warning("amo-chats failed to parse tg uid from ext_id %r", ext_id)
+                tg_uid = None
 
         if tg_uid:
             cand = []


### PR DESCRIPTION
## Summary
- avoid bare except when parsing AmoChats ext_id and log invalid values
- continue AmoChats webhook processing when Telegram UID can't be extracted

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b64f2ae08321af85d0a7652fefd9