### PR TITLE
Refactor job board webhooks to use shared handler

### DIFF
--- a/app/api/_webhook_common.py
+++ b/app/api/_webhook_common.py
@@ -1,0 +1,55 @@
+import logging
+from typing import Callable
+
+import httpx
+
+from app.adapters.amo_client import AmoClient
+from app.services.dedup import calc_key, check_and_store
+from app.services.lead_processor import (
+    enrich_applicant,
+    create_lead,
+    send_invite,
+    tag_lead,
+)
+from app.models import IncomingPayload
+
+logger = logging.getLogger(__name__)
+
+
+async def process_job_board_webhook(
+    platform: str,
+    raw: bytes,
+    http_client: httpx.AsyncClient,
+    parse_payload: Callable[[bytes], IncomingPayload],
+) -> dict:
+    """Process an incoming job board webhook.
+
+    Handles deduplication, payload parsing and lead processing.
+    """
+    key = calc_key(platform, raw)
+    if not await check_and_store(key):
+        return {"ok": True, "duplicate": True}
+
+    try:
+        payload = parse_payload(raw)
+    except ValueError as exc:
+        logger.warning("%s webhook: %s; payload=%s", platform, exc, raw)
+        return {"ok": True, "skipped": True}
+
+    payload = await enrich_applicant(payload, http_client)
+
+    amo = await AmoClient.create(http_client)
+    lead_id, kind = await create_lead(payload, amo)
+
+    if not lead_id:
+        if kind == "ignore":
+            return {"ok": True, "ignored": True, "reason": "no-keywords"}
+        return {"ok": True, "queued": True, "reason": "reauth_required"}
+
+    await send_invite(payload, lead_id)
+    await tag_lead(lead_id, kind, amo)
+
+    return {"ok": True, "lead_id": lead_id}
+
+
+__all__ = ["process_job_board_webhook"]

--- a/app/api/avito_incoming.py
+++ b/app/api/avito_incoming.py
@@ -1,21 +1,11 @@
 """Endpoints handling incoming Avito webhooks."""
 
-import logging
 import httpx
 from fastapi import APIRouter, Depends, Request
 
-from app.adapters.amo_client import AmoClient
+from app.api._webhook_common import process_job_board_webhook
 from app.http_client import get_http_client
-from app.services.dedup import calc_key, check_and_store
 from app.services.payload_parsers import extract_avito_payload, parse_avito_payload
-from app.services.lead_processor import (
-    enrich_applicant,
-    create_lead,
-    send_invite,
-    tag_lead,
-)
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -26,31 +16,10 @@ async def webhook_avito(
 ):
     raw = await request.body()
 
-    key = calc_key("avito", raw)
-    if not await check_and_store(key):
-        return {"ok": True, "duplicate": True}
+    def parse(raw_bytes: bytes):
+        return parse_avito_payload(extract_avito_payload(raw_bytes))
 
-    try:
-        avito_payload = extract_avito_payload(raw)
-        payload = parse_avito_payload(avito_payload)
-    except ValueError as exc:
-        logger.warning("Avito webhook: %s; payload=%s", exc, raw)
-        return {"ok": True, "skipped": True}
-
-    payload = await enrich_applicant(payload, http_client)
-
-    amo = await AmoClient.create(http_client)
-    lead_id, kind = await create_lead(payload, amo)
-
-    if not lead_id:
-        if kind == "ignore":
-            return {"ok": True, "ignored": True, "reason": "no-keywords"}
-        return {"ok": True, "queued": True, "reason": "reauth_required"}
-
-    await send_invite(payload, lead_id)
-    await tag_lead(lead_id, kind, amo)
-
-    return {"ok": True, "lead_id": lead_id}
+    return await process_job_board_webhook("avito", raw, http_client, parse)
 
 
 __all__ = ["router"]

--- a/app/api/hh_incoming.py
+++ b/app/api/hh_incoming.py
@@ -1,21 +1,11 @@
 """Endpoints handling incoming HeadHunter webhooks."""
 
-import logging
 import httpx
 from fastapi import APIRouter, Depends, Request
 
