### PR TITLE
Add CI workflow and status badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pylint mypy
+      - name: Run pytest
+        run: pytest
+      - name: Run pylint
+        run: pylint app
+      - name: Run mypy
+        run: mypy app

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# hr-bridge
+
+[![CI](https://github.com/OWNER/hr-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/hr-bridge/actions/workflows/ci.yml)
+
+Project description.


### PR DESCRIPTION
## Summary
- add GitHub Actions CI workflow to run pytest, pylint, and mypy
- show CI status badge in README

## Testing
- `pytest`
- `pylint app`
- `mypy --follow-imports=skip app`


------
https://chatgpt.com/codex/tasks/task_e_68a8cf7d13b08321b42c595adba48660