### PR TITLE
Validate HH webhook event list

### DIFF
--- a/app/api/hh_webhooks.py
+++ b/app/api/hh_webhooks.py
@@ -10,6 +10,9 @@ from app.core.config import get_settings
 log = logging.getLogger(__name__)
 HH_SUBS_URL = "https://api.hh.ru/webhook/subscriptions"
 
+# Supported webhook events from HeadHunter API.
+ALLOWED_ACTIONS = {"negotiation_created"}
+
 
 def _target_url() -> str:
     s = get_settings()
@@ -19,9 +22,16 @@ def _target_url() -> str:
 def _events() -> list[str]:
     s = get_settings()
     raw = (getattr(s, "HH_WEBHOOK_EVENTS", "") or "").strip()
-    if raw:
-        return [e.strip() for e in raw.split(",") if e.strip()]
-    return ["negotiation_created"]
+    events = (
+        [e.strip() for e in raw.split(",") if e.strip()]
+        if raw
+        else ["negotiation_created"]
+    )
+    allowed = [e for e in events if e in ALLOWED_ACTIONS]
+    invalid = [e for e in events if e not in ALLOWED_ACTIONS]
+    if invalid:
+        log.warning("HH webhook: unsupported events ignored: %s", ",".join(invalid))
+    return allowed
 
 
 async def ensure_hh_webhook(client: httpx.AsyncClient) -> None:
@@ -48,6 +58,9 @@ async def ensure_hh_webhook(client: httpx.AsyncClient) -> None:
         "Content-Type": "application/json",
     }
     want_actions = _events()  # список строк событий
+    if not want_actions:
+        log.warning("HH webhook: no valid events specified — skipping registration")
+        return
 
     try:
         r = await client.get(HH_SUBS_URL, headers=headers, timeout=20)

--- a/tests/test_hh_webhooks.py
+++ b/tests/test_hh_webhooks.py
@@ -1,3 +1,4 @@
+import json
 import pytest
 import httpx
 from sqlalchemy import insert
@@ -53,3 +54,91 @@ async def test_ensure_hh_webhook_uses_first_owner(in_memory_db, monkeypatch):
 
     assert captured, "no requests were made"
     assert captured[0].headers.get("Authorization") == "Bearer tok2"
+
+
+def _set_events(monkeypatch, value: str):
+    class Dummy:
+        HH_WEBHOOK_EVENTS = value
+
+    monkeypatch.setattr(hh_webhooks, "get_settings", lambda: Dummy())
+
+
+def test_events_filtered(monkeypatch, caplog):
+    _set_events(monkeypatch, "negotiation_created,invalid")
+
+    with caplog.at_level("WARNING"):
+        events = hh_webhooks._events()
+
+    assert events == ["negotiation_created"]
+    assert "unsupported events" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_ensure_skips_when_no_valid_events(in_memory_db, monkeypatch):
+    async with get_session() as s:
+        await s.execute(
+            insert(models.Token).values(
+                id=1,
+                service="hh",
+                owner_id="1",
+                access_token="tok1",
+                refresh_token="r1",
+                expires_at=0,
+            )
+        )
+        await s.commit()
+
+    async def fake_list_owners(service: str):
+        return ["1"]
+
+    monkeypatch.setattr(DbTokenStore, "list_owners", staticmethod(fake_list_owners))
+    monkeypatch.setattr(hh_webhooks, "_target_url", lambda: "http://example.com")
+    _set_events(monkeypatch, "invalid")
+
+    captured = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await hh_webhooks.ensure_hh_webhook(client)
+
+    assert captured == []
+
+
+@pytest.mark.asyncio
+async def test_ensure_posts_only_valid_events(in_memory_db, monkeypatch):
+    async with get_session() as s:
+        await s.execute(
+            insert(models.Token).values(
+                id=1,
+                service="hh",
+                owner_id="1",
+                access_token="tok1",
+                refresh_token="r1",
+                expires_at=0,
+            )
+        )
+        await s.commit()
+
+    async def fake_list_owners(service: str):
+        return ["1"]
+
+    monkeypatch.setattr(DbTokenStore, "list_owners", staticmethod(fake_list_owners))
+    monkeypatch.setattr(hh_webhooks, "_target_url", lambda: "http://example.com")
+    _set_events(monkeypatch, "negotiation_created,invalid")
+
+    captured = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        if request.method == "GET":
+            return httpx.Response(200, json=[])
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await hh_webhooks.ensure_hh_webhook(client)
+
+    assert len(captured) == 2
+    assert json.loads(captured[1].content)["actions"] == ["negotiation_created"]


### PR DESCRIPTION
## Summary
- add `ALLOWED_ACTIONS` and filter unsupported HeadHunter webhook events
- skip webhook registration when no valid events remain
- add tests covering event validation and posting only supported actions

## Testing
- `pytest tests/test_hh_webhooks.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9c12efd788321a9d0e8639ddc2d5d