### PR TITLE
refactor: introduce RabbitMQ client

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -10,7 +10,7 @@ from app.http_client import get_http_client
 from app.core.config import settings
 from app.services.dedup import cleanup_older_than
 from app.services.hh_mapping import load as hh_map_load, set_all as hh_map_set
-from app.services.queue import publish_task
+from app.services.queue import rabbitmq, RabbitMQClient
 from app.db.token_store import DbTokenStore
 
 router = APIRouter()
@@ -44,9 +44,12 @@ async def put_hh_mapping(payload: dict):
 
 
 @admin.post("/rmq-test")
-async def rmq_test(payload: dict | None = None):
+async def rmq_test(
+    payload: dict | None = None,
+    queue_client: RabbitMQClient = Depends(lambda: rabbitmq),
+):
     msg = (payload or {}).get("msg", "hi")
-    await publish_task({"platform": "debug", "action": "echo", "msg": msg})
+    await queue_client.publish_task({"platform": "debug", "action": "echo", "msg": msg})
     return {"ok": True}
 
 
@@ -86,8 +89,10 @@ async def hh_states(
 
 
 @admin.post("/hh-autofill")
-async def hh_autofill_admin():
-    await publish_task({"platform": "system", "action": "hh_autofill"})
+async def hh_autofill_admin(
+    queue_client: RabbitMQClient = Depends(lambda: rabbitmq),
+):
+    await queue_client.publish_task({"platform": "system", "action": "hh_autofill"})
     return {"ok": True, "queued": True}
 
 

--- a/app/api/amo_webhooks.py
+++ b/app/api/amo_webhooks.py
@@ -10,7 +10,7 @@ from app.core.config import settings
 from app.http_client import get_http_client
 from app.services.dedup import calc_key, check_and_store
 from app.services.hh_mapping import get as hh_map_get, load as hh_map_load
-from app.services.queue import publish_task
+from app.services.queue import rabbitmq, RabbitMQClient
 from app.store import find_link
 
 from .utils import (
@@ -50,7 +50,11 @@ async def parse_status_events(request: Request) -> list[tuple[int, int]]:
 
 
 async def handle_hh_event(
-    lead_id: int, status_id: int, link: dict, http_client: httpx.AsyncClient
+    lead_id: int,
+    status_id: int,
+    link: dict,
+    http_client: httpx.AsyncClient,
+    queue_client: RabbitMQClient = rabbitmq,
 ):
     ext_id = link.get("external_id")
     owner_id = link.get("owner_id")
@@ -89,7 +93,7 @@ async def handle_hh_event(
         except Exception:
             logger.exception("Failed to map refusal reason")
 
-    await publish_task(
+    await queue_client.publish_task(
         {
             "platform": "hh",
             "action": "set_state",
@@ -100,10 +104,12 @@ async def handle_hh_event(
     )
 
 
-async def handle_avito_event(lead_id: int, status_id: int, link: dict):
+async def handle_avito_event(
+    lead_id: int, status_id: int, link: dict, queue_client: RabbitMQClient = rabbitmq
+):
     ext_id = link.get("external_id")
     owner_id = link.get("owner_id")
-    await publish_task(
+    await queue_client.publish_task(
         {
             "platform": "avito",
             "action": "mark_read",
@@ -115,7 +121,9 @@ async def handle_avito_event(lead_id: int, status_id: int, link: dict):
 
 @router.post("/webhooks/amo")
 async def amo_webhook(
-    request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)
+    request: Request,
+    http_client: httpx.AsyncClient = Depends(get_http_client),
+    queue_client: RabbitMQClient = Depends(lambda: rabbitmq),
 ):
     raw = await request.body()
     key = calc_key("amo", raw)
@@ -133,9 +141,9 @@ async def amo_webhook(
 
         platform = link.get("platform")
         if platform == "hh":
-            await handle_hh_event(lead_id, status_id, link, http_client)
+            await handle_hh_event(lead_id, status_id, link, http_client, queue_client)
         elif platform == "avito":
-            await handle_avito_event(lead_id, status_id, link)
+            await handle_avito_event(lead_id, status_id, link, queue_client)
 
     return {"ok": True, "events": len(events)}
 

--- a/app/api/api_amochats.py
+++ b/app/api/api_amochats.py
@@ -8,7 +8,7 @@ from app.services.dedup import calc_key, check_and_store
 from app.core.guards import require_admin
 from app.store_chat import get_by_lead, get_by_conversation, set_conversation, get_by_user
 from app.core.config import settings
-from app.services.queue import publish_task
+from app.services.queue import rabbitmq, RabbitMQClient
 
 logger = logging.getLogger(__name__)
 router_amo_chats = APIRouter()
@@ -38,7 +38,11 @@ async def verify_signature(request: Request, call_next):
 
 
 @router_amo_chats.post("/webhooks/amo-chats/in/{scope_id}")
-async def amochats_in(request: Request, scope_id: str | None = None):
+async def amochats_in(
+    request: Request,
+    scope_id: str | None = None,
+    queue_client: RabbitMQClient = Depends(lambda: rabbitmq),
+):
     raw = await request.body()
 
     key = calc_key("amo_chats", raw)
@@ -125,7 +129,7 @@ async def amochats_in(request: Request, scope_id: str | None = None):
         user_id = ln.user_id
         # надёжный ключ против дублей
         key_src = f"amo:{conv_ref_id}:{msg_id or hashlib.sha256((text or '').encode()).hexdigest()[:16]}"
-        await publish_task({
+        await queue_client.publish_task({
             "platform": "mirror",
             "action": "amo_to_tg",
             "bot_kind": bot_kind,

--- a/app/api/oauth.py
+++ b/app/api/oauth.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends
 from fastapi.responses import RedirectResponse
 
 from app.core.config import settings
-from app.services.queue import publish_task
+from app.services.queue import rabbitmq, RabbitMQClient
 from app.db.token_store import DbTokenStore, TokenData
 from app.http_client import get_http_client
 
@@ -254,6 +254,7 @@ async def amo_callback(
     code: str | None = None,
     state: str | None = None,
     http_client: httpx.AsyncClient = Depends(get_http_client),
+    queue_client: RabbitMQClient = Depends(lambda: rabbitmq),
 ):
     if not code:
         return {"ok": False, "provider": "amo", "step": "callback", "error": "no code"}
@@ -307,7 +308,7 @@ async def amo_callback(
         )
 
         try:
-            await publish_task({"platform": "system", "action": "hh_autofill"})
+            await queue_client.publish_task({"platform": "system", "action": "hh_autofill"})
             logger.info("Queued hh_autofill after amo oauth")
         except Exception:
             logger.exception("Failed to queue hh_autofill after amo oauth")

--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -6,7 +6,7 @@ import json
 from app.adapters import hh as hh_adapt
 from app.adapters.amo_client import ReauthRequired
 from app.core.config import settings
-from app.services.queue import publish_task
+from app.services.queue import rabbitmq, RabbitMQClient
 from app.store import save_link
 from app.api.utils import route_kind
 from app.services import amo_lead_enrichment
@@ -42,7 +42,11 @@ async def enrich_applicant(
     return payload
 
 
-async def create_lead(payload: IncomingPayload, client) -> tuple[int | None, str]:
+async def create_lead(
+    payload: IncomingPayload,
+    client,
+    queue_client: RabbitMQClient = rabbitmq,
+) -> tuple[int | None, str]:
     """Create lead in AmoCRM and return (lead_id, kind)."""
     title = payload.vacancy_title or ""
     desc = payload.vacancy_desc or ""
@@ -79,7 +83,7 @@ async def create_lead(payload: IncomingPayload, client) -> tuple[int | None, str
     try:
         created = await client.create_leads(body)
     except ReauthRequired:
-        await publish_task(
+        await queue_client.publish_task(
             {
                 "platform": payload.platform or "unknown",
                 "action": "amo_create_lead",
@@ -111,7 +115,9 @@ async def create_lead(payload: IncomingPayload, client) -> tuple[int | None, str
     return lead_id, kind
 
 
-async def send_invite(payload: IncomingPayload, lead_id: int) -> str:
+async def send_invite(
+    payload: IncomingPayload, lead_id: int, queue_client: RabbitMQClient = rabbitmq
+) -> str:
     """Send invite link to applicant via platform-specific channels."""
     kind = payload.kind or route_kind(
         desc=payload.vacancy_desc or "",
@@ -131,7 +137,7 @@ async def send_invite(payload: IncomingPayload, lead_id: int) -> str:
     platform = payload.platform
     applicant_id = payload.applicant.id
     if platform == "avito" and applicant_id:
-        await publish_task(
+        await queue_client.publish_task(
             {
                 "platform": "avito",
                 "action": "send_message",
@@ -141,7 +147,7 @@ async def send_invite(payload: IncomingPayload, lead_id: int) -> str:
             }
         )
     if platform == "hh" and applicant_id:
-        await publish_task(
+        await queue_client.publish_task(
             {
                 "platform": "hh",
                 "action": "send_message",

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -1,163 +1,198 @@
-import json, os
+"""RabbitMQ client wrapper providing convenient helpers for publishing and consuming.
+
+This module exposes :class:`RabbitMQClient` and a default instance ``rabbitmq`` which
+is used across the project. The class keeps state of the connection/channel and
+provides methods to publish tasks, republish to retry/DLQ queues and to consume
+tasks.
+"""
+
+from __future__ import annotations
+
 import asyncio
-import aio_pika
+import json
 import logging
+import os
+from typing import Awaitable, Callable
+
+import aio_pika
 from aio_pika import exceptions as aio_exc
+
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
-_conn = _chan = _exch = None
 
 
 def _int(name: str, default: int) -> int:
     try:
         return int(os.getenv(name, str(default)))
-    except Exception:
+    except Exception:  # pragma: no cover - defensive
         return default
 
 
 RMQ_PREFETCH = _int("RMQ_PREFETCH", 32)
 
 
-async def _ensure() -> None:
-    global _conn, _chan, _exch
-    if _conn and not _conn.is_closed and _chan and not _chan.is_closed:
-        return
+class RabbitMQClient:
+    """Maintain state of RMQ connection and provide helper methods."""
 
-    _conn = await aio_pika.connect_robust(settings.RABBITMQ_URL)
-    _chan = await _conn.channel(publisher_confirms=True)
-    await _chan.set_qos(prefetch_count=RMQ_PREFETCH)
+    def __init__(self) -> None:
+        self._conn: aio_pika.RobustConnection | None = None
+        self._chan: aio_pika.Channel | None = None
+        self._exch: aio_pika.Exchange | None = None
 
-    _exch = await _chan.declare_exchange(
-        settings.RMQ_EXCHANGE, aio_pika.ExchangeType.DIRECT, durable=True
-    )
+    async def _ensure(self) -> None:
+        if self._conn and not self._conn.is_closed and self._chan and not self._chan.is_closed:
+            return
 
-    await _chan.declare_queue(settings.RMQ_TASK_QUEUE, durable=True)
-    await _chan.declare_queue(
-        settings.RMQ_RETRY_QUEUE,
-        durable=True,
-        arguments={
-            "x-message-ttl": settings.RMQ_RETRY_TTL_MS,
-            "x-dead-letter-exchange": settings.RMQ_EXCHANGE,
-            "x-dead-letter-routing-key": "tasks",
-        },
-    )
-    await _chan.declare_queue(settings.RMQ_DLQ_QUEUE, durable=True)
+        self._conn = await aio_pika.connect_robust(settings.RABBITMQ_URL)
+        self._chan = await self._conn.channel(publisher_confirms=True)
+        await self._chan.set_qos(prefetch_count=RMQ_PREFETCH)
 
-    q_main = await _chan.get_queue(settings.RMQ_TASK_QUEUE)
-    await q_main.bind(_exch, routing_key="tasks")
+        self._exch = await self._chan.declare_exchange(
+            settings.RMQ_EXCHANGE, aio_pika.ExchangeType.DIRECT, durable=True
+        )
 
-    q_dlq = await _chan.get_queue(settings.RMQ_DLQ_QUEUE)
-    await q_dlq.bind(_exch, routing_key="tasks.dlq")
+        await self._chan.declare_queue(settings.RMQ_TASK_QUEUE, durable=True)
+        await self._chan.declare_queue(
+            settings.RMQ_RETRY_QUEUE,
+            durable=True,
+            arguments={
+                "x-message-ttl": settings.RMQ_RETRY_TTL_MS,
+                "x-dead-letter-exchange": settings.RMQ_EXCHANGE,
+                "x-dead-letter-routing-key": "tasks",
+            },
+        )
+        await self._chan.declare_queue(settings.RMQ_DLQ_QUEUE, durable=True)
 
+        q_main = await self._chan.get_queue(settings.RMQ_TASK_QUEUE)
+        await q_main.bind(self._exch, routing_key="tasks")
 
-async def connect() -> None:
-    await _ensure()
+        q_dlq = await self._chan.get_queue(settings.RMQ_DLQ_QUEUE)
+        await q_dlq.bind(self._exch, routing_key="tasks.dlq")
 
+    async def connect(self) -> None:
+        await self._ensure()
 
-async def close() -> None:
-    global _conn, _chan, _exch
-    try:
-        if _chan and not _chan.is_closed:
-            await _chan.close()
-    finally:
-        if _conn and not _conn.is_closed:
-            await _conn.close()
-    _conn = _chan = _exch = None
+    async def close(self) -> None:
+        try:
+            if self._chan and not self._chan.is_closed:
+                await self._chan.close()
+        finally:
+            if self._conn and not self._conn.is_closed:
+                await self._conn.close()
+        self._conn = self._chan = self._exch = None
 
+    async def publish_task(self, payload: dict, attempts: int = 0) -> None:
+        if not self._conn or self._conn.is_closed or not self._chan or self._chan.is_closed:
+            await self._ensure()
+        body = json.dumps({"payload": payload, "attempts": attempts}, ensure_ascii=False).encode()
+        msg = aio_pika.Message(body=body, delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
+        try:
+            assert self._exch is not None
+            await self._exch.publish(msg, routing_key="tasks")
+        except aio_exc.AMQPError:
+            await self._ensure()
+            assert self._exch is not None
+            await self._exch.publish(msg, routing_key="tasks")
 
-async def publish_task(payload: dict, attempts: int = 0) -> None:
-    if not _conn or _conn.is_closed or not _chan or _chan.is_closed:
-        await _ensure()
-    body = json.dumps({"payload": payload, "attempts": attempts}, ensure_ascii=False).encode()
-    msg = aio_pika.Message(body=body, delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
-    try:
-        await _exch.publish(msg, routing_key="tasks")
-    except aio_exc.AMQPError:
-        await _ensure()
-        await _exch.publish(msg, routing_key="tasks")
+    async def publish_retry(self, payload: dict, attempts: int) -> None:
+        if not self._conn or self._conn.is_closed or not self._chan or self._chan.is_closed:
+            await self._ensure()
+        body = json.dumps({"payload": payload, "attempts": attempts}, ensure_ascii=False).encode()
+        msg = aio_pika.Message(body=body, delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
+        try:
+            assert self._chan is not None
+            await self._chan.default_exchange.publish(
+                msg, routing_key=settings.RMQ_RETRY_QUEUE
+            )
+        except aio_exc.AMQPError:
+            await self._ensure()
+            assert self._chan is not None
+            await self._chan.default_exchange.publish(
+                msg, routing_key=settings.RMQ_RETRY_QUEUE
+            )
 
+    async def publish_dlq(
+        self, payload: dict, attempts: int, error: str | None = None
+    ) -> None:
+        if not self._conn or self._conn.is_closed or not self._chan or self._chan.is_closed:
+            await self._ensure()
+        obj = {"payload": payload, "attempts": attempts, "error": error}
+        body = json.dumps(obj, ensure_ascii=False).encode()
+        msg = aio_pika.Message(body=body, delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
+        try:
+            assert self._exch is not None
+            await self._exch.publish(msg, routing_key="tasks.dlq")
+        except aio_exc.AMQPError:
+            await self._ensure()
+            assert self._exch is not None
+            await self._exch.publish(msg, routing_key="tasks.dlq")
 
-async def publish_retry(payload: dict, attempts: int) -> None:
-    if not _conn or _conn.is_closed or not _chan or _chan.is_closed:
-        await _ensure()
-    body = json.dumps({"payload": payload, "attempts": attempts}, ensure_ascii=False).encode()
-    msg = aio_pika.Message(body=body, delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
-    try:
-        await _chan.default_exchange.publish(msg, routing_key=settings.RMQ_RETRY_QUEUE)
-    except aio_exc.AMQPError:
-        await _ensure()
-        await _chan.default_exchange.publish(msg, routing_key=settings.RMQ_RETRY_QUEUE)
+    async def consume(
+        self, handler: Callable[[dict, int], Awaitable[None]], max_attempts: int = 10
+    ) -> None:
+        if not self._conn or self._conn.is_closed or not self._chan or self._chan.is_closed:
+            await self._ensure()
 
+        async def _worker() -> None:
+            while True:
+                try:
+                    if (
+                        not self._conn
+                        or self._conn.is_closed
+                        or not self._chan
+                        or self._chan.is_closed
+                    ):
+                        await self._ensure()
 
-async def publish_dlq(payload: dict, attempts: int, error: str | None = None) -> None:
-    if not _conn or _conn.is_closed or not _chan or _chan.is_closed:
-        await _ensure()
-    obj = {"payload": payload, "attempts": attempts, "error": error}
-    body = json.dumps(obj, ensure_ascii=False).encode()
-    msg = aio_pika.Message(body=body, delivery_mode=aio_pika.DeliveryMode.PERSISTENT)
-    try:
-        await _exch.publish(msg, routing_key="tasks.dlq")
-    except aio_exc.AMQPError:
-        await _ensure()
-        await _exch.publish(msg, routing_key="tasks.dlq")
-
-
-async def consume(handler, max_attempts: int = 10):
-    if not _conn or _conn.is_closed or not _chan or _chan.is_closed:
-        await _ensure()
-
-    async def _worker():
-        while True:
-            try:
-                if not _conn or _conn.is_closed or not _chan or _chan.is_closed:
-                    await _ensure()
-
-                q = await _chan.get_queue(settings.RMQ_TASK_QUEUE)
-                async with q.iterator() as it:
-                    async for message in it:
-                        obj = None
-                        attempts = 0
-                        payload = {}
-                        try:
-                            obj = json.loads(message.body.decode("utf-8"))
-                            payload = obj.get("payload") or {}
+                    q = await self._chan.get_queue(settings.RMQ_TASK_QUEUE)
+                    async with q.iterator() as it:
+                        async for message in it:
+                            obj = None
+                            attempts = 0
+                            payload = {}
                             try:
-                                attempts = int(obj.get("attempts") or 0)
-                            except Exception:
-                                attempts = 0
+                                obj = json.loads(message.body.decode("utf-8"))
+                                payload = obj.get("payload") or {}
+                                try:
+                                    attempts = int(obj.get("attempts") or 0)
+                                except Exception:
+                                    attempts = 0
 
-                            # запустим обработчик
-                            await handler(payload, attempts)
+                                await handler(payload, attempts)
+                                await message.ack()
+                            except Exception as e:  # pragma: no cover - mostly network
+                                await message.ack()
+                                try:
+                                    cur_attempts = attempts + 1
+                                    if cur_attempts >= max_attempts:
+                                        await self.publish_dlq(payload, cur_attempts, str(e))
+                                        logger.exception(
+                                            "sent to DLQ after attempts=%s", cur_attempts
+                                        )
+                                    else:
+                                        await self.publish_retry(payload, cur_attempts)
+                                        logger.exception(
+                                            "requeued to retry, attempt=%s", cur_attempts
+                                        )
+                                except Exception:  # pragma: no cover - log only
+                                    logger.exception("failed to republish to retry/DLQ")
+                except asyncio.CancelledError:
+                    break
+                except aio_exc.AMQPError:  # pragma: no cover - network errors
+                    logger.exception("RMQ connection lost, retrying ...")
+                    await asyncio.sleep(1)
+                    await self._ensure()
 
-                            # успех
-                            await message.ack()
+        workers = settings.RMQ_CONSUMERS
+        async with asyncio.TaskGroup() as tg:
+            for _ in range(workers):
+                tg.create_task(_worker())
 
-                        except Exception as e:
-                            # не оставляем в очереди — ACK и перекидываем в retry/DLQ
-                            await message.ack()
-                            try:
-                                cur_attempts = attempts + 1
-                                if cur_attempts >= max_attempts:
-                                    await publish_dlq(payload, cur_attempts, str(e))
-                                    logger.exception(
-                                        "sent to DLQ after attempts=%s", cur_attempts
-                                    )
-                                else:
-                                    await publish_retry(payload, cur_attempts)
-                                    logger.exception(
-                                        "requeued to retry, attempt=%s", cur_attempts
-                                    )
-                            except Exception:
-                                logger.exception("failed to republish to retry/DLQ")
-            except asyncio.CancelledError:
-                break
-            except aio_exc.AMQPError:
-                logger.exception("RMQ connection lost, retrying ...")
-                await asyncio.sleep(1)
-                await _ensure()
 
-    workers = settings.RMQ_CONSUMERS
-    async with asyncio.TaskGroup() as tg:
-        for _ in range(workers):
-            tg.create_task(_worker())
+# Global instance used across the project
+rabbitmq = RabbitMQClient()
+
+
+__all__ = ["RabbitMQClient", "rabbitmq"]
+

--- a/app/services/survey.py
+++ b/app/services/survey.py
@@ -1,7 +1,7 @@
 from aiogram.types import Message
 
 from app.core.config import settings
-from app.services.queue import publish_task
+from app.services.queue import rabbitmq, RabbitMQClient
 
 
 def parse_start_arg(text: str) -> int | None:
@@ -37,15 +37,20 @@ def pretty_tg_identity(m: Message) -> str:
     return f"@{m.from_user.username}" if m.from_user.username else f"id:{m.from_user.id}"
 
 
-async def mark_went_to_bot_async(lead_id: int, bot_kind: str, identity: str):
+async def mark_went_to_bot_async(
+    lead_id: int,
+    bot_kind: str,
+    identity: str,
+    queue_client: RabbitMQClient = rabbitmq,
+):
     # переносим на воркер: добавляем заметку и тег через RMQ
-    await publish_task({
+    await queue_client.publish_task({
         "platform": "amo",
         "action": "amo_add_note",
         "lead_id": lead_id,
         "text": f"[{bot_kind}] Кандидат перешёл в бота (TG {identity}).",
     })
-    await publish_task({
+    await queue_client.publish_task({
         "platform": "amo",
         "action": "amo_add_tags",
         "lead_id": lead_id,

--- a/app/services/survey_service.py
+++ b/app/services/survey_service.py
@@ -1,5 +1,5 @@
 from app.core.config import settings
-from app.services.queue import publish_task
+from app.services.queue import rabbitmq, RabbitMQClient
 from app.store_survey import (
     start_or_reset_survey,
     get_survey,
@@ -10,10 +10,13 @@ from app.services.survey import mark_went_to_bot_async
 
 
 class SurveyService:
+    def __init__(self, queue_client: RabbitMQClient = rabbitmq) -> None:
+        self.queue_client = queue_client
+
     async def start(self, user_id: int, bot_kind: str, lead_id: int, identity: str) -> None:
         """Start or reset survey and mark that user went to bot."""
         await start_or_reset_survey(user_id, bot_kind, lead_id)
-        await mark_went_to_bot_async(lead_id, bot_kind, identity)
+        await mark_went_to_bot_async(lead_id, bot_kind, identity, self.queue_client)
 
     async def get(self, user_id: int, bot_kind: str):
         return await get_survey(user_id, bot_kind)
@@ -22,13 +25,13 @@ class SurveyService:
         return await store_answer_and_advance(user_id, bot_kind, text)
 
     async def finish(self, user_id: int, bot_kind: str, lead_id: int, summary: str) -> None:
-        await publish_task({
+        await self.queue_client.publish_task({
             "platform": "amo",
             "action": "amo_add_tags",
             "lead_id": lead_id,
             "tags": [settings.AMO_TAG_SURVEY_DONE],
         })
-        await publish_task({
+        await self.queue_client.publish_task({
             "platform": "amo",
             "action": "amo_add_note",
             "lead_id": lead_id,

--- a/app/services/worker_rmq.py
+++ b/app/services/worker_rmq.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 import asyncio, os, logging
 from httpx import HTTPStatusError, TimeoutException, ConnectError
 
-from app.services.queue import consume, publish_retry, publish_dlq
+from app.services.queue import rabbitmq, RabbitMQClient
 from app.adapters.amo_client import ReauthRequired
 from app.core.logging_setup import setup_logging
 
@@ -52,7 +52,7 @@ HANDLERS = {
 }
 
 
-async def handle(payload: dict, attempts: int):
+async def handle(payload: dict, attempts: int, queue_client: RabbitMQClient = rabbitmq):
     try:
         plat = payload.get("platform")
         act = payload.get("action")
@@ -63,18 +63,18 @@ async def handle(payload: dict, attempts: int):
 
     except ReauthRequired as e:
         logger.warning("ReauthRequired: %s", e)
-        await publish_dlq(payload, attempts + 1, f"ReauthRequired: {e}")
+        await queue_client.publish_dlq(payload, attempts + 1, f"ReauthRequired: {e}")
 
     except Exception as e:
         if _is_transient(e) and attempts + 1 < WORKER_MAX_ATTEMPTS:
-            await publish_retry(payload, attempts + 1)
+            await queue_client.publish_retry(payload, attempts + 1)
         else:
             logger.exception("Task failed terminally")
-            await publish_dlq(payload, attempts + 1, str(e))
+            await queue_client.publish_dlq(payload, attempts + 1, str(e))
 
 
-async def run_forever():
-    await consume(handle)
+async def run_forever(queue_client: RabbitMQClient = rabbitmq):
+    await queue_client.consume(lambda payload, attempts: handle(payload, attempts, queue_client))
 
 
 if __name__ == "__main__":

--- a/app/tg_router.py
+++ b/app/tg_router.py
@@ -5,7 +5,7 @@ from aiogram.types import Message
 
 from app.core.config import settings
 from app.store_chat import upsert_tg_link, get_by_user
-from app.services.queue import publish_task
+from app.services.queue import rabbitmq, RabbitMQClient
 from app.services.survey import (
     parse_start_arg,
     survey_prompt,
@@ -17,16 +17,16 @@ from app.services.survey_service import SurveyService
 logger = logging.getLogger("tg.router")
 
 
-def make_router(bot_kind: str) -> Dispatcher:
+def make_router(bot_kind: str, queue_client: RabbitMQClient = rabbitmq) -> Dispatcher:
     dp = Dispatcher()
-    svc = SurveyService()
+    svc = SurveyService(queue_client)
 
     async def _answer_and_mirror(m: Message, text: str, bot_kind: str, lead_id: int, conv_id: str | None):
         # 1) отвечаем в TG
         await m.answer(text)
         # 2) отправляем в AmoChats через RMQ (воркер создаст чат при необходимости)
         msg_key = f"bot_to_amo:{lead_id}:{m.message_id}"
-        await publish_task({
+        await queue_client.publish_task({
             "platform": "mirror",
             "action": "bot_to_amo",
             "text": text,
@@ -74,7 +74,7 @@ def make_router(bot_kind: str) -> Dispatcher:
 
         # TG -> Amo (заметка + AmoChats) целиком через воркер
         msg_key = f"tg:{m.chat.id}:{m.message_id}"
-        await publish_task({
+        await queue_client.publish_task({
             "platform": "mirror",
             "action": "tg_to_amo",
             "lead_id": lead_id,

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from app.db import init_db
 import time
 from app.services.hh_mapping import load
 from app.api.hh_webhooks import ensure_hh_webhook
-from app.services.queue import publish_task, consume, connect as queue_connect, close as queue_close
+from app.services.queue import rabbitmq
 from app.http_client import get_http_client, close_http_client
 from app.api.tg_webhooks import router as tg_wh_router
 from app.core.logging_setup import setup_logging
@@ -83,7 +83,7 @@ async def auto_register_telegram_webhooks() -> None:
 async def on_startup():
     await init_db()
     await ensure_tokens()
-    await queue_connect()
+    await rabbitmq.connect()
     try:
         from app.db.token_store import DbTokenStore
         from app.services.hh_mapping import load as load_hh_mapping
@@ -91,14 +91,14 @@ async def on_startup():
         amo_tok = await DbTokenStore("amo").load()
         if amo_tok and amo_tok.get("access_token") and int(amo_tok.get("expires_at", 0)) > int(time.time()) + 30:
             if not load_hh_mapping():
-                await publish_task({"platform": "system", "action": "hh_autofill"})
+                await rabbitmq.publish_task({"platform": "system", "action": "hh_autofill"})
                 log.info("Queued hh_autofill on startup")
     except Exception:
         log.info("Amo token not ready on startup — hh_autofill will be queued after OAuth")
 
         # стартуем RMQ consumer
     try:
-        app.state.rmq_task = asyncio.create_task(consume(_handle_task, max_attempts=10))
+        app.state.rmq_task = asyncio.create_task(rabbitmq.consume(_handle_task, max_attempts=10))
         log.info("RMQ consumer started")
     except Exception:
         log.exception("Failed to start RMQ consumer")
@@ -116,7 +116,7 @@ async def on_shutdown():
         t.cancel()
         with contextlib.suppress(Exception):
             await t
-    await queue_close()
+    await rabbitmq.close()
     await close_http_client()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,8 +121,9 @@ def queue_mock(monkeypatch):
     for mod_name in modules:
         try:
             mod = importlib.import_module(mod_name)
-            if hasattr(mod, "publish_task"):
-                monkeypatch.setattr(mod, "publish_task", fake_publish, raising=False)
+            client = getattr(mod, "rabbitmq", None)
+            if client and hasattr(client, "publish_task"):
+                monkeypatch.setattr(client, "publish_task", fake_publish, raising=False)
         except Exception:
             pass
 

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -2,7 +2,8 @@ import json
 import types
 import pytest
 
-from app.services import queue
+from app.core.config import settings
+from app.services.queue import RabbitMQClient
 
 
 @pytest.mark.asyncio
@@ -19,15 +20,15 @@ async def test_publish_task(monkeypatch):
         def __init__(self):
             self.default_exchange = DummyExchange()
 
-    dummy_chan = DummyChan()
+    client = RabbitMQClient()
 
     async def fake_ensure():
-        queue._exch = dummy_exch
-        queue._chan = dummy_chan
+        client._exch = dummy_exch
+        client._chan = DummyChan()
 
-    monkeypatch.setattr(queue, "_ensure", fake_ensure)
+    monkeypatch.setattr(client, "_ensure", fake_ensure)
 
-    await queue.publish_task({"foo": "bar"}, attempts=2)
+    await client.publish_task({"foo": "bar"}, attempts=2)
     assert published == [({"payload": {"foo": "bar"}, "attempts": 2}, "tasks")]
 
 
@@ -40,14 +41,15 @@ async def test_publish_retry(monkeypatch):
             published.append((json.loads(msg.body.decode()), routing_key))
 
     dummy_chan = types.SimpleNamespace(default_exchange=DummyExchange())
+    client = RabbitMQClient()
 
     async def fake_ensure():
-        queue._chan = dummy_chan
+        client._chan = dummy_chan
 
-    monkeypatch.setattr(queue, "_ensure", fake_ensure)
+    monkeypatch.setattr(client, "_ensure", fake_ensure)
 
-    await queue.publish_retry({"a": 1}, attempts=3)
-    assert published == [({"payload": {"a": 1}, "attempts": 3}, queue.settings.RMQ_RETRY_QUEUE)]
+    await client.publish_retry({"a": 1}, attempts=3)
+    assert published == [({"payload": {"a": 1}, "attempts": 3}, settings.RMQ_RETRY_QUEUE)]
 
 
 @pytest.mark.asyncio
@@ -59,11 +61,13 @@ async def test_publish_dlq(monkeypatch):
             published.append((json.loads(msg.body.decode()), routing_key))
 
     dummy_exch = DummyExchange()
+    client = RabbitMQClient()
 
     async def fake_ensure():
-        queue._exch = dummy_exch
+        client._exch = dummy_exch
 
-    monkeypatch.setattr(queue, "_ensure", fake_ensure)
+    monkeypatch.setattr(client, "_ensure", fake_ensure)
 
-    await queue.publish_dlq({"a": 1}, attempts=4, error="boom")
+    await client.publish_dlq({"a": 1}, attempts=4, error="boom")
     assert published == [({"payload": {"a": 1}, "attempts": 4, "error": "boom"}, "tasks.dlq")]
+

--- a/tests/test_tg_router.py
+++ b/tests/test_tg_router.py
@@ -70,7 +70,7 @@ async def feed(dp, bot, update):
 @pytest.mark.asyncio
 async def test_start(monkeypatch, queue_mock):
     svc = DummySurveyService()
-    monkeypatch.setattr(tg_router, "SurveyService", lambda: svc)
+    monkeypatch.setattr(tg_router, "SurveyService", lambda *a, **k: svc)
     async def dummy_upsert(*a, **k):
         return None
     monkeypatch.setattr(tg_router, "upsert_tg_link", dummy_upsert)
@@ -100,7 +100,7 @@ async def test_start(monkeypatch, queue_mock):
 @pytest.mark.asyncio
 async def test_text_step(monkeypatch, queue_mock):
     svc = DummySurveyService()
-    monkeypatch.setattr(tg_router, "SurveyService", lambda: svc)
+    monkeypatch.setattr(tg_router, "SurveyService", lambda *a, **k: svc)
     async def dummy_upsert(*a, **k):
         return None
     monkeypatch.setattr(tg_router, "upsert_tg_link", dummy_upsert)
@@ -133,7 +133,7 @@ async def test_text_step(monkeypatch, queue_mock):
 @pytest.mark.asyncio
 async def test_survey_finish(monkeypatch, queue_mock):
     svc = DummySurveyService()
-    monkeypatch.setattr(tg_router, "SurveyService", lambda: svc)
+    monkeypatch.setattr(tg_router, "SurveyService", lambda *a, **k: svc)
     async def dummy_upsert(*a, **k):
         return None
     monkeypatch.setattr(tg_router, "upsert_tg_link", dummy_upsert)
@@ -172,7 +172,7 @@ async def test_survey_finish(monkeypatch, queue_mock):
 @pytest.mark.asyncio
 async def test_text_no_lead(monkeypatch, queue_mock):
     svc = DummySurveyService()
-    monkeypatch.setattr(tg_router, "SurveyService", lambda: svc)
+    monkeypatch.setattr(tg_router, "SurveyService", lambda *a, **k: svc)
     async def dummy_upsert(*a, **k):
         return None
     async def dummy_get(*a, **k):
@@ -204,7 +204,7 @@ async def test_text_no_lead(monkeypatch, queue_mock):
 @pytest.mark.asyncio
 async def test_text_session_missing(monkeypatch, queue_mock):
     svc = DummySurveyService()
-    monkeypatch.setattr(tg_router, "SurveyService", lambda: svc)
+    monkeypatch.setattr(tg_router, "SurveyService", lambda *a, **k: svc)
     async def dummy_upsert(*a, **k):
         return None
     monkeypatch.setattr(tg_router, "upsert_tg_link", dummy_upsert)


### PR DESCRIPTION
## Summary
- add RabbitMQClient class managing connection and channels
- inject RabbitMQ client into services and update usages
- adjust tests for new client interface

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8d37a3884832195ed5ea653f7f355