### PR TITLE
Add tests for HH incoming webhook

### DIFF
--- a/tests/test_hh_incoming.py
+++ b/tests/test_hh_incoming.py
@@ -1,0 +1,158 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from app.api import hh_incoming
+from app.models import IncomingPayload, Applicant
+
+
+@pytest.fixture
+def client(monkeypatch):
+    app = FastAPI()
+    app.include_router(hh_incoming.router)
+
+    class DummyAmoClient:
+        @classmethod
+        async def create(cls, http_client):
+            return object()
+
+    monkeypatch.setattr(hh_incoming, "AmoClient", DummyAmoClient)
+    return TestClient(app)
+
+
+def _payload() -> IncomingPayload:
+    return IncomingPayload(platform="hh", owner_id="1", applicant=Applicant(id="a", name="b"))
+
+
+def test_webhook_success(monkeypatch, client):
+    async def fake_check(key):
+        return True
+
+    monkeypatch.setattr(hh_incoming, "check_and_store", fake_check)
+    monkeypatch.setattr(hh_incoming, "parse_hh_payload", lambda raw: _payload())
+
+    async def fake_enrich(payload, http_client):
+        return payload
+
+    monkeypatch.setattr(hh_incoming, "enrich_applicant", fake_enrich)
+
+    async def fake_create_lead(payload, amo):
+        return 777, "kind"
+
+    monkeypatch.setattr(hh_incoming, "create_lead", fake_create_lead)
+
+    called = {}
+
+    async def fake_send_invite(payload, lead_id):
+        called["invite"] = lead_id
+
+    async def fake_tag_lead(lead_id, kind, amo):
+        called["tag"] = kind
+
+    monkeypatch.setattr(hh_incoming, "send_invite", fake_send_invite)
+    monkeypatch.setattr(hh_incoming, "tag_lead", fake_tag_lead)
+
+    r = client.post("/webhooks/hh", data=b"{}")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "lead_id": 777}
+    assert called["invite"] == 777
+    assert called["tag"] == "kind"
+
+
+def test_webhook_duplicate(monkeypatch, client):
+    async def fake_check(key):
+        return False
+
+    monkeypatch.setattr(hh_incoming, "check_and_store", fake_check)
+
+    called = False
+
+    def fake_parse(raw):
+        nonlocal called
+        called = True
+        return _payload()
+
+    monkeypatch.setattr(hh_incoming, "parse_hh_payload", fake_parse)
+
+    r = client.post("/webhooks/hh", data=b"{}")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "duplicate": True}
+    assert not called
+
+
+def test_webhook_bad_payload(monkeypatch, client):
+    async def fake_check(key):
+        return True
+
+    monkeypatch.setattr(hh_incoming, "check_and_store", fake_check)
+
+    def fake_parse(raw):
+        raise ValueError("bad")
+
+    monkeypatch.setattr(hh_incoming, "parse_hh_payload", fake_parse)
+
+    r = client.post("/webhooks/hh", data=b"{}")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "skipped": True}
+
+
+def test_webhook_ignored(monkeypatch, client):
+    async def fake_check(key):
+        return True
+
+    monkeypatch.setattr(hh_incoming, "check_and_store", fake_check)
+    monkeypatch.setattr(hh_incoming, "parse_hh_payload", lambda raw: _payload())
+
+    async def fake_enrich(payload, http_client):
+        return payload
+
+    monkeypatch.setattr(hh_incoming, "enrich_applicant", fake_enrich)
+
+    async def fake_create_lead(payload, amo):
+        return None, "ignore"
+
+    monkeypatch.setattr(hh_incoming, "create_lead", fake_create_lead)
+
+    async def fake_send_invite(*args, **kwargs):
+        raise AssertionError("send_invite should not be called")
+
+    async def fake_tag_lead(*args, **kwargs):
+        raise AssertionError("tag_lead should not be called")
+
+    monkeypatch.setattr(hh_incoming, "send_invite", fake_send_invite)
+    monkeypatch.setattr(hh_incoming, "tag_lead", fake_tag_lead)
+
+    r = client.post("/webhooks/hh", data=b"{}")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "ignored": True, "reason": "no-keywords"}
+
+
+def test_webhook_queued(monkeypatch, client):
+    async def fake_check(key):
+        return True
+
+    monkeypatch.setattr(hh_incoming, "check_and_store", fake_check)
+    monkeypatch.setattr(hh_incoming, "parse_hh_payload", lambda raw: _payload())
+
+    async def fake_enrich(payload, http_client):
+        return payload
+
+    monkeypatch.setattr(hh_incoming, "enrich_applicant", fake_enrich)
+
+    async def fake_create_lead(payload, amo):
+        return None, "master"
+
+    monkeypatch.setattr(hh_incoming, "create_lead", fake_create_lead)
+
+    async def fake_send_invite(*args, **kwargs):
+        raise AssertionError("send_invite should not be called")
+
+    async def fake_tag_lead(*args, **kwargs):
+        raise AssertionError("tag_lead should not be called")
+
+    monkeypatch.setattr(hh_incoming, "send_invite", fake_send_invite)
+    monkeypatch.setattr(hh_incoming, "tag_lead", fake_tag_lead)
+
+    r = client.post("/webhooks/hh", data=b"{}")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "queued": True, "reason": "reauth_required"}


### PR DESCRIPTION
## Summary
- add tests for HeadHunter webhook covering success, duplicate, invalid, ignored and queued flows

## Testing
- `pytest tests/test_hh_incoming.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c9a344bc832194fc0c075ca08cd5