### PR TITLE
Handle specific errors in applicant enrichment

### DIFF
--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -1,6 +1,7 @@
 import logging
 import time
 import httpx
+import json
 
 from app.adapters import hh as hh_adapt
 from app.adapters.amo_client import ReauthRequired
@@ -32,8 +33,12 @@ async def enrich_applicant(
                     if payload.applicant.name and payload.applicant.name != "кандидат"
                     else extra.get("name") or payload.applicant.name
                 )
-        except Exception as e:  # pragma: no cover - log only
-            logger.warning("HH enrich failed: %s", e)
+        except (httpx.HTTPError, json.JSONDecodeError) as e:  # pragma: no cover - log only
+            logger.warning(
+                "HH enrich failed for applicant %s: %s",
+                payload.applicant.id,
+                type(e).__name__,
+            )
     return payload
 
 


### PR DESCRIPTION
## Summary
- Handle only httpx.HTTPError and json.JSONDecodeError in applicant enrichment
- Log applicant ID and error type when HeadHunter data fetch fails

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8b7ecd5d4832185d8e18ffd7c3632