### PR TITLE
Add docstrings and tidy hh mapping

### DIFF
--- a/app/services/hh_mapping.py
+++ b/app/services/hh_mapping.py
@@ -1,4 +1,12 @@
-import json, os
+"""Utilities for storing and retrieving HeadHunter status mappings.
+
+The mappings are kept in a JSON file on disk and mirrored in an in-memory
+cache for faster access. Helper functions provide safe concurrent reads and
+writes to this data.
+"""
+
+import json
+import os
 from threading import Lock
 from typing import Optional
 
@@ -7,11 +15,16 @@ _cache: dict[str, str] = {}
 _lock = Lock()
 
 
-def _ensure_dir():
+def _ensure_dir() -> None:
+    """Create the directory that stores the mapping file if needed."""
     os.makedirs("data", exist_ok=True)
 
 
 def load() -> dict[str, str]:
+    """Load mappings from disk.
+
+    Returns an empty dictionary when no data file is present.
+    """
     _ensure_dir()
     if os.path.exists(PATH):
         with open(PATH, "r", encoding="utf-8") as f:
@@ -20,6 +33,7 @@ def load() -> dict[str, str]:
 
 
 def get(status_id: int) -> Optional[str]:
+    """Return the mapped value for ``status_id`` if it exists."""
     with _lock:
         if not _cache:
             _cache.update(load())
@@ -27,6 +41,7 @@ def get(status_id: int) -> Optional[str]:
 
 
 def set_all(mapping: dict[str, str]) -> dict[str, str]:
+    """Persist a new mapping to disk and refresh the in-memory cache."""
     _ensure_dir()
     with open(PATH, "w", encoding="utf-8") as f:
         json.dump(mapping, f, ensure_ascii=False, indent=2)


### PR DESCRIPTION
## Summary
- document hh mapping module and its helpers
- split combined imports and add docstrings for public functions

## Testing
- `pytest`
- `pylint app/services/hh_mapping.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9692e0fe0832183af87f930c362dd