### PR TITLE
Handle HH negotiation notifications

### DIFF
--- a/app/services/payload_parsers.py
+++ b/app/services/payload_parsers.py
@@ -40,13 +40,24 @@ def parse_hh_payload(raw: bytes) -> IncomingPayload:
         obj.get("id")
         or data.get("response_id")
         or obj.get("negotiation_id")
+        or obj.get("topic_id")
+        or obj.get("chat_id")
+        or obj.get("resume_id")
         or ""
     )
 
     vacancy = obj.get("vacancy") or {}
     applicant = obj.get("applicant") or obj.get("resume", {}).get("owner", {}) or {}
 
-    vacancy_id = str(vacancy.get("id") or data.get("vacancy_id") or "") or None
+    vacancy_id = (
+        str(
+            vacancy.get("id")
+            or data.get("vacancy_id")
+            or obj.get("vacancy_id")
+            or ""
+        )
+        or None
+    )
     vacancy_title = vacancy.get("name") or data.get("vacancy_title") or ""
     vacancy_desc = vacancy.get("description") or data.get("vacancy_description") or ""
     applicant_name = (
@@ -57,6 +68,7 @@ def parse_hh_payload(raw: bytes) -> IncomingPayload:
         str(
             data.get("employer", {}).get("id")
             or obj.get("employer", {}).get("id")
+            or obj.get("employer_id")
             or ""
         )
         or None

--- a/tests/test_hh_webhooks.py
+++ b/tests/test_hh_webhooks.py
@@ -67,10 +67,12 @@ def test_events_filtered(monkeypatch, caplog):
     _set_events(monkeypatch, "negotiation_created,invalid")
 
     with caplog.at_level("WARNING"):
-        events = hh_webhooks._events()
+        actions = hh_webhooks._actions()
 
-    assert events == ["negotiation_created"]
-    assert "unsupported events" in caplog.text
+    assert actions == [
+        {"type": "NEW_NEGOTIATION_VACANCY", "settings": {"vacancies_only_mine": False}}
+    ]
+    assert "неподдерживаемые события" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -141,4 +143,6 @@ async def test_ensure_posts_only_valid_events(in_memory_db, monkeypatch):
         await hh_webhooks.ensure_hh_webhook(client)
 
     assert len(captured) == 2
-    assert json.loads(captured[1].content)["actions"] == ["negotiation_created"]
+    assert json.loads(captured[1].content)["actions"] == [
+        {"type": "NEW_NEGOTIATION_VACANCY", "settings": {"vacancies_only_mine": False}}
+    ]

--- a/tests/test_payload_parsers.py
+++ b/tests/test_payload_parsers.py
@@ -37,6 +37,28 @@ def test_parse_hh_payload_missing_id():
         parse_hh_payload(raw)
 
 
+def test_parse_hh_payload_new_negotiation():
+    raw = json.dumps(
+        {
+            "id": "notification1",
+            "payload": {
+                "topic_id": "topic1",
+                "resume_id": "resume1",
+                "vacancy_id": "vac1",
+                "employer_id": "emp1",
+                "chat_id": "chat1",
+            },
+        }
+    ).encode()
+
+    payload = parse_hh_payload(raw)
+    assert payload.platform == "hh"
+    assert payload.owner_id == "emp1"
+    assert payload.vacancy_id == "vac1"
+    assert payload.applicant.id == "topic1"
+    assert payload.applicant.name == "кандидат"
+
+
 def test_parse_hh_payload_bad_json():
     with pytest.raises(ValueError):
         parse_hh_payload(b"{bad json")


### PR DESCRIPTION
## Summary
- broaden HH payload parsing to accept negotiation notifications and use topic, vacancy, and employer fields to populate IDs
- adjust tests for new HH action structure and add coverage for negotiation payloads

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9f2ca5f6483218c4a0b223758f66b