### PR TITLE
Fix middleware module lint warnings

### DIFF
--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -1,3 +1,5 @@
+"""Middleware for request logging and Prometheus metrics collection."""
+
 import logging
 import time
 
@@ -15,7 +17,7 @@ REQUEST_LATENCY = Histogram(
 )
 
 
-class LoggingMiddleware(BaseHTTPMiddleware):
+class LoggingMiddleware(BaseHTTPMiddleware):  # pylint: disable=too-few-public-methods
     """ASGI middleware for structured request/response logging and metrics."""
 
     async def dispatch(self, request: Request, call_next):


### PR DESCRIPTION
## Summary
- add module docstring to middleware
- disable Pylint too-few-public-methods for LoggingMiddleware

## Testing
- `pytest`
- `pylint app/core/middleware.py`


------
https://chatgpt.com/codex/tasks/task_e_68a96f775eb8832193a04dacf2a6311d