### PR TITLE
Avoid redundant token updates

### DIFF
--- a/app/db/token_store.py
+++ b/app/db/token_store.py
@@ -56,6 +56,10 @@ class DbTokenStore:
             )
 
             if row:
+                # Выполняем update только при наличии изменений
+                has_changes = any(getattr(row, k) != v for k, v in values.items())
+                if not has_changes:
+                    return
                 await s.execute(
                     update(Token)
                     .where(


### PR DESCRIPTION
## Summary
- Skip token update when values are unchanged

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c810481c832189ea39d1e8c3cfdd