### PR TITLE
Add missing docstring for Avito webhook endpoint

### DIFF
--- a/app/api/avito_incoming.py
+++ b/app/api/avito_incoming.py
@@ -14,6 +14,7 @@ router = APIRouter()
 async def webhook_avito(
     request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)
 ):
+    """Handle incoming Avito webhook requests."""
     raw = await request.body()
 
     def parse(raw_bytes: bytes):


### PR DESCRIPTION
## Summary
- add docstring for `webhook_avito` endpoint

## Testing
- `pylint app/api/avito_incoming.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a96f527f188321b342620e404cee3d