### PR TITLE
chore: document API router setup

### DIFF
--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,11 +1,16 @@
+"""Application API routers."""
+
 from fastapi import APIRouter, Depends
+
 from app.core.guards import require_admin
+from . import admin as admin_module
+from . import amo_webhooks, avito_incoming, hh_incoming, oauth
 
 __all__ = ["build_routers"]
 
 
-def build_routers():
-    from . import oauth, admin as admin_module, hh_incoming, avito_incoming, amo_webhooks
+def build_routers() -> tuple[APIRouter, APIRouter]:
+    """Build and return public and administrative API routers."""
 
     router = APIRouter()
     admin = APIRouter(prefix="/admin", dependencies=[Depends(require_admin)])


### PR DESCRIPTION
## Summary
- add module and function docstrings for API router builder
- move imports to module top-level for clarity

## Testing
- `pytest`
- `pylint app/api/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68a96d2380d48321b214f1799b9aad88