### PR TITLE
Refactor HTTP client to factory pattern

### DIFF
--- a/app/http_client.py
+++ b/app/http_client.py
@@ -1,27 +1,39 @@
+"""Utilities for a shared HTTP client.
+
+This module exposes :func:`get_http_client` to obtain a lazily created
+:class:`httpx.AsyncClient` that is reused across the application. Call
+:func:`close_http_client` on application shutdown to properly release
+resources held by the client.
+"""
+
 import httpx
 
 
-# Shared HTTP client instance. Created lazily on first use.
-_http_client: httpx.AsyncClient | None = None
+class _HttpClientFactory:
+    """Factory managing a shared :class:`httpx.AsyncClient` instance."""
+
+    _client: httpx.AsyncClient | None = None
+
+    @classmethod
+    def get_client(cls) -> httpx.AsyncClient:
+        """Return the shared AsyncClient instance."""
+        if cls._client is None:
+            cls._client = httpx.AsyncClient()
+        return cls._client
+
+    @classmethod
+    async def close_client(cls) -> None:
+        """Close and discard the shared client instance."""
+        if cls._client is not None:
+            await cls._client.aclose()
+            cls._client = None
 
 
 def get_http_client() -> httpx.AsyncClient:
-    """Return a singleton :class:`httpx.AsyncClient` instance.
-
-    The client is instantiated on first access and reused afterwards.
-    """
-
-    global _http_client
-
-    if _http_client is None:
-        _http_client = httpx.AsyncClient()
-
-    return _http_client
+    """Return the shared :class:`httpx.AsyncClient` instance."""
+    return _HttpClientFactory.get_client()
 
 
 async def close_http_client() -> None:
-    """Close the shared AsyncClient instance."""
-    global _http_client
-    if _http_client is not None:
-        await _http_client.aclose()
-        _http_client = None
+    """Close the shared :class:`httpx.AsyncClient` instance."""
+    await _HttpClientFactory.close_client()


### PR DESCRIPTION
## Summary
- remove module-level global state in `http_client` by introducing a simple factory singleton
- document shared HTTP client usage with module docstring

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9588920188321bcd80fe4c7563eaf