### PR TITLE
Add SurveyService and integrate with Telegram router

### DIFF
--- a/app/services/survey_service.py
+++ b/app/services/survey_service.py
@@ -1,0 +1,37 @@
+from app.core.config import settings
+from app.services.queue import publish_task
+from app.store_survey import (
+    start_or_reset_survey,
+    get_survey,
+    store_answer_and_advance,
+    delete_survey,
+)
+from app.services.survey import mark_went_to_bot_async
+
+
+class SurveyService:
+    async def start(self, user_id: int, bot_kind: str, lead_id: int, identity: str) -> None:
+        """Start or reset survey and mark that user went to bot."""
+        await start_or_reset_survey(user_id, bot_kind, lead_id)
+        await mark_went_to_bot_async(lead_id, bot_kind, identity)
+
+    async def get(self, user_id: int, bot_kind: str):
+        return await get_survey(user_id, bot_kind)
+
+    async def store_answer(self, user_id: int, bot_kind: str, text: str):
+        return await store_answer_and_advance(user_id, bot_kind, text)
+
+    async def finish(self, user_id: int, bot_kind: str, lead_id: int, summary: str) -> None:
+        await publish_task({
+            "platform": "amo",
+            "action": "amo_add_tags",
+            "lead_id": lead_id,
+            "tags": [settings.AMO_TAG_SURVEY_DONE],
+        })
+        await publish_task({
+            "platform": "amo",
+            "action": "amo_add_note",
+            "lead_id": lead_id,
+            "text": f"[{bot_kind}] {summary}",
+        })
+        await delete_survey(user_id, bot_kind)

--- a/app/tg_router.py
+++ b/app/tg_router.py
@@ -5,23 +5,21 @@ from aiogram.types import Message
 
 from app.core.config import settings
 from app.store_chat import upsert_tg_link, get_by_user
-from app.store_survey import (
-    start_or_reset_survey, get_survey, store_answer_and_advance, delete_survey
-)
 from app.services.queue import publish_task
 from app.services.survey import (
     parse_start_arg,
     survey_prompt,
     survey_summary,
     pretty_tg_identity,
-    mark_went_to_bot_async,
 )
+from app.services.survey_service import SurveyService
 
 logger = logging.getLogger("tg.router")
 
 
 def make_router(bot_kind: str) -> Dispatcher:
     dp = Dispatcher()
+    svc = SurveyService()
 
     async def _answer_and_mirror(m: Message, text: str, bot_kind: str, lead_id: int, conv_id: str | None):
         # 1) отвечаем в TG
@@ -47,8 +45,7 @@ def make_router(bot_kind: str) -> Dispatcher:
             return
 
         await upsert_tg_link(m.from_user.id, bot_kind, lead_id)
-        await start_or_reset_survey(m.from_user.id, bot_kind, lead_id)
-        await mark_went_to_bot_async(lead_id, bot_kind, pretty_tg_identity(m))
+        await svc.start(m.from_user.id, bot_kind, lead_id, pretty_tg_identity(m))
 
         greeting = "Здравствуйте! Нужны пару уточнений по заявке.\n\n" + survey_prompt(0)
         await _answer_and_mirror(m, greeting, bot_kind, lead_id, conv_id=None)
@@ -58,7 +55,7 @@ def make_router(bot_kind: str) -> Dispatcher:
     @dp.message(F.text)
     async def on_text(m: Message):
         text = m.text or ""
-        survey = await get_survey(m.from_user.id, bot_kind)
+        survey = await svc.get(m.from_user.id, bot_kind)
 
         # найдём привязку даже если опрос завершён
         lead_id: int | None = None
@@ -91,7 +88,7 @@ def make_router(bot_kind: str) -> Dispatcher:
 
         # опрос
         if survey:
-            survey = await store_answer_and_advance(m.from_user.id, bot_kind, text)
+            survey = await svc.store_answer(m.from_user.id, bot_kind, text)
             if not survey:
                 await _answer_and_mirror(m, "Сессия не найдена. Нажмите /start ещё раз.", bot_kind, lead_id, conv_id)
                 return
