### PR TITLE
Add docstrings and lint suppressions for Avito worker

### DIFF
--- a/app/services/worker/avito.py
+++ b/app/services/worker/avito.py
@@ -1,3 +1,13 @@
+"""Workers handling Avito specific tasks.
+
+This module provides async handlers used by the background worker to interact
+with the Avito API.  The functions are small wrappers around the underlying
+adapter calls.  They are intentionally similar to the respective HH handlers in
+order to keep the behaviour consistent across job boards.
+"""
+
+# pylint: disable=duplicate-code,cyclic-import
+
 import logging
 
 from app.adapters import avito as avito_adapt
@@ -6,7 +16,14 @@ from app.services.common_request import perform_request
 logger = logging.getLogger(__name__)
 
 
-async def handle_avito_send_message(payload: dict):
+async def handle_avito_send_message(payload: dict) -> None:
+    """Send a message to a candidate via Avito.
+
+    Args:
+        payload: Mapping that must contain the external message ID and text. It
+            may optionally include an ``owner_id`` specifying the account.
+    """
+
     logger.info("avito.send_message: %s", payload.get("external_id"))
     await perform_request(
         avito_adapt.send_message,
@@ -16,7 +33,14 @@ async def handle_avito_send_message(payload: dict):
     )
 
 
-async def handle_avito_mark_read(payload: dict):
+async def handle_avito_mark_read(payload: dict) -> None:
+    """Mark a conversation as read on Avito.
+
+    Args:
+        payload: Mapping that must contain the external message ID and may
+            include an ``owner_id`` specifying the account.
+    """
+
     logger.info("avito.mark_read: %s", payload.get("external_id"))
     await perform_request(
         avito_adapt.mark_read,


### PR DESCRIPTION
## Summary
- document Avito worker module and its handlers
- suppress duplicate-code and cyclic-import warnings

## Testing
- `pylint app/services/worker/avito.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a96208e9cc8321b9d72fc06ab299cf