### PR TITLE
test: centralize app and service mocks

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,11 @@
 import os
 import sys
 import types
+import importlib
 import pytest
 import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 # Ensure project root is on sys.path
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -75,3 +78,79 @@ async def in_memory_db(monkeypatch):
         yield
     finally:
         await engine.dispose()
+
+
+@pytest.fixture
+def app(monkeypatch):
+    """FastAPI application with essential routers for tests."""
+    from app.api import hh_incoming
+
+    application = FastAPI()
+
+    class DummyAmoClient:
+        @classmethod
+        async def create(cls, http_client):
+            return object()
+
+    monkeypatch.setattr(hh_incoming, "AmoClient", DummyAmoClient, raising=False)
+    application.include_router(hh_incoming.router)
+    return application
+
+
+@pytest.fixture
+def client(app):
+    """Synchronous test client for FastAPI app."""
+    return TestClient(app)
+
+
+@pytest.fixture
+def queue_mock(monkeypatch):
+    """Capture tasks published to the queue."""
+    published: list = []
+
+    async def fake_publish(payload, *args, **kwargs):
+        published.append(payload)
+
+    modules = [
+        "app.services.queue",
+        "app.services.lead_processor",
+        "app.services.survey",
+        "app.services.survey_service",
+        "app.tg_router",
+    ]
+    for mod_name in modules:
+        try:
+            mod = importlib.import_module(mod_name)
+            if hasattr(mod, "publish_task"):
+                monkeypatch.setattr(mod, "publish_task", fake_publish, raising=False)
+        except Exception:
+            pass
+
+    return published
+
+
+@pytest.fixture
+def token_mock(monkeypatch):
+    """Mock OAuth token retrieval."""
+    async def fake_ensure_fresh_access(**kwargs):
+        return "token"
+
+    async def fake_refresh_tokens(*args, **kwargs):
+        return {"access_token": "token"}
+
+    modules = [
+        "app.oauth2",
+        "app.adapters.hh",
+        "app.adapters.avito",
+    ]
+    for mod_name in modules:
+        try:
+            mod = importlib.import_module(mod_name)
+            if hasattr(mod, "ensure_fresh_access"):
+                monkeypatch.setattr(mod, "ensure_fresh_access", fake_ensure_fresh_access, raising=False)
+            if mod_name == "app.oauth2" and hasattr(mod, "refresh_tokens"):
+                monkeypatch.setattr(mod, "refresh_tokens", fake_refresh_tokens, raising=False)
+        except Exception:
+            pass
+
+    return "token"

--- a/tests/test_adapters_avito.py
+++ b/tests/test_adapters_avito.py
@@ -6,22 +6,19 @@ from app.adapters import avito
 
 
 @pytest.mark.asyncio
-async def test_avito_send_message(monkeypatch):
-    async def fake_ensure_fresh_access(**kwargs):
-        return "token"
-
+async def test_avito_send_message(monkeypatch, token_mock):
     async def fake_with_retry(coro, attempts, is_retryable):
         return await coro()
 
-    monkeypatch.setattr(avito, "ensure_fresh_access", fake_ensure_fresh_access)
     monkeypatch.setattr(avito, "with_retry", fake_with_retry)
+    token = token_mock
 
     captured = {}
 
     def handler(request):
         captured["url"] = str(request.url)
         captured["json"] = json.loads(request.content.decode())
