### PR TITLE
chore: quiet pylint for models

### DIFF
--- a/app/db/models.py
+++ b/app/db/models.py
@@ -1,4 +1,9 @@
+"""Database models for the HR Bridge application."""
+
 from __future__ import annotations
+
+# pylint: disable=too-few-public-methods
+
 from datetime import datetime
 
 from sqlalchemy import BigInteger, Text, Integer, TIMESTAMP, UniqueConstraint


### PR DESCRIPTION
## Summary
- add module docstring to db models
- silence too-few-public-methods Pylint warnings for ORM models

## Testing
- `pytest`
- `pylint app`
- `mypy app` *(fails: Item "None" of "Channel | None" has no attribute "get_queue" [union-attr] and more)*

------
https://chatgpt.com/codex/tasks/task_e_68a96bf22be48321b3cfad555e37d589