### PR TITLE
Add module docstring for webhook common utilities

### DIFF
--- a/app/api/_webhook_common.py
+++ b/app/api/_webhook_common.py
@@ -1,3 +1,5 @@
+"""Shared logic for processing job board webhooks."""
+
 import logging
 from typing import Callable
 


### PR DESCRIPTION
## Summary
- document job board webhook handler module

## Testing
- `pytest -q`
- `pylint app/api/_webhook_common.py`


------
https://chatgpt.com/codex/tasks/task_e_68a96f6987448321bd4048fb8b92043f