-from app.adapters.amo_client import AmoClient
+from app.api._webhook_common import process_job_board_webhook
 from app.http_client import get_http_client
-from app.services.dedup import calc_key, check_and_store
 from app.services.payload_parsers import parse_hh_payload
-from app.services.lead_processor import (
-    enrich_applicant,
-    create_lead,
-    send_invite,
-    tag_lead,
-)
-
-logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -25,31 +15,7 @@ async def webhook_hh(
     request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)
 ):
     raw = await request.body()
-
-    key = calc_key("hh", raw)
-    if not await check_and_store(key):
-        return {"ok": True, "duplicate": True}
-
-    try:
-        payload = parse_hh_payload(raw)
-    except ValueError as exc:
-        logger.warning("HH webhook: %s; payload=%s", exc, raw)
-        return {"ok": True, "skipped": True}
-
-    payload = await enrich_applicant(payload, http_client)
-
-    amo = await AmoClient.create(http_client)
-    lead_id, kind = await create_lead(payload, amo)
-
-    if not lead_id:
-        if kind == "ignore":
-            return {"ok": True, "ignored": True, "reason": "no-keywords"}
-        return {"ok": True, "queued": True, "reason": "reauth_required"}
-
-    await send_invite(payload, lead_id)
-    await tag_lead(lead_id, kind, amo)
-
-    return {"ok": True, "lead_id": lead_id}
+    return await process_job_board_webhook("hh", raw, http_client, parse_hh_payload)
 
 
 __all__ = ["router"]

--- a/tests/test_hh_incoming.py
+++ b/tests/test_hh_incoming.py
@@ -1,4 +1,4 @@
-from app.api import hh_incoming
+from app.api import hh_incoming, _webhook_common
 from app.models import IncomingPayload, Applicant
 
 
@@ -10,18 +10,22 @@ def test_webhook_success(monkeypatch, client):
     async def fake_check(key):
         return True
 
-    monkeypatch.setattr(hh_incoming, "check_and_store", fake_check)
+    monkeypatch.setattr(_webhook_common, "check_and_store", fake_check)
     monkeypatch.setattr(hh_incoming, "parse_hh_payload", lambda raw: _payload())
 
     async def fake_enrich(payload, http_client):
         return payload
 
-    monkeypatch.setattr(hh_incoming, "enrich_applicant", fake_enrich)
+    monkeypatch.setattr(_webhook_common, "enrich_applicant", fake_enrich)
 
     async def fake_create_lead(payload, amo):
         return 777, "kind"
 
-    monkeypatch.setattr(hh_incoming, "create_lead", fake_create_lead)
+    monkeypatch.setattr(_webhook_common, "create_lead", fake_create_lead)
+
+    async def fake_amo_create(cls, client):
+        return object()
+    monkeypatch.setattr(_webhook_common.AmoClient, "create", classmethod(fake_amo_create))
 
     called = {}
 
@@ -31,8 +35,8 @@ def test_webhook_success(monkeypatch, client):
     async def fake_tag_lead(lead_id, kind, amo):
         called["tag"] = kind
 
-    monkeypatch.setattr(hh_incoming, "send_invite", fake_send_invite)
-    monkeypatch.setattr(hh_incoming, "tag_lead", fake_tag_lead)
+    monkeypatch.setattr(_webhook_common, "send_invite", fake_send_invite)
+    monkeypatch.setattr(_webhook_common, "tag_lead", fake_tag_lead)
 
     r = client.post("/webhooks/hh", data=b"{}")
     assert r.status_code == 200
@@ -45,7 +49,7 @@ def test_webhook_duplicate(monkeypatch, client):
     async def fake_check(key):
         return False
 
-    monkeypatch.setattr(hh_incoming, "check_and_store", fake_check)
+    monkeypatch.setattr(_webhook_common, "check_and_store", fake_check)
 
     called = False
 
@@ -66,7 +70,7 @@ def test_webhook_bad_payload(monkeypatch, client):
     async def fake_check(key):
         return True
 
