### PR TITLE
Fix queue service lint issues

### DIFF
--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -190,12 +190,19 @@ class RabbitMQClient:
                                 try:
                                     attempts = int(obj.get("attempts") or 0)
                                 except (TypeError, ValueError):
-                                    logger.warning("Invalid attempts value: %s", obj.get("attempts"))
+                                    logger.warning(
+                                        "Invalid attempts value: %s",
+                                        obj.get("attempts"),
+                                    )
                                     attempts = 0
 
                                 await handler(payload, attempts)
                                 await message.ack()
-                            except (json.JSONDecodeError, aio_exc.AMQPError, RuntimeError) as e:  # pragma: no cover - mostly network
+                            except (
+                                json.JSONDecodeError,
+                                aio_exc.AMQPError,
+                                RuntimeError,
+                            ) as e:  # pragma: no cover - mostly network
                                 await message.ack()
                                 try:
                                     cur_attempts = attempts + 1


### PR DESCRIPTION
## Summary
- reformat queue service lines exceeding 100 characters
- add missing newline at end of queue service file

## Testing
- `pylint app/services/queue.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96d3e484c832189e7311a417cff31