### PR TITLE
docs: add module docstring

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,3 +1,5 @@
+"""Shared Pydantic models used throughout the service."""
+
 from __future__ import annotations
 
 from pydantic import BaseModel, Field, ConfigDict


### PR DESCRIPTION
## Summary
- add missing module docstring in app/models

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a96d70ff28832185830d5c1ecc3826