@@ -100,21 +97,7 @@ def make_router(bot_kind: str) -> Dispatcher:
                 await _answer_and_mirror(m, survey_prompt(survey.step), bot_kind, lead_id, conv_id)
             else:
                 summary = survey_summary(survey.city, survey.experience, survey.time_pref)
-                # ставим тег и заметку — тоже через воркер
-                await publish_task({
-                    "platform": "amo",
-                    "action": "amo_add_tags",
-                    "lead_id": lead_id,
-                    "tags": [settings.AMO_TAG_SURVEY_DONE],
-                })
-                await publish_task({
-                    "platform": "amo",
-                    "action": "amo_add_note",
-                    "lead_id": lead_id,
-                    "text": f"[{bot_kind}] {summary}",
-                })
-
-                await delete_survey(m.from_user.id, bot_kind)
+                await svc.finish(m.from_user.id, bot_kind, lead_id, summary)
                 await _answer_and_mirror(
                     m,
                     "Спасибо! Мы передали информацию рекрутеру. С вами свяжутся.",

--- a/tests/test_survey_service.py
+++ b/tests/test_survey_service.py
@@ -1,0 +1,98 @@
+import types
+import pytest
+
+from app.core.config import settings
+from app.services.survey_service import SurveyService
+
+
+@pytest.mark.asyncio
+async def test_start(monkeypatch):
+    called = []
+
+    async def fake_start_or_reset(user_id, bot_kind, lead_id):
+        called.append((user_id, bot_kind, lead_id))
+
+    monkeypatch.setattr(
+        "app.services.survey_service.start_or_reset_survey", fake_start_or_reset
+    )
+
+    published = []
+
+    async def fake_publish(payload):
+        published.append(payload)
+
+    monkeypatch.setattr("app.services.survey.publish_task", fake_publish)
+
+    svc = SurveyService()
+    await svc.start(1, "bot", 10, "id:42")
+
+    assert called == [(1, "bot", 10)]
+    assert published == [
+        {
+            "platform": "amo",
+            "action": "amo_add_note",
+            "lead_id": 10,
+            "text": "[bot] Кандидат перешёл в бота (TG id:42).",
+        },
+        {
+            "platform": "amo",
+            "action": "amo_add_tags",
+            "lead_id": 10,
+            "tags": [settings.AMO_TAG_WENT_TO_BOT],
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_store_answer(monkeypatch):
+    called = []
+
+    async def fake_store(user_id, bot_kind, text):
+        called.append((user_id, bot_kind, text))
+        return types.SimpleNamespace(answer=text)
+
+    monkeypatch.setattr(
+        "app.services.survey_service.store_answer_and_advance", fake_store
+    )
+
+    svc = SurveyService()
+    res = await svc.store_answer(2, "bot2", "hi")
+
+    assert called == [(2, "bot2", "hi")]
+    assert res.answer == "hi"
+
+
+@pytest.mark.asyncio
+async def test_finish(monkeypatch):
+    deleted = []
+
+    async def fake_delete(user_id, bot_kind):
+        deleted.append((user_id, bot_kind))
+
+    monkeypatch.setattr("app.services.survey_service.delete_survey", fake_delete)
+
+    published = []
+
+    async def fake_publish(payload):
+        published.append(payload)
+
+    monkeypatch.setattr("app.services.survey_service.publish_task", fake_publish)
+
+    svc = SurveyService()
+    await svc.finish(3, "b3", 33, "summary")
+
+    assert published == [
+        {
+            "platform": "amo",
+            "action": "amo_add_tags",
+            "lead_id": 33,
+            "tags": [settings.AMO_TAG_SURVEY_DONE],
+        },
+        {
+            "platform": "amo",
+            "action": "amo_add_note",
+            "lead_id": 33,
+            "text": "[b3] summary",
+        },
+    ]
+    assert deleted == [(3, "b3")]


### PR DESCRIPTION
## Summary
- encapsulate survey DB and queue logic into SurveyService
- refactor Telegram router to delegate survey lifecycle to the new service
- add unit tests for SurveyService

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8be021d4883218c3155941c420c2a