### PR TITLE
refactor: add common request helper

### DIFF
--- a/app/services/common_request.py
+++ b/app/services/common_request.py
@@ -1,0 +1,19 @@
+import typing
+from app.http_client import get_http_client
+
+T = typing.TypeVar("T")
+
+async def perform_request(
+    func: typing.Callable[..., typing.Awaitable[T]],
+    *args: typing.Any,
+    client=None,
+    **kwargs: typing.Any,
+) -> T:
+    """Execute *func* with a shared HTTP client.
+
+    If *client* is not provided, :func:`get_http_client` is used.
+    Additional positional and keyword arguments are forwarded to *func*.
+    """
+    if client is None:
+        client = get_http_client()
+    return await func(*args, client=client, **kwargs)

--- a/app/services/worker/avito.py
+++ b/app/services/worker/avito.py
@@ -1,26 +1,25 @@
 import logging
 
 from app.adapters import avito as avito_adapt
-from app.http_client import get_http_client
+from app.services.common_request import perform_request
 
 logger = logging.getLogger(__name__)
 
 
 async def handle_avito_send_message(payload: dict):
     logger.info("avito.send_message: %s", payload.get("external_id"))
-    client = get_http_client()
-    await avito_adapt.send_message(
+    await perform_request(
+        avito_adapt.send_message,
         payload["external_id"],
         payload["text"],
         owner_id=payload.get("owner_id"),
-        client=client,
     )
 
 
 async def handle_avito_mark_read(payload: dict):
     logger.info("avito.mark_read: %s", payload.get("external_id"))
-    await avito_adapt.mark_read(
+    await perform_request(
+        avito_adapt.mark_read,
         payload["external_id"],
         owner_id=payload.get("owner_id"),
-        client=get_http_client(),
     )

--- a/tests/test_common_request.py
+++ b/tests/test_common_request.py
@@ -1,0 +1,40 @@
+import pytest
+
+from app.services import common_request
+
+
+@pytest.mark.asyncio
+async def test_perform_request_uses_shared_client(monkeypatch):
+    called = {}
+
+    async def dummy_adapter(arg1, client, arg2=None):
+        called['client'] = client
+        called['args'] = (arg1, arg2)
+        return 'ok'
+
+    sentinel_client = object()
+    monkeypatch.setattr(common_request, 'get_http_client', lambda: sentinel_client)
+
+    result = await common_request.perform_request(dummy_adapter, 'a', arg2='b')
+    assert result == 'ok'
+    assert called['client'] is sentinel_client
+    assert called['args'] == ('a', 'b')
+
+
+@pytest.mark.asyncio
+async def test_perform_request_custom_client(monkeypatch):
+    called = {}
+
+    async def dummy_adapter(client):
+        called['client'] = client
+        return 'done'
+
+    def fake_get_http_client():
+        raise AssertionError('get_http_client should not be called')
+
+    monkeypatch.setattr(common_request, 'get_http_client', fake_get_http_client)
+    explicit_client = object()
+
+    result = await common_request.perform_request(dummy_adapter, client=explicit_client)
+    assert result == 'done'
+    assert called['client'] is explicit_client


### PR DESCRIPTION
## Summary
- add reusable `perform_request` helper for adapter calls
- refactor Avito worker handlers to use shared helper
- test helper for shared and explicit client usage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a95e843bc08321940b4177666386ba