### PR TITLE
Use first HH employer token for webhook registration

### DIFF
--- a/app/api/hh_webhooks.py
+++ b/app/api/hh_webhooks.py
@@ -33,7 +33,11 @@ async def ensure_hh_webhook(client: httpx.AsyncClient) -> None:
         return
 
     try:
-        tok = await DbTokenStore("hh").load()
+        owners = await DbTokenStore.list_owners("hh")
+        if not owners:
+            raise RuntimeError("no employers")
+        employer_id = owners[0]
+        tok = await DbTokenStore("hh", employer_id).load()
     except (RuntimeError, SQLAlchemyError):
         log.info("HH webhook: нет токена работодателя — пропускаю регистрацию")
         return

--- a/tests/test_hh_webhooks.py
+++ b/tests/test_hh_webhooks.py
@@ -1,0 +1,55 @@
+import pytest
+import httpx
+from sqlalchemy import insert
+
+from app.api import hh_webhooks
+from app.db.db import get_session
+from app.db import models
+from app.db.token_store import DbTokenStore
+
+
+@pytest.mark.asyncio
+async def test_ensure_hh_webhook_uses_first_owner(in_memory_db, monkeypatch):
+    # Insert tokens for two employers
+    async with get_session() as s:
+        await s.execute(
+            insert(models.Token).values(
+                id=1,
+                service="hh",
+                owner_id="1",
+                access_token="tok1",
+                refresh_token="r1",
+                expires_at=0,
+            )
+        )
+        await s.execute(
+            insert(models.Token).values(
+                id=2,
+                service="hh",
+                owner_id="2",
+                access_token="tok2",
+                refresh_token="r2",
+                expires_at=0,
+            )
+        )
+        await s.commit()
+
+    async def fake_list_owners(service: str):
+        return ["2", "1"]
+
+    monkeypatch.setattr(DbTokenStore, "list_owners", staticmethod(fake_list_owners))
+    monkeypatch.setattr(hh_webhooks, "_target_url", lambda: "http://example.com")
+
+    captured = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        if request.method == "GET":
+            return httpx.Response(200, json=[])
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await hh_webhooks.ensure_hh_webhook(client)
+
+    assert captured, "no requests were made"
+    assert captured[0].headers.get("Authorization") == "Bearer tok2"


### PR DESCRIPTION
## Summary
- ensure HH webhook registration uses first available employer token from DB
- add unit test verifying correct token selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9a0896d0483219fd8e05feab71dd9