### PR TITLE
docs: add docstrings for amo worker handlers

### DIFF
--- a/app/services/worker/amo.py
+++ b/app/services/worker/amo.py
@@ -1,3 +1,10 @@
+"""Helpers for processing tasks related to amoCRM.
+
+The functions defined here are small asynchronous handlers that are used by the
+worker service.  Each handler delegates to :class:`app.adapters.amo_client.AmoClient`
+to perform the actual API call.
+"""
+
 import logging
 
 from app.adapters.amo_client import AmoClient
@@ -6,19 +13,37 @@ from app.http_client import get_http_client
 logger = logging.getLogger(__name__)
 
 
-async def handle_amo_create_lead(payload: dict):
+async def handle_amo_create_lead(payload: dict) -> None:
+    """Create a lead in amoCRM.
+
+    Args:
+        payload: Mapping with a ``lead_body`` key describing the lead to create.
+    """
+
     logger.info("amo.create_lead")
     amo = await AmoClient.create(get_http_client())
     await amo.create_leads(payload["lead_body"])
 
 
-async def handle_amo_add_note(payload: dict):
+async def handle_amo_add_note(payload: dict) -> None:
+    """Attach a note to a lead in amoCRM.
+
+    Args:
+        payload: Must contain ``lead_id`` and ``text`` for the note contents.
+    """
+
     logger.info("amo.add_note: %s", payload.get("lead_id"))
     amo = await AmoClient.create(get_http_client())
     await amo.add_note(int(payload["lead_id"]), payload["text"])
 
 
-async def handle_amo_add_tags(payload: dict):
+async def handle_amo_add_tags(payload: dict) -> None:
+    """Add tags to a lead in amoCRM.
+
+    Args:
+        payload: Must contain ``lead_id`` and may include a list of ``tags``.
+    """
+
     logger.info("amo.add_tags: %s", payload.get("lead_id"))
     amo = await AmoClient.create(get_http_client())
     await amo.add_tags(int(payload["lead_id"]), list(payload.get("tags") or []))


### PR DESCRIPTION
## Summary
- document amo worker module and handlers

## Testing
- `pylint app/services/worker/amo.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9692754b88321b6116413291a514c