### PR TITLE
Add docstrings for hh worker

### DIFF
--- a/app/services/worker/hh.py
+++ b/app/services/worker/hh.py
@@ -1,3 +1,10 @@
+"""Worker handlers for the HeadHunter (hh.ru) service.
+
+The module provides functions that proxy worker payloads to the ``hh`` adapter.
+Each handler expects a payload dictionary produced by message broker tasks and
+forwards it to the appropriate adapter function using a shared HTTP client.
+"""
+
 import logging
 
 from app.adapters import hh as hh_adapt
@@ -7,6 +14,12 @@ logger = logging.getLogger(__name__)
 
 
 async def handle_hh_send_message(payload: dict):
+    """Send a message via the hh adapter.
+
+    The ``payload`` must contain ``external_id`` and ``text`` keys. Optionally,
+    the ``owner_id`` key can be provided to target a specific employer.
+    """
+
     logger.info("hh.send_message: %s", payload.get("external_id"))
     client = get_http_client()
     await hh_adapt.send_message(
@@ -18,6 +31,12 @@ async def handle_hh_send_message(payload: dict):
 
 
 async def handle_hh_set_state(payload: dict):
+    """Update an employer's state in hh.ru.
+
+    The ``payload`` must contain ``external_id`` and ``target_state`` keys. The
+    optional ``owner_id`` key is used to specify the employer account context.
+    """
+
     logger.info(
         "hh.set_state: %s -> %s",
         payload.get("external_id"),


### PR DESCRIPTION
## Summary
- document hh worker handlers with clear module and function docstrings

## Testing
- `pylint app/services/worker/hh.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a96d5887448321b0dae41236a2e45b