### PR TITLE
Use multi-stage Python 3.11 base image and unbuffered logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
-FROM python:3.13-slim
+FROM python:3.11-slim AS builder
 WORKDIR /app
-COPY requirements.txt* /app/
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements.txt .
+RUN pip install --no-cache-dir --prefix=/install -r requirements.txt
+
+FROM python:3.11-slim
+ENV PYTHONUNBUFFERED=1
+WORKDIR /app
+COPY --from=builder /install /usr/local
 COPY . /app
 CMD ["python", "-m", "app.worker_rmq"]


### PR DESCRIPTION
## Summary
- Build image with Python 3.11 slim using multi-stage approach
- Install dependencies in a builder stage and copy runtime files only
- Enable unbuffered Python logging by default

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8d80e24f08321a52b7d8f6570b41a