### PR TITLE
refactor: centralize request retries

### DIFF
--- a/app/adapters/_requests.py
+++ b/app/adapters/_requests.py
@@ -1,0 +1,43 @@
+import httpx
+from typing import Any, Callable, Optional, Type
+
+from app.core.retry import with_retry
+
+
+def _is_retryable(status: int) -> bool:
+    return status == 429 or 500 <= status < 600
+
+
+async def request_with_retry(
+    client: httpx.AsyncClient,
+    method: str,
+    url: str,
+    *,
+    headers: Optional[dict[str, str]] = None,
+    json: Any = None,
+    timeout: int = 30,
+    attempts: int = 5,
+    error_cls: Type[Exception],
+    service: str,
+    action: str,
+    retry_func: Callable = with_retry,
+) -> httpx.Response:
+    async def attempt() -> httpx.Response:
+        r = await client.request(
+            method,
+            url,
+            headers=headers,
+            json=json,
+            timeout=timeout,
+        )
+        r.raise_for_status()
+        return r
+
+    try:
+        return await retry_func(
+            attempt,
+            attempts=attempts,
+            is_retryable=lambda e: isinstance(e, httpx.HTTPStatusError) and _is_retryable(e.response.status_code),
+        )
+    except httpx.HTTPStatusError as e:  # pragma: no cover - network errors
+        raise error_cls(f"{service} {action} failed {e.response.status_code}: {e.response.text}") from e

--- a/app/adapters/avito.py
+++ b/app/adapters/avito.py
@@ -4,14 +4,11 @@ from typing import Optional
 from app.core.config import get_settings
 from app.api.oauth2 import ensure_fresh_access
 from app.core.retry import with_retry
+from ._requests import request_with_retry
 
 
 class AvitoError(Exception):
     ...
-
-
-def _is_retryable(status: int) -> bool:
-    return status == 429 or 500 <= status < 600
 
 
 async def _access_token(owner_id: Optional[str], client: httpx.AsyncClient) -> str:
@@ -39,26 +36,21 @@ async def send_message(
     url = s.AVITO_API_BASE.rstrip("/") + s.AVITO_SEND_MESSAGE_PATH.format(negotiation_id=negotiation_id)
     body = {"message": {"text": text}}
 
-    async def attempt() -> None:
-        r = await client.post(
-            url,
-            json=body,
-            headers={
-                "Authorization": f"Bearer {access}",
-                "Accept": "application/json",
-            },
-            timeout=30,
-        )
-        r.raise_for_status()
-
-    try:
-        await with_retry(
-            attempt,
-            attempts=5,
-            is_retryable=lambda e: isinstance(e, httpx.HTTPStatusError) and _is_retryable(e.response.status_code),
-        )
-    except httpx.HTTPStatusError as e:  # pragma: no cover - network errors
-        raise AvitoError(f"Avito send_message failed {e.response.status_code}: {e.response.text}") from e
+    await request_with_retry(
+        client,
+        "POST",
+        url,
+        json=body,
+        headers={
+            "Authorization": f"Bearer {access}",
+            "Accept": "application/json",
+        },
+        timeout=30,
+        error_cls=AvitoError,
+        service="Avito",
+        action="send_message",
+        retry_func=with_retry,
+    )
 
 
 async def mark_read(
@@ -70,22 +62,17 @@ async def mark_read(
     access = await _access_token(owner_id, client)
     url = s.AVITO_API_BASE.rstrip("/") + s.AVITO_MARK_READ_PATH.format(negotiation_id=negotiation_id)
 
-    async def attempt() -> None:
-        r = await client.post(
-            url,
-            headers={
-                "Authorization": f"Bearer {access}",
-                "Accept": "application/json",
-            },
-            timeout=20,
-        )
-        r.raise_for_status()
-
-    try:
-        await with_retry(
-            attempt,
-            attempts=5,
-            is_retryable=lambda e: isinstance(e, httpx.HTTPStatusError) and _is_retryable(e.response.status_code),
-        )
-    except httpx.HTTPStatusError as e:  # pragma: no cover - network errors
-        raise AvitoError(f"Avito mark_read failed {e.response.status_code}: {e.response.text}") from e
+    await request_with_retry(
+        client,
+        "POST",
+        url,
+        headers={
+            "Authorization": f"Bearer {access}",
+            "Accept": "application/json",
+        },
+        timeout=20,
+        error_cls=AvitoError,
+        service="Avito",
+        action="mark_read",
+        retry_func=with_retry,
+    )

--- a/app/adapters/hh.py
+++ b/app/adapters/hh.py
@@ -4,14 +4,11 @@ from typing import Optional
 from app.core.config import get_settings
 from app.api.oauth2 import ensure_fresh_access
 from app.core.retry import with_retry
+from ._requests import request_with_retry
 
 
 class HHError(Exception):
     ...
-
-
-def _is_retryable(status: int) -> bool:
-    return status == 429 or 500 <= status < 600
 
 
 async def set_employer_state(
@@ -36,26 +33,21 @@ async def set_employer_state(
     url = s.HH_API_BASE.rstrip("/") + s.HH_SET_STATE_PATH.format(response_id=response_id)
     payload = {"status": target_state}
 
-    async def attempt() -> None:
-        r = await client.post(
-            url,
-            json=payload,
-            headers={
-                "Authorization": f"Bearer {access}",
-                "Accept": "application/json",
-            },
-            timeout=30,
-        )
-        r.raise_for_status()
-
-    try:
-        await with_retry(
-            attempt,
-            attempts=5,
-            is_retryable=lambda e: isinstance(e, httpx.HTTPStatusError) and _is_retryable(e.response.status_code),
-        )
-    except httpx.HTTPStatusError as e:  # pragma: no cover - network errors
-        raise HHError(f"HH set_state failed {e.response.status_code}: {e.response.text}") from e
+    await request_with_retry(
+        client,
+        "POST",
+        url,
+        json=payload,
+        headers={
+            "Authorization": f"Bearer {access}",
+            "Accept": "application/json",
+        },
+        timeout=30,
+        error_cls=HHError,
+        service="HH",
+        action="set_state",
+        retry_func=with_retry,
+    )
 
 
 async def send_message(
@@ -78,26 +70,21 @@ async def send_message(
     url = s.HH_API_BASE.rstrip("/") + f"/negotiations/{response_id}/messages"
     payload = {"message": {"text": text}}
 
-    async def attempt() -> None:
-        r = await client.post(
-            url,
-            json=payload,
-            headers={
-                "Authorization": f"Bearer {access}",
-                "Accept": "application/json",
-            },
-            timeout=30,
-        )
-        r.raise_for_status()
-
-    try:
-        await with_retry(
-            attempt,
-            attempts=5,
-            is_retryable=lambda e: isinstance(e, httpx.HTTPStatusError) and _is_retryable(e.response.status_code),
-        )
-    except httpx.HTTPStatusError as e:  # pragma: no cover - network errors
-        raise HHError(f"HH send_message failed {e.response.status_code}: {e.response.text}") from e
+    await request_with_retry(
+        client,
+        "POST",
+        url,
+        json=payload,
+        headers={
+            "Authorization": f"Bearer {access}",
+            "Accept": "application/json",
+        },
+        timeout=30,
+        error_cls=HHError,
+        service="HH",
+        action="send_message",
+        retry_func=with_retry,
+    )
 
 
 async def fetch_applicant_details(


### PR DESCRIPTION
## Summary
- add reusable request_with_retry helper
- simplify Avito and HH adapters to leverage shared retry logic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9649713188321a1b86a8db00e4c2c