### PR TITLE
Fix lint issues in background task handler

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -10,6 +10,7 @@ from app.http_client import get_http_client
 
 
 async def handle_task(p: dict):
+    """Process background tasks based on platform and action."""
     if p.get("platform") == "system" and p.get("action") == "hh_autofill":
 
         tok = await DbTokenStore("amo").load()
@@ -34,7 +35,11 @@ async def handle_task(p: dict):
         return
 
     if p["platform"] == "avito" and p["action"] == "mark_read":
-        await avito_adapt.mark_read(p["external_id"], owner_id=p.get("owner_id"), client=get_http_client())
+        await avito_adapt.mark_read(
+            p["external_id"],
+            owner_id=p.get("owner_id"),
+            client=get_http_client(),
+        )
         return
 
     if p["platform"] == "avito" and p["action"] == "send_message":
@@ -55,4 +60,3 @@ async def handle_task(p: dict):
 
 
 __all__ = ["handle_task"]
-


### PR DESCRIPTION
## Summary
- add missing docstring and reformat task handler for readability
- wrap Avito mark_read call to satisfy line length rules

## Testing
- `pylint app/api/tasks.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96d1a14748321a66cca197d526aa7