### PR TITLE
Fix pylint trailing newline in base module

### DIFF
--- a/app/db/base.py
+++ b/app/db/base.py
@@ -5,4 +5,3 @@ from sqlalchemy.orm import DeclarativeBase
 
 class Base(DeclarativeBase):  # pylint: disable=too-few-public-methods
     """Base class for all SQLAlchemy models."""
-


### PR DESCRIPTION
## Summary
- remove stray trailing newline from app/db/base.py

## Testing
- `pylint app/db/base.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a96f8102f083219e212851b972420f