### PR TITLE
Add docstrings for Telegram service

### DIFF
--- a/app/services/telegram.py
+++ b/app/services/telegram.py
@@ -1,3 +1,5 @@
+"""Utilities for sending messages through Telegram with retry support."""
+
 from aiogram import Bot
 from aiogram.exceptions import TelegramAPIError, TelegramRetryAfter
 
@@ -5,10 +7,14 @@ from app.core.retry import with_retry
 
 
 async def tg_send_with_retry(bot: Bot, chat_id: int, text: str) -> None:
+    """Send ``text`` to ``chat_id`` via *bot*, retrying on transient failures."""
+
     async def send() -> None:
+        """Perform the actual API call to send the message."""
         await bot.send_message(chat_id=chat_id, text=text)
 
     def _is_retryable(exc: Exception):
+        """Return delay or True if *exc* should trigger a retry."""
         if isinstance(exc, TelegramRetryAfter):
             return exc.retry_after
         if isinstance(exc, TelegramAPIError):


### PR DESCRIPTION
## Summary
- add docstrings for Telegram retry helper

## Testing
- `python -m pylint app/services/telegram.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96f84b2a48321bed64bacf4d04e65