-    monkeypatch.setattr(hh_incoming, "check_and_store", fake_check)
+    monkeypatch.setattr(_webhook_common, "check_and_store", fake_check)
 
     def fake_parse(raw):
         raise ValueError("bad")
@@ -82,18 +86,22 @@ def test_webhook_ignored(monkeypatch, client):
     async def fake_check(key):
         return True
 
-    monkeypatch.setattr(hh_incoming, "check_and_store", fake_check)
+    monkeypatch.setattr(_webhook_common, "check_and_store", fake_check)
     monkeypatch.setattr(hh_incoming, "parse_hh_payload", lambda raw: _payload())
 
     async def fake_enrich(payload, http_client):
         return payload
 
-    monkeypatch.setattr(hh_incoming, "enrich_applicant", fake_enrich)
+    monkeypatch.setattr(_webhook_common, "enrich_applicant", fake_enrich)
 
     async def fake_create_lead(payload, amo):
         return None, "ignore"
 
-    monkeypatch.setattr(hh_incoming, "create_lead", fake_create_lead)
+    monkeypatch.setattr(_webhook_common, "create_lead", fake_create_lead)
+
+    async def fake_amo_create(cls, client):
+        return object()
+    monkeypatch.setattr(_webhook_common.AmoClient, "create", classmethod(fake_amo_create))
 
     async def fake_send_invite(*args, **kwargs):
         raise AssertionError("send_invite should not be called")
@@ -101,8 +109,8 @@ def test_webhook_ignored(monkeypatch, client):
     async def fake_tag_lead(*args, **kwargs):
         raise AssertionError("tag_lead should not be called")
 
-    monkeypatch.setattr(hh_incoming, "send_invite", fake_send_invite)
-    monkeypatch.setattr(hh_incoming, "tag_lead", fake_tag_lead)
+    monkeypatch.setattr(_webhook_common, "send_invite", fake_send_invite)
+    monkeypatch.setattr(_webhook_common, "tag_lead", fake_tag_lead)
 
     r = client.post("/webhooks/hh", data=b"{}")
     assert r.status_code == 200
@@ -113,18 +121,22 @@ def test_webhook_queued(monkeypatch, client):
     async def fake_check(key):
         return True
 
-    monkeypatch.setattr(hh_incoming, "check_and_store", fake_check)
+    monkeypatch.setattr(_webhook_common, "check_and_store", fake_check)
     monkeypatch.setattr(hh_incoming, "parse_hh_payload", lambda raw: _payload())
 
     async def fake_enrich(payload, http_client):
         return payload
 
-    monkeypatch.setattr(hh_incoming, "enrich_applicant", fake_enrich)
+    monkeypatch.setattr(_webhook_common, "enrich_applicant", fake_enrich)
 
     async def fake_create_lead(payload, amo):
         return None, "master"
 
-    monkeypatch.setattr(hh_incoming, "create_lead", fake_create_lead)
+    monkeypatch.setattr(_webhook_common, "create_lead", fake_create_lead)
+
+    async def fake_amo_create(cls, client):
+        return object()
+    monkeypatch.setattr(_webhook_common.AmoClient, "create", classmethod(fake_amo_create))
 
     async def fake_send_invite(*args, **kwargs):
         raise AssertionError("send_invite should not be called")
@@ -132,8 +144,8 @@ def test_webhook_queued(monkeypatch, client):
     async def fake_tag_lead(*args, **kwargs):
         raise AssertionError("tag_lead should not be called")
 
-    monkeypatch.setattr(hh_incoming, "send_invite", fake_send_invite)
-    monkeypatch.setattr(hh_incoming, "tag_lead", fake_tag_lead)
+    monkeypatch.setattr(_webhook_common, "send_invite", fake_send_invite)
+    monkeypatch.setattr(_webhook_common, "tag_lead", fake_tag_lead)
 
     r = client.post("/webhooks/hh", data=b"{}")
     assert r.status_code == 200


### PR DESCRIPTION
## Summary
- centralize deduplication, parsing, and lead processing in `process_job_board_webhook`
- refactor Avito and HH webhook endpoints to use the shared utility
- adjust HH webhook tests for new shared logic

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9656dbe008321a644ee15bee85499