### PR TITLE
Handle errors in job board webhook processing

### DIFF
--- a/app/api/_webhook_common.py
+++ b/app/api/_webhook_common.py
@@ -38,20 +38,24 @@ async def process_job_board_webhook(
         logger.warning("%s webhook: %s; payload=%s", platform, exc, raw)
         return {"ok": True, "skipped": True}
 
-    payload = await enrich_applicant(payload, http_client)
+    try:
+        payload = await enrich_applicant(payload, http_client)
 
-    amo = await AmoClient.create(http_client)
-    lead_id, kind = await create_lead(payload, amo)
+        amo = await AmoClient.create(http_client)
+        lead_id, kind = await create_lead(payload, amo)
 
-    if not lead_id:
-        if kind == "ignore":
-            return {"ok": True, "ignored": True, "reason": "no-keywords"}
-        return {"ok": True, "queued": True, "reason": "reauth_required"}
+        if not lead_id:
+            if kind == "ignore":
+                return {"ok": True, "ignored": True, "reason": "no-keywords"}
+            return {"ok": True, "queued": True, "reason": "reauth_required"}
 
-    await send_invite(payload, lead_id)
-    await tag_lead(lead_id, kind, amo)
+        await send_invite(payload, lead_id)
+        await tag_lead(lead_id, kind, amo)
 
-    return {"ok": True, "lead_id": lead_id}
+        return {"ok": True, "lead_id": lead_id}
+    except Exception:
+        logger.exception("%s webhook: internal error", platform)
+        return {"ok": False, "error": "internal_error"}
 
 
 __all__ = ["process_job_board_webhook"]

--- a/tests/test_hh_incoming.py
+++ b/tests/test_hh_incoming.py
@@ -150,3 +150,86 @@ def test_webhook_queued(monkeypatch, client):
     r = client.post("/webhooks/hh", data=b"{}")
     assert r.status_code == 200
     assert r.json() == {"ok": True, "queued": True, "reason": "reauth_required"}
+
+
+def test_webhook_enrich_error(monkeypatch, client):
+    async def fake_check(key):
+        return True
+
+    monkeypatch.setattr(_webhook_common, "check_and_store", fake_check)
+    monkeypatch.setattr(hh_incoming, "parse_hh_payload", lambda raw: _payload())
+
+    async def boom(payload, http_client):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(_webhook_common, "enrich_applicant", boom)
+
+    r = client.post("/webhooks/hh", data=b"{}")
+    assert r.status_code == 200
+    assert r.json() == {"ok": False, "error": "internal_error"}
+
+
+def test_webhook_create_lead_error(monkeypatch, client):
+    async def fake_check(key):
+        return True
+
+    monkeypatch.setattr(_webhook_common, "check_and_store", fake_check)
+    monkeypatch.setattr(hh_incoming, "parse_hh_payload", lambda raw: _payload())
+
+    async def fake_enrich(payload, http_client):
+        return payload
+
+    monkeypatch.setattr(_webhook_common, "enrich_applicant", fake_enrich)
+
+    async def fake_amo_create(cls, client):
+        return object()
+
+    monkeypatch.setattr(_webhook_common.AmoClient, "create", classmethod(fake_amo_create))
+
+    async def boom(payload, amo):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(_webhook_common, "create_lead", boom)
+
+    r = client.post("/webhooks/hh", data=b"{}")
+    assert r.status_code == 200
+    assert r.json() == {"ok": False, "error": "internal_error"}
+
+
+def test_webhook_tag_error(monkeypatch, client):
+    async def fake_check(key):
+        return True
+
+    monkeypatch.setattr(_webhook_common, "check_and_store", fake_check)
+    monkeypatch.setattr(hh_incoming, "parse_hh_payload", lambda raw: _payload())
+
+    async def fake_enrich(payload, http_client):
+        return payload
+
+    monkeypatch.setattr(_webhook_common, "enrich_applicant", fake_enrich)
+
+    async def fake_amo_create(cls, client):
+        return object()
+
+    monkeypatch.setattr(_webhook_common.AmoClient, "create", classmethod(fake_amo_create))
+
+    async def fake_create_lead(payload, amo):
+        return 123, "kind"
+
+    monkeypatch.setattr(_webhook_common, "create_lead", fake_create_lead)
+
+    called = {}
+
+    async def fake_send_invite(payload, lead_id):
+        called["invite"] = lead_id
+
+    async def boom(lead_id, kind, amo):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(_webhook_common, "send_invite", fake_send_invite)
+    monkeypatch.setattr(_webhook_common, "tag_lead", boom)
+
+    r = client.post("/webhooks/hh", data=b"{}")
+    assert r.status_code == 200
+    assert r.json() == {"ok": False, "error": "internal_error"}
+    assert called["invite"] == 123


### PR DESCRIPTION
## Summary
- wrap webhook enrichment and lead processing in try/except to return structured errors
- add tests for enrichment, lead creation, and tagging failures

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9c21f9a948321b9d2f125537398b4