### PR TITLE
Improve hashtag routing and typing

### DIFF
--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -1,13 +1,18 @@
 """Utility helpers used across API modules."""
 
 import re
+from typing import Mapping
 
 
-HASHTAG_RE = re.compile(r"(?i)(?<!\\w)#\\s*(мастер|оператор)\\b")
+HASHTAG_RE = re.compile(r"(?i)(?<!\w)#\s*(?:мастер|оператор)\b")
 
 
-def events_from_form(form) -> list[tuple[int, int]]:
-    """Extract lead/status pairs from AmoCRM webhook form."""
+def events_from_form(form: Mapping[str, str]) -> list[tuple[int, int]]:
+    """Extract lead/status pairs from AmoCRM webhook form.
+
+    Args:
+        form: Mapping of form field names to their values.
+    """
     keys = list(form.keys())
     idxs: set[int] = set()
     for k in keys:
@@ -29,8 +34,8 @@ def route_kind(*, desc: str = "", raw: str = "") -> str:
     m = HASHTAG_RE.search(blob)
     if not m:
         return "ignore"
-    val = (m.group(1) or "").strip().lower()
-    return "master" if val.startswith("мастер") else "operator"
+    val = m.group(0).lower()
+    return "master" if "мастер" in val else "operator"
 
 
 _REFUSAL_NAMES = {

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1,0 +1,27 @@
+import pytest
+
+from app.api.utils import route_kind
+
+
+@pytest.mark.parametrize(
+    "desc, raw, expected",
+    [
+        ("#мастер", "", "master"),
+        ("", "текст #оператор", "operator"),
+    ],
+)
+def test_route_kind_positive(desc, raw, expected):
+    assert route_kind(desc=desc, raw=raw) == expected
+
+
+@pytest.mark.parametrize(
+    "desc",
+    [
+        "мастер",  # no hashtag
+        "#мастерская",  # word continuation
+        "#операторский",  # word continuation
+        "a#оператор",  # preceding word char
+    ],
+)
+def test_route_kind_negative(desc):
+    assert route_kind(desc=desc) == "ignore"


### PR DESCRIPTION
## Summary
- refine hashtag regex to support `#мастер` and `#оператор` without capture
- type annotate `events_from_form` form parameter
- add unit tests for `route_kind`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8bae3c23083219a7e71b963166af9