### PR TITLE
Fix trailing newline in logging setup

### DIFF
--- a/app/core/logging_setup.py
+++ b/app/core/logging_setup.py
@@ -24,4 +24,3 @@ def setup_logging(level: str = "INFO") -> None:
     )
     handler.setFormatter(formatter)
     root.handlers = [handler]
-


### PR DESCRIPTION
## Summary
- remove extraneous trailing newline in logging setup to satisfy pylint

## Testing
- `pylint app/core/logging_setup.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96f7177788321b82c9bba59fe30cd