### PR TITLE
Enforce admin token requirement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,7 +23,8 @@ HH_SYNC_ENABLED=false
 AVITO_SYNC_ENABLED=false
 AVITO_MARK_READ_ON_STAGE_CHANGE=true
 
-ADMIN_TOKEN=
+# Required: token for accessing admin endpoints
+ADMIN_TOKEN=changeme
 AMO_CHATS_BASE=https://amojo.amocrm.ru
 AMO_CHATS_SCOPE_ID=
 AMO_CHATS_SECRET=

--- a/README.md
+++ b/README.md
@@ -3,3 +3,9 @@
 [![CI](https://github.com/OWNER/hr-bridge/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/hr-bridge/actions/workflows/ci.yml)
 
 Project description.
+
+## Configuration
+
+The application requires the `ADMIN_TOKEN` environment variable to be set.
+This token protects administrative endpoints and must be provided in the
+environment or in a `.env` file before running the service.

--- a/app/core/guards.py
+++ b/app/core/guards.py
@@ -3,10 +3,9 @@ from .config import settings
 
 
 async def require_admin(authorization: str | None = Header(None), x_admin_token: str | None = Header(None)):
-    token = settings.ADMIN_TOKEN or ""
+    token = settings.ADMIN_TOKEN
     if not token:
-        # если не задан — пропустим (на dev), но в проде ОБЯЗАТЕЛЬНО задай
-        return
+        raise RuntimeError("ADMIN_TOKEN must be set")
     # допускаем либо Authorization: Bearer <token>, либо X-Admin-Token: <token>
     if authorization and authorization.startswith("Bearer "):
         if authorization.removeprefix("Bearer ").strip() == token:

--- a/tests/test_tg_webhooks.py
+++ b/tests/test_tg_webhooks.py
@@ -99,11 +99,11 @@ def test_set_webhooks(monkeypatch):
     monkeypatch.setattr(tg_webhooks, "tokens", {"m": "token"})
     monkeypatch.setattr(tg_webhooks.settings, "TELEGRAM_WEBHOOK_BASE", "https://example")
     monkeypatch.setattr(tg_webhooks.settings, "TELEGRAM_WEBHOOK_SECRET", "s3cr")
-    monkeypatch.setattr(tg_webhooks.settings, "ADMIN_TOKEN", "")
+    monkeypatch.setattr(tg_webhooks.settings, "ADMIN_TOKEN", "secret")
 
     app = _build_admin_app()
     client = TestClient(app)
-    r = client.post("/admin/tg/set-webhooks")
+    r = client.post("/admin/tg/set-webhooks", headers={"X-Admin-Token": "secret"})
     assert r.status_code == 200
     assert r.json() == {"ok": True, "set": {"m": "ok"}}
 
@@ -132,11 +132,11 @@ def test_set_webhooks_no_base(monkeypatch):
     monkeypatch.setattr(tg_webhooks, "Bot", DummyBot)
     monkeypatch.setattr(tg_webhooks, "tokens", {"m": "token"})
     monkeypatch.setattr(tg_webhooks.settings, "TELEGRAM_WEBHOOK_BASE", "")
-    monkeypatch.setattr(tg_webhooks.settings, "ADMIN_TOKEN", "")
+    monkeypatch.setattr(tg_webhooks.settings, "ADMIN_TOKEN", "secret")
 
     app = _build_admin_app()
     client = TestClient(app)
-    r = client.post("/admin/tg/set-webhooks")
+    r = client.post("/admin/tg/set-webhooks", headers={"X-Admin-Token": "secret"})
     assert r.status_code == 200
     assert r.json() == {"ok": False, "error": "TELEGRAM_WEBHOOK_BASE is empty"}
     assert DummyBot.instances == []
@@ -162,11 +162,11 @@ def test_delete_webhooks(monkeypatch):
 
     monkeypatch.setattr(tg_webhooks, "Bot", DummyBot)
     monkeypatch.setattr(tg_webhooks, "tokens", {"m": "token"})
-    monkeypatch.setattr(tg_webhooks.settings, "ADMIN_TOKEN", "")
+    monkeypatch.setattr(tg_webhooks.settings, "ADMIN_TOKEN", "secret")
 
     app = _build_admin_app()
     client = TestClient(app)
-    r = client.post("/admin/tg/delete-webhooks")
+    r = client.post("/admin/tg/delete-webhooks", headers={"X-Admin-Token": "secret"})
     assert r.status_code == 200
     assert r.json() == {"ok": True, "results": {"m": True}}
 
@@ -196,11 +196,11 @@ def test_webhook_info(monkeypatch):
 
     monkeypatch.setattr(tg_webhooks, "Bot", DummyBot)
     monkeypatch.setattr(tg_webhooks, "tokens", {"m": "token"})
-    monkeypatch.setattr(tg_webhooks.settings, "ADMIN_TOKEN", "")
+    monkeypatch.setattr(tg_webhooks.settings, "ADMIN_TOKEN", "secret")
 
     app = _build_admin_app()
     client = TestClient(app)
-    r = client.get("/admin/tg/webhook-info")
+    r = client.get("/admin/tg/webhook-info", headers={"X-Admin-Token": "secret"})
     assert r.status_code == 200
     assert r.json() == {"ok": True, "info": {"m": {"url": "info"}}}
 


### PR DESCRIPTION
## Summary
- raise configuration error when ADMIN_TOKEN is missing
- document mandatory ADMIN_TOKEN in README and .env.example
- update admin webhooks tests to provide ADMIN_TOKEN

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8d9aa86f08321a4528108c0b64bb9