### PR TITLE
Add module docstring for services package init

### DIFF
--- a/app/services/__init__.py
+++ b/app/services/__init__.py
@@ -1,3 +1,9 @@
+"""Initialization for the services package.
+
+This package exposes selected helper functions for use throughout the
+application, such as :func:`tg_send_with_retry`.
+"""
+
 from .telegram import tg_send_with_retry
 
 __all__ = ["tg_send_with_retry"]


### PR DESCRIPTION
## Summary
- add module docstring to services package initializer

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a96d58aa60832192d517e5dabbe753