### PR TITLE
Fix retry utility lint issues

### DIFF
--- a/app/core/retry.py
+++ b/app/core/retry.py
@@ -1,11 +1,17 @@
+"""Utility for retrying coroutines with exponential backoff."""
+
 import asyncio
-from typing import Callable, Awaitable, TypeVar, Union
+from typing import Awaitable, Callable, TypeVar, Union
 
 T = TypeVar("T")
 RetryCheck = Callable[[Exception], Union[bool, float]]
 
 
-async def with_retry(coro: Callable[[], Awaitable[T]], attempts: int, is_retryable: RetryCheck) -> T:
+async def with_retry(
+    coro: Callable[[], Awaitable[T]],
+    attempts: int,
+    is_retryable: RetryCheck,
+) -> T:
     """Execute ``coro`` with exponential backoff.
 
     ``is_retryable`` should return either ``True`` to use exponential backoff
@@ -16,7 +22,7 @@ async def with_retry(coro: Callable[[], Awaitable[T]], attempts: int, is_retryab
     for attempt in range(attempts):
         try:
             return await coro()
-        except Exception as e:  # noqa: BLE001 - propagate non retryable errors
+        except Exception as e:  # noqa: BLE001  # pylint: disable=broad-exception-caught
             delay = is_retryable(e)
             if delay is False or attempt == attempts - 1:
                 raise


### PR DESCRIPTION
## Summary
- document retry utility module
- format retry helper for line length
- suppress lint for intentional broad exception

## Testing
- `pylint app/core/retry.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a96f7642dc83219451ea3ca1281f17