### PR TITLE
Add docstrings for refusal helpers and fix trailing newline

### DIFF
--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -49,10 +49,12 @@ _REFUSAL_NAMES = {
 
 
 def is_refusal_code(code: str | None) -> bool:
+    """Return ``True`` if the given code represents a refusal."""
     return bool(code) and (code.startswith("discard") or code.startswith("reject"))
 
 
 def refusal_text(code: str | None) -> str | None:
+    """Map a refusal code to its human‑readable description."""
     return _REFUSAL_NAMES.get(code or "")
 
 
@@ -67,6 +69,7 @@ REFUSAL_TEXT_TO_HH = {
 
 
 def norm_reason(s: str | None) -> str:
+    """Normalize reason text by stripping whitespace and lowering case."""
     return (s or "").strip().lower()
 
 
@@ -78,4 +81,3 @@ __all__ = [
     "REFUSAL_TEXT_TO_HH",
     "norm_reason",
 ]
-


### PR DESCRIPTION
## Summary
- document refusal utility functions in `app/api/utils.py`
- remove extra trailing newline at file end

## Testing
- `pylint app/api/utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96bd00a2c8321ae74725026dbab3a