### PR TITLE
Refactor Avito payload parsing with dedicated model and extractor

### DIFF
--- a/app/api/avito_incoming.py
+++ b/app/api/avito_incoming.py
@@ -7,7 +7,7 @@ from fastapi import APIRouter, Depends, Request
 from app.adapters.amo_client import AmoClient
 from app.http_client import get_http_client
 from app.services.dedup import calc_key, check_and_store
-from app.services.payload_parsers import parse_avito_payload
+from app.services.payload_parsers import extract_avito_payload, parse_avito_payload
 from app.services.lead_processor import (
     enrich_applicant,
     create_lead,
@@ -31,7 +31,8 @@ async def webhook_avito(
         return {"ok": True, "duplicate": True}
 
     try:
-        payload = parse_avito_payload(raw)
+        avito_payload = extract_avito_payload(raw)
+        payload = parse_avito_payload(avito_payload)
     except ValueError as exc:
         logger.warning("Avito webhook: %s; payload=%s", exc, raw)
         return {"ok": True, "skipped": True}

--- a/app/models.py
+++ b/app/models.py
@@ -29,4 +29,18 @@ class IncomingPayload(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
-__all__ = ["IncomingPayload", "Applicant"]
+class AvitoPayload(BaseModel):
+    """Raw Avito webhook payload after initial extraction."""
+
+    chat_id: str = Field(..., min_length=1)
+    item_id: str | None = None
+    item_title: str = "Отклик Avito"
+    item_description: str = ""
+    applicant_id: str | None = None
+    text: str = ""
+    owner_id: str | None = None
+
+    model_config = ConfigDict(extra="allow")
+
+
+__all__ = ["IncomingPayload", "Applicant", "AvitoPayload"]

--- a/app/services/payload_parsers.py
+++ b/app/services/payload_parsers.py
@@ -3,7 +3,7 @@ import logging
 
 from pydantic import ValidationError
 
-from app.models import Applicant, IncomingPayload
+from app.models import Applicant, IncomingPayload, AvitoPayload
 
 logger = logging.getLogger(__name__)
 
@@ -73,18 +73,9 @@ def parse_hh_payload(raw: bytes) -> IncomingPayload:
         raise exc
 
 
-def parse_avito_payload(raw: bytes) -> IncomingPayload:
-    """Parse raw Avito webhook data into normalized payload.
+def extract_avito_payload(raw: bytes) -> AvitoPayload:
+    """Extract raw Avito webhook data into :class:`AvitoPayload`."""
 
-    Args:
-        raw: Raw HTTP body bytes.
-
-    Returns:
-        Normalized payload dictionary suitable for `_process_incoming`.
-
-    Raises:
-        ValueError: If the JSON is malformed or required identifiers are missing.
-    """
     try:
         data = json.loads(raw.decode() or "{}")
     except Exception as exc:  # pragma: no cover - log only
@@ -95,40 +86,54 @@ def parse_avito_payload(raw: bytes) -> IncomingPayload:
     val = payload_root.get("value") or {}
 
     chat_id = str(val.get("chat_id") or "")
-
     text = (val.get("content") or {}).get("text") or ""
     item = val.get("item") or {}
     ctx = val.get("context") or {}
 
     item_id = str(item.get("id") or ctx.get("item_id") or "") or None
-    vacancy_title = item.get("title") or val.get("title") or "Отклик Avito"
-    vacancy_desc = item.get("description") or ctx.get("description") or ""
-    applicant_id = str(val.get("user_id") or val.get("author_id") or "")
+    item_title = item.get("title") or val.get("title") or "Отклик Avito"
+    item_description = item.get("description") or ctx.get("description") or ""
+    applicant_id = str(val.get("user_id") or val.get("author_id") or "") or None
 
     owner_id = (
         str(
             data.get("account_id")
             or payload_root.get("account_id")
             or val.get("account_id")
-            or ""
+            or "",
         )
         or None
     )
 
+    return AvitoPayload(
+        chat_id=chat_id,
+        item_id=item_id,
+        item_title=item_title,
+        item_description=item_description,
+        applicant_id=applicant_id,
+        text=text,
+        owner_id=owner_id,
+    )
+
+
+def parse_avito_payload(payload: AvitoPayload) -> IncomingPayload:
+    """Normalize :class:`AvitoPayload` into :class:`IncomingPayload`."""
+
     try:
         return IncomingPayload(
             platform="avito",
-            owner_id=owner_id,
-            vacancy_id=item_id,
-            vacancy_title=vacancy_title,
-            vacancy_desc=vacancy_desc,
+            owner_id=payload.owner_id,
+            vacancy_id=payload.item_id,
+            vacancy_title=payload.item_title,
+            vacancy_desc=payload.item_description,
             applicant=Applicant(
-                id=chat_id, name=f'user:{applicant_id or "unknown"}'
+                id=payload.chat_id, name=f"user:{payload.applicant_id or 'unknown'}"
             ),
-            raw_text=text,
+            raw_text=payload.text,
         )
     except ValidationError as exc:
         raise exc
 
 
-__all__ = ["parse_hh_payload", "parse_avito_payload"]
+__all__ = ["parse_hh_payload", "extract_avito_payload", "parse_avito_payload"]
+

--- a/tests/test_payload_parsers.py
+++ b/tests/test_payload_parsers.py
@@ -2,8 +2,12 @@ import json
 import pytest
 from pydantic import ValidationError
 
-from app.models import IncomingPayload
-from app.services.payload_parsers import parse_hh_payload, parse_avito_payload
+from app.models import IncomingPayload, AvitoPayload
+from app.services.payload_parsers import (
+    parse_hh_payload,
+    extract_avito_payload,
+    parse_avito_payload,
+)
 
 
 def test_parse_hh_payload_ok():
@@ -38,6 +42,29 @@ def test_parse_hh_payload_bad_json():
         parse_hh_payload(b"{bad json")
 
 
+def test_extract_avito_payload_ok():
+    raw = json.dumps(
+        {
+            "payload": {
+                "value": {
+                    "chat_id": "chat1",
+                    "content": {"text": "hi"},
+                    "item": {"id": "item1", "title": "Vac", "description": "Desc"},
+                    "user_id": "u1",
+                },
+                "account_id": "acc1",
+            }
+        }
+    ).encode()
+
+    payload = extract_avito_payload(raw)
+    assert isinstance(payload, AvitoPayload)
+    assert payload.chat_id == "chat1"
+    assert payload.item_id == "item1"
+    assert payload.text == "hi"
+    assert payload.owner_id == "acc1"
+
+
 def test_parse_avito_payload_ok():
     raw = json.dumps(
         {
@@ -53,7 +80,8 @@ def test_parse_avito_payload_ok():
         }
     ).encode()
 
-    payload = parse_avito_payload(raw)
+    avito_payload = extract_avito_payload(raw)
+    payload = parse_avito_payload(avito_payload)
     assert isinstance(payload, IncomingPayload)
     assert payload.platform == "avito"
     assert payload.owner_id == "acc1"
@@ -63,12 +91,12 @@ def test_parse_avito_payload_ok():
     assert payload.raw_text == "hi"
 
 
-def test_parse_avito_payload_missing_chat_id():
+def test_extract_avito_payload_missing_chat_id():
     raw = json.dumps({"payload": {"value": {}}}).encode()
     with pytest.raises(ValidationError):
-        parse_avito_payload(raw)
+        extract_avito_payload(raw)
 
 
-def test_parse_avito_payload_bad_json():
+def test_extract_avito_payload_bad_json():
     with pytest.raises(ValueError):
-        parse_avito_payload(b"not json")
+        extract_avito_payload(b"not json")


### PR DESCRIPTION
## Summary
- add AvitoPayload pydantic model
- split Avito parsing into extract and normalize steps
- update Avito webhook handler and tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8bcc51c9c832185b14280ec6996c5