### PR TITLE
test: cover telegram webhook admin endpoints

### DIFF
--- a/tests/test_tg_webhooks.py
+++ b/tests/test_tg_webhooks.py
@@ -68,3 +68,142 @@ def test_factory_bad_secret(monkeypatch, sample_update):
     client = TestClient(app)
     r = client.post("/tg/webhook/master", json=sample_update)
     assert r.status_code == 401
+
+
+def _build_admin_app():
+    app = FastAPI()
+    app.include_router(tg_webhooks.admin_tg)
+    return app
+
+
+def test_set_webhooks(monkeypatch):
+    class DummyBot:
+        instances = []
+
+        def __init__(self, token):
+            self.token = token
+            self.calls = []
+            DummyBot.instances.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def set_webhook(self, **kwargs):
+            self.calls.append(("set_webhook", kwargs))
+            return "ok"
+
+    monkeypatch.setattr(tg_webhooks, "Bot", DummyBot)
+    monkeypatch.setattr(tg_webhooks, "tokens", {"m": "token"})
+    monkeypatch.setattr(tg_webhooks.settings, "TELEGRAM_WEBHOOK_BASE", "https://example")
+    monkeypatch.setattr(tg_webhooks.settings, "TELEGRAM_WEBHOOK_SECRET", "s3cr")
+    monkeypatch.setattr(tg_webhooks.settings, "ADMIN_TOKEN", "")
+
+    app = _build_admin_app()
+    client = TestClient(app)
+    r = client.post("/admin/tg/set-webhooks")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "set": {"m": "ok"}}
+
+    assert len(DummyBot.instances) == 1
+    call = DummyBot.instances[0].calls[0]
+    assert call[0] == "set_webhook"
+    assert call[1]["url"] == "https://example/tg/webhook/m"
+    assert call[1]["secret_token"] == "s3cr"
+    assert call[1]["allowed_updates"] == ["message"]
+    assert call[1]["drop_pending_updates"] is True
+
+
+def test_set_webhooks_no_base(monkeypatch):
+    class DummyBot:
+        instances = []
+
+        def __init__(self, token):
+            DummyBot.instances.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+    monkeypatch.setattr(tg_webhooks, "Bot", DummyBot)
+    monkeypatch.setattr(tg_webhooks, "tokens", {"m": "token"})
+    monkeypatch.setattr(tg_webhooks.settings, "TELEGRAM_WEBHOOK_BASE", "")
+    monkeypatch.setattr(tg_webhooks.settings, "ADMIN_TOKEN", "")
+
+    app = _build_admin_app()
+    client = TestClient(app)
+    r = client.post("/admin/tg/set-webhooks")
+    assert r.status_code == 200
+    assert r.json() == {"ok": False, "error": "TELEGRAM_WEBHOOK_BASE is empty"}
+    assert DummyBot.instances == []
+
+
+def test_delete_webhooks(monkeypatch):
+    class DummyBot:
+        instances = []
+
+        def __init__(self, token):
+            self.calls = []
+            DummyBot.instances.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def delete_webhook(self, **kwargs):
+            self.calls.append(("delete_webhook", kwargs))
+            return True
+
+    monkeypatch.setattr(tg_webhooks, "Bot", DummyBot)
+    monkeypatch.setattr(tg_webhooks, "tokens", {"m": "token"})
+    monkeypatch.setattr(tg_webhooks.settings, "ADMIN_TOKEN", "")
+
+    app = _build_admin_app()
+    client = TestClient(app)
+    r = client.post("/admin/tg/delete-webhooks")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "results": {"m": True}}
+
+    assert len(DummyBot.instances) == 1
+    call = DummyBot.instances[0].calls[0]
+    assert call[0] == "delete_webhook"
+    assert call[1] == {"drop_pending_updates": True}
+
+
+def test_webhook_info(monkeypatch):
+    class DummyBot:
+        instances = []
+
+        def __init__(self, token):
+            self.calls = []
+            DummyBot.instances.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        async def get_webhook_info(self):
+            self.calls.append(("get_webhook_info", {}))
+            return {"url": "info"}
+
+    monkeypatch.setattr(tg_webhooks, "Bot", DummyBot)
+    monkeypatch.setattr(tg_webhooks, "tokens", {"m": "token"})
+    monkeypatch.setattr(tg_webhooks.settings, "ADMIN_TOKEN", "")
+
+    app = _build_admin_app()
+    client = TestClient(app)
+    r = client.get("/admin/tg/webhook-info")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "info": {"m": {"url": "info"}}}
+
+    assert len(DummyBot.instances) == 1
+    call = DummyBot.instances[0].calls[0]
+    assert call[0] == "get_webhook_info"


### PR DESCRIPTION
## Summary
- add tests for setting, deleting, and inspecting telegram webhooks
- ensure webhooks require base URL and invoke correct Bot methods

## Testing
- `pytest tests/test_tg_webhooks.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a8ccf974948321964c20fc9c97f76c