### PR TITLE
Document survey helpers and refine exception handling

### DIFF
--- a/app/services/survey.py
+++ b/app/services/survey.py
@@ -1,3 +1,9 @@
+"""Helper functions used by the survey Telegram bot.
+
+The helpers include utilities for parsing ``/start`` arguments, generating
+prompts and summaries for a short survey and formatting Telegram identities.
+"""
+
 from aiogram.types import Message
 
 from app.core.config import get_settings
@@ -5,16 +11,24 @@ from app.services.queue import rabbitmq, RabbitMQClient
 
 
 def parse_start_arg(text: str) -> int | None:
+    """Extract integer ``/start`` argument from ``text``.
+
+    Returns the integer value if the message starts with ``/start <id>`` and the
+    argument can be parsed, otherwise ``None``.
+    """
+
     parts = (text or "").strip().split(maxsplit=1)
     if len(parts) == 2 and parts[0].startswith("/start"):
         try:
             return int(parts[1])
-        except Exception:
+        except ValueError:
             return None
     return None
 
 
 def survey_prompt(step: int) -> str:
+    """Return the prompt for the given survey ``step``."""
+
     if step == 0:
         return "В каком вы городе?"
     if step == 1:
@@ -25,6 +39,8 @@ def survey_prompt(step: int) -> str:
 
 
 def survey_summary(city: str | None, experience: str | None, time_pref: str | None) -> str:
+    """Compose a summary message using user-provided survey answers."""
+
     return (
         "Итоги опроса:\n"
         f"• Город: {city or '-'}\n"
@@ -34,6 +50,8 @@ def survey_summary(city: str | None, experience: str | None, time_pref: str | No
 
 
 def pretty_tg_identity(m: Message) -> str:
+    """Return a human friendly representation of the Telegram user."""
+
     return f"@{m.from_user.username}" if m.from_user.username else f"id:{m.from_user.id}"
 
 


### PR DESCRIPTION
## Summary
- add module and function docstrings to survey helpers
- replace broad Exception catch with ValueError in `parse_start_arg`

## Testing
- `pylint -f text app/services/survey.py`
- `pytest tests/test_common_request.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a969356d448321a49689c30600b317