### PR TITLE
Refactor OAuth2 token utilities to reduce arguments

### DIFF
--- a/app/adapters/avito.py
+++ b/app/adapters/avito.py
@@ -5,7 +5,7 @@ from typing import Optional
 import httpx
 
 from app.core.config import get_settings
-from app.api.oauth2 import ensure_fresh_access
+from app.api.oauth2 import ensure_fresh_access, OAuth2Config
 from app.core.retry import with_retry
 from ._requests import request_with_retry
 
@@ -18,7 +18,7 @@ async def _access_token(owner_id: Optional[str], client: httpx.AsyncClient) -> s
     """Retrieve a fresh access token for the Avito API."""
 
     s = get_settings()
-    return await ensure_fresh_access(
+    config = OAuth2Config(
         service="avito",
         token_url=s.AVITO_TOKEN_URL,
         client_id=s.AVITO_CLIENT_ID,
@@ -26,8 +26,8 @@ async def _access_token(owner_id: Optional[str], client: httpx.AsyncClient) -> s
         redirect_uri=s.AVITO_REDIRECT_URI,
         use_basic_auth=True,
         owner_id=owner_id,
-        http_client=client,
     )
+    return await ensure_fresh_access(config=config, http_client=client)
 
 
 async def send_message(

--- a/app/adapters/hh.py
+++ b/app/adapters/hh.py
@@ -2,7 +2,7 @@ import httpx
 from typing import Optional
 
 from app.core.config import get_settings
-from app.api.oauth2 import ensure_fresh_access
+from app.api.oauth2 import ensure_fresh_access, OAuth2Config
 from app.core.retry import with_retry
 from ._requests import request_with_retry
 
@@ -19,7 +19,7 @@ async def set_employer_state(
 ) -> None:
     """Меняет статус отклика (response/negotiation) у конкретного работодателя."""
     s = get_settings()
-    access = await ensure_fresh_access(
+    config = OAuth2Config(
         service="hh",
         token_url=s.HH_TOKEN_URL,
         client_id=s.HH_CLIENT_ID,
@@ -27,8 +27,8 @@ async def set_employer_state(
         redirect_uri=s.HH_REDIRECT_URI,
         use_basic_auth=False,
         owner_id=employer_id,
-        http_client=client,
     )
+    access = await ensure_fresh_access(config=config, http_client=client)
 
     url = s.HH_API_BASE.rstrip("/") + s.HH_SET_STATE_PATH.format(response_id=response_id)
     payload = {"status": target_state}
@@ -57,7 +57,7 @@ async def send_message(
     client: httpx.AsyncClient,
 ) -> None:
     s = get_settings()
-    access = await ensure_fresh_access(
+    config = OAuth2Config(
         service="hh",
         token_url=s.HH_TOKEN_URL,
         client_id=s.HH_CLIENT_ID,
@@ -65,8 +65,8 @@ async def send_message(
         redirect_uri=s.HH_REDIRECT_URI,
         use_basic_auth=False,
         owner_id=employer_id,
-        http_client=client,
     )
+    access = await ensure_fresh_access(config=config, http_client=client)
     url = s.HH_API_BASE.rstrip("/") + f"/negotiations/{response_id}/messages"
     payload = {"message": {"text": text}}
 
@@ -93,7 +93,7 @@ async def fetch_applicant_details(
     client: httpx.AsyncClient,
 ) -> dict:
     s = get_settings()
-    access = await ensure_fresh_access(
+    config = OAuth2Config(
         service="hh",
         token_url=s.HH_TOKEN_URL,
         client_id=s.HH_CLIENT_ID,
@@ -101,8 +101,8 @@ async def fetch_applicant_details(
         redirect_uri=s.HH_REDIRECT_URI,
         use_basic_auth=False,
         owner_id=employer_id,
-        http_client=client,
     )
+    access = await ensure_fresh_access(config=config, http_client=client)
 
     h = {"Authorization": f"Bearer {access}", "Accept": "application/json"}
     base = s.HH_API_BASE.rstrip("/")

--- a/app/api/oauth2.py
+++ b/app/api/oauth2.py
@@ -1,49 +1,66 @@
+"""Utilities for refreshing OAuth2 tokens and ensuring valid access tokens."""
+
 from __future__ import annotations
+
 import time
-import httpx
+from dataclasses import dataclass
 from typing import Optional
+
+import httpx
+
 from app.db.token_store import DbTokenStore, TokenData
 from app.http_client import get_http_client
 
 
 class OAuth2RefreshError(Exception):
-    pass
+    """Raised when the OAuth2 refresh flow fails."""
+
+
+@dataclass
+class OAuth2Config:
+    """Configuration required for OAuth2 token refreshes."""
+
+    service: str
+    token_url: str
+    client_id: str
+    client_secret: str
+    redirect_uri: Optional[str] = None
+    use_basic_auth: bool = False
+    owner_id: Optional[str] = None
 
 
 async def refresh_tokens(
     *,
-    service: str,
-    token_url: str,
-    client_id: str,
-    client_secret: str,
+    config: OAuth2Config,
     refresh_token: str,
-    redirect_uri: Optional[str] = None,
-    use_basic_auth: bool = False,
-    owner_id: Optional[str] = None,
     http_client: httpx.AsyncClient | None = None,
 ) -> TokenData:
-    """
-    Универсальный refresh_token.
-    HH — client_id/secret в теле; Avito — BasicAuth.
-    """
+    """Refresh OAuth2 tokens using the provided configuration."""
+
     data = {"grant_type": "refresh_token", "refresh_token": refresh_token}
-    auth = httpx.BasicAuth(client_id, client_secret) if use_basic_auth else None
-    if not use_basic_auth:
-        data["client_id"] = client_id
-        data["client_secret"] = client_secret
-    if redirect_uri:
-        data["redirect_uri"] = redirect_uri
+    auth = (
+        httpx.BasicAuth(config.client_id, config.client_secret)
+        if config.use_basic_auth
+        else None
+    )
+    if not config.use_basic_auth:
+        data["client_id"] = config.client_id
+        data["client_secret"] = config.client_secret
+    if config.redirect_uri:
+        data["redirect_uri"] = config.redirect_uri
 
     client = http_client or get_http_client()
     r = await client.post(
-        token_url,
+        config.token_url,
         data=data,
         headers={"Accept": "application/json"},
         auth=auth,
         timeout=30,
     )
     if r.status_code >= 400:
-        raise OAuth2RefreshError(f"{service} refresh failed {r.status_code}: {r.text}")
+        raise OAuth2RefreshError(
+            f"{config.service} refresh failed {r.status_code}: {r.text}"
+        )
 
     d = r.json()
     server_time = int(d.get("server_time", time.time()))
@@ -54,38 +71,25 @@ async def refresh_tokens(
         "refresh_token": d.get("refresh_token", refresh_token),
         "expires_at": server_time + expires_in - 120,
     }
-    await DbTokenStore(service, owner_id).save(res)
+    await DbTokenStore(config.service, config.owner_id).save(res)
     return res
 
 
 async def ensure_fresh_access(
     *,
-    service: str,
-    token_url: str,
-    client_id: str,
-    client_secret: str,
-    redirect_uri: Optional[str] = None,
-    use_basic_auth: bool = False,
+    config: OAuth2Config,
     margin_sec: int = 120,
-    owner_id: Optional[str] = None,
     http_client: httpx.AsyncClient | None = None,
 ) -> str:
-    """
-    Возвращает свежий access_token, обновляя при необходимости.
-    """
-    store = DbTokenStore(service, owner_id)
+    """Return a valid access token, refreshing it when necessary."""
+
+    store = DbTokenStore(config.service, config.owner_id)
     data = await store.load()
     now = time.time()
     if now > data["expires_at"] - margin_sec:
         data = await refresh_tokens(
-            service=service,
-            token_url=token_url,
-            client_id=client_id,
-            client_secret=client_secret,
+            config=config,
             refresh_token=data["refresh_token"],
-            redirect_uri=redirect_uri,
-            use_basic_auth=use_basic_auth,
-            owner_id=owner_id,
             http_client=http_client,
         )
     return data["access_token"]

--- a/tests/test_oauth_token_store.py
+++ b/tests/test_oauth_token_store.py
@@ -37,11 +37,14 @@ async def test_refresh_tokens_saves_to_db(in_memory_db):
         )
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        data = await oauth2.refresh_tokens(
+        config = oauth2.OAuth2Config(
             service="svc",
             token_url="https://example.com/token",
             client_id="id",
             client_secret="secret",
+        )
+        data = await oauth2.refresh_tokens(
+            config=config,
             refresh_token="old_refresh",
             http_client=client,
         )
@@ -81,12 +84,15 @@ async def test_ensure_fresh_access_refreshes_when_expired(in_memory_db):
         )
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        token = await oauth2.ensure_fresh_access(
+        config = oauth2.OAuth2Config(
             service="svc",
             token_url="https://example.com/token",
             client_id="id",
             client_secret="secret",
             owner_id=None,
+        )
+        token = await oauth2.ensure_fresh_access(
+            config=config,
             http_client=client,
         )
 
@@ -121,12 +127,13 @@ async def test_ensure_fresh_access_uses_cached_token(in_memory_db, monkeypatch):
 
     monkeypatch.setattr(oauth2, "refresh_tokens", fake_refresh_tokens)
 
-    token = await oauth2.ensure_fresh_access(
+    config = oauth2.OAuth2Config(
         service="svc",
         token_url="https://example.com/token",
         client_id="id",
         client_secret="secret",
     )
+    token = await oauth2.ensure_fresh_access(config=config)
 
     assert token == "cached"
     assert called is False


### PR DESCRIPTION
## Summary
- add dataclass-based configuration and docstrings for OAuth2 helpers
- update adapters to use new config object when obtaining access tokens
- adjust tests to work with refactored OAuth2 API

## Testing
- `pylint app/api/oauth2.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9690bb78c8321b210b8d47c34bd2b