### PR TITLE
refactor: isolate SQLAlchemy base to break cyclic import

### DIFF
--- a/app/db/__init__.py
+++ b/app/db/__init__.py
@@ -1,5 +1,5 @@
+from .base import Base
 from .db import (
-    Base,
     get_engine,
     get_session,
     get_sessionmaker,

--- a/app/db/base.py
+++ b/app/db/base.py
@@ -1,0 +1,8 @@
+"""Shared declarative base for SQLAlchemy models."""
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class Base(DeclarativeBase):  # pylint: disable=too-few-public-methods
+    """Base class for all SQLAlchemy models."""
+

--- a/app/db/db.py
+++ b/app/db/db.py
@@ -13,10 +13,10 @@ from sqlalchemy.ext.asyncio import (
     async_sessionmaker,
     create_async_engine,
 )
-from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.pool import StaticPool
 
 from app.core.config import get_settings
+from .base import Base
 
 
 @dataclass
@@ -31,10 +31,6 @@ class _DBState:
 
 
 _STATE = _DBState()
-
-
-class Base(DeclarativeBase):  # pylint: disable=too-few-public-methods
-    """Base class for all SQLAlchemy models."""
 
 
 def _is_sqlite_memory_url(url: str) -> bool:

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -9,7 +9,7 @@ from datetime import datetime
 from sqlalchemy import BigInteger, Text, Integer, TIMESTAMP, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
-from .db import Base
+from .base import Base
 
 
 class Token(Base):

--- a/app/services/worker/avito.py
+++ b/app/services/worker/avito.py
@@ -6,7 +6,7 @@ adapter calls.  They are intentionally similar to the respective HH handlers in
 order to keep the behaviour consistent across job boards.
 """
 
-# pylint: disable=duplicate-code,cyclic-import
+# pylint: disable=duplicate-code
 
 import logging
 


### PR DESCRIPTION
## Summary
- avoid cyclic dependency in DB layer by moving Declarative Base to new module
- drop unnecessary pylint cyclic-import suppression in Avito worker

## Testing
- `pylint app/services/worker/avito.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96d5bd250832189032695c35547a8