### PR TITLE
Add module docstring for payload parsers

### DIFF
--- a/app/services/payload_parsers.py
+++ b/app/services/payload_parsers.py
@@ -1,3 +1,5 @@
+"""Utilities for parsing webhook payloads from external job platforms."""
+
 import json
 import logging
 
@@ -136,4 +138,3 @@ def parse_avito_payload(payload: AvitoPayload) -> IncomingPayload:
 
 
 __all__ = ["parse_hh_payload", "extract_avito_payload", "parse_avito_payload"]
-


### PR DESCRIPTION
## Summary
- add descriptive module docstring to `payload_parsers`
- clean up file ending to remove trailing newline

## Testing
- `pylint app/services/payload_parsers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96d44ec948321822dffb23b6ca3c5