### PR TITLE
Use first HH employer token for webhook registration

### DIFF
--- a/app/api/hh_webhooks.py
+++ b/app/api/hh_webhooks.py
@@ -33,7 +33,11 @@ async def ensure_hh_webhook(client: httpx.AsyncClient) -> None:
         return
 
     try:
-        tok = await DbTokenStore("hh").load()
+        owners = await DbTokenStore.list_owners("hh")
+        if not owners:
+            raise RuntimeError("no employers")
+        employer_id = owners[0]
+        tok = await DbTokenStore("hh", employer_id).load()
     except (RuntimeError, SQLAlchemyError):
         log.info("HH webhook: нет токена работодателя — пропускаю регистрацию")
         return
@@ -47,6 +51,11 @@ async def ensure_hh_webhook(client: httpx.AsyncClient) -> None:
 
     try:
         r = await client.get(HH_SUBS_URL, headers=headers, timeout=20)
+        if r.status_code in (401, 403, 404):
+            log.warning(
+                "HH webhook: %s — нет прав/токен/фича недоступна", r.status_code
+            )
+            return
         r.raise_for_status()
         js = r.json()
         items = js if isinstance(js, list) else js.get("items", [])

--- a/tests/test_hh_webhooks.py
+++ b/tests/test_hh_webhooks.py
@@ -1,0 +1,90 @@
+import pytest
+import httpx
+from sqlalchemy import insert
+
+from app.api import hh_webhooks
+from app.db.db import get_session
+from app.db import models
+from app.db.token_store import DbTokenStore
+
+
+@pytest.mark.asyncio
+async def test_ensure_hh_webhook_uses_first_owner(in_memory_db, monkeypatch):
+    # Insert tokens for two employers
+    async with get_session() as s:
+        await s.execute(
+            insert(models.Token).values(
+                id=1,
+                service="hh",
+                owner_id="1",
+                access_token="tok1",
+                refresh_token="r1",
+                expires_at=0,
+            )
+        )
+        await s.execute(
+            insert(models.Token).values(
+                id=2,
+                service="hh",
+                owner_id="2",
+                access_token="tok2",
+                refresh_token="r2",
+                expires_at=0,
+            )
+        )
+        await s.commit()
+
+    async def fake_list_owners(service: str):
+        return ["2", "1"]
+
+    monkeypatch.setattr(DbTokenStore, "list_owners", staticmethod(fake_list_owners))
+    monkeypatch.setattr(hh_webhooks, "_target_url", lambda: "http://example.com")
+
+    captured = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        if request.method == "GET":
+            return httpx.Response(200, json=[])
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await hh_webhooks.ensure_hh_webhook(client)
+
+    assert captured, "no requests were made"
+    assert captured[0].headers.get("Authorization") == "Bearer tok2"
+
+
+@pytest.mark.asyncio
+async def test_ensure_hh_webhook_handles_get_404(in_memory_db, monkeypatch, caplog):
+    # Insert token for a single employer
+    async with get_session() as s:
+        await s.execute(
+            insert(models.Token).values(
+                id=1,
+                service="hh",
+                owner_id="1",
+                access_token="tok",
+                refresh_token="r",
+                expires_at=0,
+            )
+        )
+        await s.commit()
+
+    monkeypatch.setattr(hh_webhooks, "_target_url", lambda: "http://example.com")
+
+    captured = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        if request.method == "GET":
+            return httpx.Response(404, json={"errors": [{"type": "not_found"}]})
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        with caplog.at_level("WARNING"):
+            await hh_webhooks.ensure_hh_webhook(client)
+
+    assert len(captured) == 1
+    assert captured[0].method == "GET"
+    assert "HH webhook: 404" in caplog.text


### PR DESCRIPTION
## Summary
- ensure HH webhook registration uses first available employer token from DB
- handle 404 when fetching existing HH webhook subscriptions
- add unit tests verifying token selection and graceful 404 handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9a0896d0483219fd8e05feab71dd9