### PR TITLE
Refactor request retry helper for pylint

### DIFF
--- a/app/adapters/_requests.py
+++ b/app/adapters/_requests.py
@@ -1,10 +1,14 @@
-import httpx
+"""HTTP request helpers with automatic retry support."""
+
 from typing import Any, Callable, Optional, Type
+
+import httpx
 
 from app.core.retry import with_retry
 
 
 def _is_retryable(status: int) -> bool:
+    """Return ``True`` if the status code represents a retryable error."""
     return status == 429 or 500 <= status < 600
 
 
@@ -22,6 +26,9 @@ async def request_with_retry(
     action: str,
     retry_func: Callable = with_retry,
 ) -> httpx.Response:
+    """Perform an HTTP request and retry on transient failures."""
+    # pylint: disable=too-many-arguments
+
     async def attempt() -> httpx.Response:
         r = await client.request(
             method,
@@ -37,7 +44,12 @@ async def request_with_retry(
         return await retry_func(
             attempt,
             attempts=attempts,
-            is_retryable=lambda e: isinstance(e, httpx.HTTPStatusError) and _is_retryable(e.response.status_code),
+            is_retryable=lambda e: (
+                isinstance(e, httpx.HTTPStatusError)
+                and _is_retryable(e.response.status_code)
+            ),
         )
     except httpx.HTTPStatusError as e:  # pragma: no cover - network errors
-        raise error_cls(f"{service} {action} failed {e.response.status_code}: {e.response.text}") from e
+        raise error_cls(
+            f"{service} {action} failed {e.response.status_code}: {e.response.text}"
+        ) from e


### PR DESCRIPTION
## Summary
- add docstrings and reorder imports in request retry helper
- wrap long lines and disable argument count lint for clarity

## Testing
- `pylint app/adapters/_requests.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a96720202c8321a33cb3b48a4f5738