### PR TITLE
Add structured logging and Prometheus metrics

### DIFF
--- a/app/core/logging_setup.py
+++ b/app/core/logging_setup.py
@@ -1,10 +1,27 @@
-import logging, sys
+"""Logging setup using a JSON formatter."""
+
+import logging
+import sys
+
+from pythonjsonlogger import jsonlogger
 
 
-def setup_logging(level: str = "INFO"):
+def setup_logging(level: str = "INFO") -> None:
+    """Configure root logger with JSON formatting.
+
+    Parameters
+    ----------
+    level: str
+        Logging level for root logger.
+    """
+
     root = logging.getLogger()
     root.setLevel(level)
-    h = logging.StreamHandler(sys.stdout)
-    fmt = logging.Formatter('%(asctime)s %(levelname)s %(name)s | %(message)s')
-    h.setFormatter(fmt)
-    root.handlers = [h]
+
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = jsonlogger.JsonFormatter(
+        "%(asctime)s %(levelname)s %(name)s %(message)s"
+    )
+    handler.setFormatter(formatter)
+    root.handlers = [handler]
+

--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -1,0 +1,46 @@
+import logging
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response as StarletteResponse
+from prometheus_client import Counter, Histogram, generate_latest, CONTENT_TYPE_LATEST
+
+# Prometheus metrics definitions
+REQUEST_COUNT = Counter(
+    "http_requests_total", "Total HTTP requests", ["method", "path", "status"]
+)
+REQUEST_LATENCY = Histogram(
+    "http_request_duration_seconds", "HTTP request latency in seconds", ["method", "path"]
+)
+
+
+class LoggingMiddleware(BaseHTTPMiddleware):
+    """ASGI middleware for structured request/response logging and metrics."""
+
+    async def dispatch(self, request: Request, call_next):
+        start_time = time.time()
+        response: StarletteResponse = await call_next(request)
+        process_time = time.time() - start_time
+
+        log = logging.getLogger("app.request")
+        log.info(
+            "request",
+            extra={
+                "method": request.method,
+                "path": request.url.path,
+                "status_code": response.status_code,
+                "duration": process_time,
+            },
+        )
+
+        REQUEST_COUNT.labels(
+            request.method, request.url.path, str(response.status_code)
+        ).inc()
+        REQUEST_LATENCY.labels(request.method, request.url.path).observe(process_time)
+        return response
+
+
+async def metrics_endpoint() -> StarletteResponse:
+    """Expose Prometheus metrics."""
+    return StarletteResponse(generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/main.py
+++ b/main.py
@@ -20,12 +20,15 @@ from app.http_client import get_http_client, close_http_client
 from app.api.tg_webhooks import router as tg_wh_router
 from app.core.logging_setup import setup_logging
 from app.db.token_store import DbTokenStore
+from app.core.middleware import LoggingMiddleware, metrics_endpoint
 
 log = logging.getLogger(__name__)
 
 setup_logging("INFO")
 
 app = FastAPI(title="Recruiting Bridge")
+app.add_middleware(LoggingMiddleware)
+app.add_route("/metrics", metrics_endpoint)
 app.include_router(router)
 app.include_router(admin)
 app.include_router(router_amo_chats)

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ python-dotenv
 psycopg2-binary
 pytest-asyncio
 aiosqlite
+python-json-logger
+prometheus_client


### PR DESCRIPTION
## Summary
- replace text logging with JSON format
- add middleware for structured request logging and Prometheus metrics
- expose `/metrics` endpoint for Prometheus scraping

## Testing
- `pip install -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8d8b1c234832193c5a7a38e59e565