### PR TITLE
Add docstring to HeadHunter webhook handler

### DIFF
--- a/app/api/hh_incoming.py
+++ b/app/api/hh_incoming.py
@@ -14,6 +14,11 @@ router = APIRouter()
 async def webhook_hh(
     request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)
 ):
+    """Handle HeadHunter webhook events.
+
+    Fetches the raw request body and passes it to the generic job board
+    webhook processor along with the HeadHunter payload parser.
+    """
     raw = await request.body()
     return await process_job_board_webhook("hh", raw, http_client, parse_hh_payload)
 


### PR DESCRIPTION
## Summary
- add docstring to `webhook_hh` to clarify purpose

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96f58648883219952402b5fab2cac