### PR TITLE
Improve bootstrap documentation and error handling

### DIFF
--- a/app/bootstrap.py
+++ b/app/bootstrap.py
@@ -1,11 +1,29 @@
+"""Utilities for seeding persistent storage during application start-up.
+
+This module provides helpers used when the application boots to ensure that
+authentication tokens required by integrations are available. If tokens are
+missing from the database but provided via environment variables, they are
+persisted so that subsequent components can access them.
+"""
+
+import logging
+
 from app.db.token_store import DbTokenStore, TokenData
 from app.core.config import get_settings
 
 
+log = logging.getLogger(__name__)
+
 settings = get_settings()
 
 
-async def ensure_tokens():
+async def ensure_tokens() -> None:
+    """Populate the token store from environment variables when necessary.
+
+    For each supported service, this function checks whether a token is
+    already persisted. If not, it attempts to load credentials from the
+    corresponding environment variables and saves them to the database.
+    """
     # пара (service, ENV-префикс)
     pairs = [("amo", "AMO"), ("hh", "HH"), ("avito", "AVITO")]
     for service, prefix in pairs:
@@ -14,8 +32,12 @@ async def ensure_tokens():
         try:
             await store.load()
             continue
-        except Exception:
+        except RuntimeError:
+            # токен отсутствует, попробуем загрузить из ENV
             pass
+        except Exception:  # pragma: no cover - log only
+            log.exception("Failed to load token for service %s", service)
+            raise
 
         at = getattr(settings, f"{prefix}_ACCESS_TOKEN", None)
         rt = getattr(settings, f"{prefix}_REFRESH_TOKEN", None)
@@ -26,3 +48,4 @@ async def ensure_tokens():
                 refresh_token=rt,
                 expires_at=int(ea),
             ))
+


### PR DESCRIPTION
## Summary
- Document bootstrap module and `ensure_tokens` helper
- Log unexpected token loading errors and re-raise instead of swallowing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a955eaee4c8321b9e629c09b0ed88e