### PR TITLE
Optimize TgLink upsert

### DIFF
--- a/app/store_chat.py
+++ b/app/store_chat.py
@@ -7,6 +7,17 @@ from app.db.models import TgLink
 
 async def upsert_tg_link(user_id: int, bot_kind: str, lead_id: int) -> None:
     async with get_session() as s:
+        current_lead = (
+            await s.execute(
+                select(TgLink.lead_id).where(
+                    TgLink.user_id == user_id, TgLink.bot_kind == bot_kind
+                )
+            )
+        ).scalar_one_or_none()
+
+        if current_lead == lead_id:
+            return
+
         stmt = (
             pg_insert(TgLink)
             .values(user_id=user_id, bot_kind=bot_kind, lead_id=lead_id, updated_at=func.now())

--- a/tests/test_store_chat.py
+++ b/tests/test_store_chat.py
@@ -1,0 +1,28 @@
+import asyncio
+import pytest
+
+from app.store_chat import upsert_tg_link, get_by_user
+
+
+@pytest.mark.asyncio
+async def test_upsert_tg_link_updates_only_on_change(in_memory_db):
+    user_id = 1
+    bot_kind = "test"
+
+    await upsert_tg_link(user_id, bot_kind, lead_id=100)
+    link = await get_by_user(user_id, bot_kind)
+    assert link is not None
+    assert link.lead_id == 100
+    first_updated_at = link.updated_at
+
+    await asyncio.sleep(1)
+    await upsert_tg_link(user_id, bot_kind, lead_id=100)
+    link_same = await get_by_user(user_id, bot_kind)
+    assert link_same.updated_at == first_updated_at
+    assert link_same.lead_id == 100
+
+    await asyncio.sleep(1)
+    await upsert_tg_link(user_id, bot_kind, lead_id=200)
+    link_updated = await get_by_user(user_id, bot_kind)
+    assert link_updated.lead_id == 200
+    assert link_updated.updated_at != first_updated_at


### PR DESCRIPTION
## Summary
- avoid updating TgLink when lead stays the same
- test TgLink upsert behavior

## Testing
- `pytest tests/test_store_chat.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8c604ddcc83218401b1ee7ed2cab8