-        assert request.headers["Authorization"] == "Bearer token"
+        assert request.headers["Authorization"] == f"Bearer {token}"
         return httpx.Response(200, json={})
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
@@ -32,14 +29,10 @@ async def test_avito_send_message(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_avito_send_message_error(monkeypatch):
-    async def fake_ensure_fresh_access(**kwargs):
-        return "token"
-
+async def test_avito_send_message_error(monkeypatch, token_mock):
     async def fake_with_retry(coro, attempts, is_retryable):
         return await coro()
 
-    monkeypatch.setattr(avito, "ensure_fresh_access", fake_ensure_fresh_access)
     monkeypatch.setattr(avito, "with_retry", fake_with_retry)
 
     def handler(request):
@@ -51,21 +44,18 @@ async def test_avito_send_message_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_avito_mark_read(monkeypatch):
-    async def fake_ensure_fresh_access(**kwargs):
-        return "token"
-
+async def test_avito_mark_read(monkeypatch, token_mock):
     async def fake_with_retry(coro, attempts, is_retryable):
         return await coro()
 
-    monkeypatch.setattr(avito, "ensure_fresh_access", fake_ensure_fresh_access)
     monkeypatch.setattr(avito, "with_retry", fake_with_retry)
+    token = token_mock
 
     captured = {}
 
     def handler(request):
         captured["url"] = str(request.url)
-        assert request.headers["Authorization"] == "Bearer token"
+        assert request.headers["Authorization"] == f"Bearer {token}"
         return httpx.Response(200)
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:

--- a/tests/test_adapters_hh.py
+++ b/tests/test_adapters_hh.py
@@ -6,22 +6,19 @@ from app.adapters import hh
 
 
 @pytest.mark.asyncio
-async def test_hh_send_message(monkeypatch):
-    async def fake_ensure_fresh_access(**kwargs):
-        return "token"
-
+async def test_hh_send_message(monkeypatch, token_mock):
     async def fake_with_retry(coro, attempts, is_retryable):
         return await coro()
 
-    monkeypatch.setattr(hh, "ensure_fresh_access", fake_ensure_fresh_access)
     monkeypatch.setattr(hh, "with_retry", fake_with_retry)
+    token = token_mock
 
     captured = {}
 
     def handler(request):
         captured["url"] = str(request.url)
         captured["json"] = json.loads(request.content.decode())
-        assert request.headers["Authorization"] == "Bearer token"
+        assert request.headers["Authorization"] == f"Bearer {token}"
         assert request.headers["Accept"] == "application/json"
         return httpx.Response(200, json={})
 
@@ -33,14 +30,10 @@ async def test_hh_send_message(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_hh_send_message_error(monkeypatch):
-    async def fake_ensure_fresh_access(**kwargs):
-        return "token"
-
+async def test_hh_send_message_error(monkeypatch, token_mock):
     async def fake_with_retry(coro, attempts, is_retryable):
         return await coro()
 
-    monkeypatch.setattr(hh, "ensure_fresh_access", fake_ensure_fresh_access)
     monkeypatch.setattr(hh, "with_retry", fake_with_retry)
 
     def handler(request):
@@ -52,11 +45,7 @@ async def test_hh_send_message_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_hh_fetch_applicant_details(monkeypatch):
-    async def fake_ensure_fresh_access(**kwargs):
-        return "token"
-
-    monkeypatch.setattr(hh, "ensure_fresh_access", fake_ensure_fresh_access)
+async def test_hh_fetch_applicant_details(monkeypatch, token_mock):
 
     def handler(request):
         if request.url.path.endswith("/negotiations/resp1"):

--- a/tests/test_hh_incoming.py
+++ b/tests/test_hh_incoming.py
@@ -1,23 +1,7 @@
 import pytest
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 
 from app.api import hh_incoming
 from app.models import IncomingPayload, Applicant
-
-
-@pytest.fixture
-def client(monkeypatch):
-    app = FastAPI()
-    app.include_router(hh_incoming.router)
-
-    class DummyAmoClient:
-        @classmethod
-        async def create(cls, http_client):
-            return object()
-
-    monkeypatch.setattr(hh_incoming, "AmoClient", DummyAmoClient)
-    return TestClient(app)
 
 
 def _payload() -> IncomingPayload:

--- a/tests/test_lead_processor.py
+++ b/tests/test_lead_processor.py
@@ -59,14 +59,7 @@ async def test_create_lead(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_send_invite(monkeypatch):
-    calls = []
-
-    async def fake_publish(payload):
-        calls.append(payload)
-
-    monkeypatch.setattr(lead_processor, "publish_task", fake_publish)
-
+async def test_send_invite(queue_mock):
     payload = IncomingPayload(
         platform="hh",
         owner_id="o1",
@@ -76,7 +69,7 @@ async def test_send_invite(monkeypatch):
 
     link = await lead_processor.send_invite(payload, 555)
     assert "start=555" in link
-    assert calls and calls[0]["platform"] == "hh"
+    assert queue_mock and queue_mock[0]["platform"] == "hh"
 
 
 @pytest.mark.asyncio

--- a/tests/test_survey_service.py
+++ b/tests/test_survey_service.py
@@ -6,7 +6,7 @@ from app.services.survey_service import SurveyService
 
 
 @pytest.mark.asyncio
-async def test_start(monkeypatch):
+async def test_start(monkeypatch, queue_mock):
     called = []
 
     async def fake_start_or_reset(user_id, bot_kind, lead_id):
@@ -16,18 +16,11 @@ async def test_start(monkeypatch):
         "app.services.survey_service.start_or_reset_survey", fake_start_or_reset
     )
 
-    published = []
-
-    async def fake_publish(payload):
-        published.append(payload)
-
-    monkeypatch.setattr("app.services.survey.publish_task", fake_publish)
-
     svc = SurveyService()
     await svc.start(1, "bot", 10, "id:42")
 
     assert called == [(1, "bot", 10)]
-    assert published == [
+    assert queue_mock == [
         {
             "platform": "amo",
             "action": "amo_add_note",
@@ -63,7 +56,7 @@ async def test_store_answer(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_finish(monkeypatch):
+async def test_finish(monkeypatch, queue_mock):
     deleted = []
 
     async def fake_delete(user_id, bot_kind):
@@ -71,17 +64,10 @@ async def test_finish(monkeypatch):
 
     monkeypatch.setattr("app.services.survey_service.delete_survey", fake_delete)
 
-    published = []
-
-    async def fake_publish(payload):
-        published.append(payload)
-
-    monkeypatch.setattr("app.services.survey_service.publish_task", fake_publish)
-
     svc = SurveyService()
     await svc.finish(3, "b3", 33, "summary")
 
-    assert published == [
+    assert queue_mock == [
         {
             "platform": "amo",
             "action": "amo_add_tags",

--- a/tests/test_tg_router.py
+++ b/tests/test_tg_router.py
@@ -68,24 +68,12 @@ async def feed(dp, bot, update):
 
 
 @pytest.mark.asyncio
-async def test_start(monkeypatch):
+async def test_start(monkeypatch, queue_mock):
     svc = DummySurveyService()
     monkeypatch.setattr(tg_router, "SurveyService", lambda: svc)
     async def dummy_upsert(*a, **k):
         return None
     monkeypatch.setattr(tg_router, "upsert_tg_link", dummy_upsert)
-
-    published = []
-
-    async def fake_publish(payload):
-        published.append(payload)
-
-    monkeypatch.setattr(tg_router, "publish_task", fake_publish)
-    # survey and survey_service also import publish_task
-    import app.services.survey as survey_mod
-    import app.services.survey_service as svc_mod
-    monkeypatch.setattr(survey_mod, "publish_task", fake_publish)
-    monkeypatch.setattr(svc_mod, "publish_task", fake_publish)
 
     dp = tg_router.make_router("master")
     bot, sent = make_bot()
@@ -105,28 +93,17 @@ async def test_start(monkeypatch):
     await bot.session.close()
 
     assert sent and "Здравствуйте" in sent[0]["text"]
-    assert published[-1]["action"] == "bot_to_amo"
-    assert published[-1]["lead_id"] == 777
+    assert queue_mock[-1]["action"] == "bot_to_amo"
+    assert queue_mock[-1]["lead_id"] == 777
 
 
 @pytest.mark.asyncio
-async def test_text_step(monkeypatch):
+async def test_text_step(monkeypatch, queue_mock):
     svc = DummySurveyService()
     monkeypatch.setattr(tg_router, "SurveyService", lambda: svc)
     async def dummy_upsert(*a, **k):
         return None
     monkeypatch.setattr(tg_router, "upsert_tg_link", dummy_upsert)
-
-    published = []
-
-    async def fake_publish(payload):
-        published.append(payload)
-
-    monkeypatch.setattr(tg_router, "publish_task", fake_publish)
-    import app.services.survey as survey_mod
-    import app.services.survey_service as svc_mod
-    monkeypatch.setattr(survey_mod, "publish_task", fake_publish)
-    monkeypatch.setattr(svc_mod, "publish_task", fake_publish)
 
     await svc.start(1, "master", 555, "id:1")
 
@@ -148,29 +125,18 @@ async def test_text_step(monkeypatch):
     await bot.session.close()
 
     assert sent and "Опишите" in sent[0]["text"]
-    assert published[0]["action"] == "tg_to_amo"
-    assert published[1]["action"] == "bot_to_amo"
+    assert queue_mock[0]["action"] == "tg_to_amo"
+    assert queue_mock[1]["action"] == "bot_to_amo"
     assert svc.data[1]["step"] == 1
 
 
 @pytest.mark.asyncio
-async def test_survey_finish(monkeypatch):
+async def test_survey_finish(monkeypatch, queue_mock):
     svc = DummySurveyService()
     monkeypatch.setattr(tg_router, "SurveyService", lambda: svc)
     async def dummy_upsert(*a, **k):
         return None
     monkeypatch.setattr(tg_router, "upsert_tg_link", dummy_upsert)
-
-    published = []
-
-    async def fake_publish(payload):
-        published.append(payload)
-
-    monkeypatch.setattr(tg_router, "publish_task", fake_publish)
-    import app.services.survey as survey_mod
-    import app.services.survey_service as svc_mod
-    monkeypatch.setattr(survey_mod, "publish_task", fake_publish)
-    monkeypatch.setattr(svc_mod, "publish_task", fake_publish)
 
     svc.data[1] = {
         "lead_id": 555,
@@ -197,14 +163,14 @@ async def test_survey_finish(monkeypatch):
     await bot.session.close()
 
     assert sent and "Спасибо" in sent[0]["text"]
-    assert published[0]["action"] == "tg_to_amo"
-    assert published[1]["action"] == "bot_to_amo"
+    assert queue_mock[0]["action"] == "tg_to_amo"
+    assert queue_mock[1]["action"] == "bot_to_amo"
     # finish called with summary
     assert svc.finished and "Итоги опроса" in svc.finished[3]
 
 
 @pytest.mark.asyncio
-async def test_text_no_lead(monkeypatch):
+async def test_text_no_lead(monkeypatch, queue_mock):
     svc = DummySurveyService()
     monkeypatch.setattr(tg_router, "SurveyService", lambda: svc)
     async def dummy_upsert(*a, **k):
@@ -213,17 +179,6 @@ async def test_text_no_lead(monkeypatch):
         return None
     monkeypatch.setattr(tg_router, "upsert_tg_link", dummy_upsert)
     monkeypatch.setattr(tg_router, "get_by_user", dummy_get)
-
-    published = []
-
-    async def fake_publish(payload):
-        published.append(payload)
-
-    monkeypatch.setattr(tg_router, "publish_task", fake_publish)
-    import app.services.survey as survey_mod
-    import app.services.survey_service as svc_mod
-    monkeypatch.setattr(survey_mod, "publish_task", fake_publish)
-    monkeypatch.setattr(svc_mod, "publish_task", fake_publish)
 
     dp = tg_router.make_router("master")
     bot, sent = make_bot()
@@ -243,27 +198,16 @@ async def test_text_no_lead(monkeypatch):
     await bot.session.close()
 
     assert sent and "Нажмите /start" in sent[0]["text"]
-    assert published == []
+    assert queue_mock == []
 
 
 @pytest.mark.asyncio
-async def test_text_session_missing(monkeypatch):
+async def test_text_session_missing(monkeypatch, queue_mock):
     svc = DummySurveyService()
     monkeypatch.setattr(tg_router, "SurveyService", lambda: svc)
     async def dummy_upsert(*a, **k):
         return None
     monkeypatch.setattr(tg_router, "upsert_tg_link", dummy_upsert)
-
-    published = []
-
-    async def fake_publish(payload):
-        published.append(payload)
-
-    monkeypatch.setattr(tg_router, "publish_task", fake_publish)
-    import app.services.survey as survey_mod
-    import app.services.survey_service as svc_mod
-    monkeypatch.setattr(survey_mod, "publish_task", fake_publish)
-    monkeypatch.setattr(svc_mod, "publish_task", fake_publish)
 
     svc.data[1] = {"lead_id": 555, "step": 0}
 
@@ -290,5 +234,5 @@ async def test_text_session_missing(monkeypatch):
     await bot.session.close()
 
     assert sent and "Сессия не найдена" in sent[0]["text"]
-    assert published[0]["action"] == "tg_to_amo"
-    assert published[1]["action"] == "bot_to_amo"
+    assert queue_mock[0]["action"] == "tg_to_amo"
+    assert queue_mock[1]["action"] == "bot_to_amo"


### PR DESCRIPTION
## Summary
- add shared fixtures for FastAPI app, queue publishing, and OAuth tokens
- refactor tests to reuse common fixtures

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8cdf84b308321a5eb8ac66d842f6b