### PR TITLE
Add documentation for admin guard

### DIFF
--- a/app/core/guards.py
+++ b/app/core/guards.py
@@ -1,12 +1,20 @@
+"""Authentication guards for endpoints requiring admin privileges."""
+
 from fastapi import Header, HTTPException, status
+
 from .config import get_settings
 
 
-async def require_admin(authorization: str | None = Header(None), x_admin_token: str | None = Header(None)):
+async def require_admin(
+    authorization: str | None = Header(None),
+    x_admin_token: str | None = Header(None),
+):
+    """Validate admin credentials via Authorization or X-Admin-Token headers."""
     token = get_settings().ADMIN_TOKEN
     if not token:
         raise RuntimeError("ADMIN_TOKEN must be set")
-    # допускаем либо Authorization: Bearer <token>, либо X-Admin-Token: <token>
+    # допускаем либо Authorization: Bearer <token>,
+    # либо X-Admin-Token: <token>
     if authorization and authorization.startswith("Bearer "):
         if authorization.removeprefix("Bearer ").strip() == token:
             return


### PR DESCRIPTION
## Summary
- add module docstring for admin guard
- document require_admin and wrap long lines

## Testing
- `pylint app/core/guards.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96d250b788321a366d4ad16021a27