### PR TITLE
Refresh HH tokens on expiry

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -12,6 +12,7 @@ from app.core.config import get_settings
 from app.services.dedup import cleanup_older_than
 from app.services.hh_mapping import load as hh_map_load, set_all as hh_map_set
 from app.services.queue import rabbitmq, RabbitMQClient
+from app.api.oauth2 import OAuth2Config, ensure_fresh_access
 from app.db.token_store import DbTokenStore
 
 router = APIRouter()
@@ -85,14 +86,25 @@ async def hh_states(
     """Return the HeadHunter negotiation states."""
 
     try:
-        tok = await DbTokenStore("hh", owner_id).load()
+        access = await ensure_fresh_access(
+            config=OAuth2Config(
+                service="hh",
+                token_url=s.HH_TOKEN_URL,
+                client_id=s.HH_CLIENT_ID,
+                client_secret=s.HH_CLIENT_SECRET,
+                redirect_uri=s.HH_REDIRECT_URI,
+                use_basic_auth=False,
+                owner_id=owner_id,
+            ),
+            http_client=http_client,
+        )
     except (RuntimeError, SQLAlchemyError) as exc:
         return {"ok": False, "error": f"no hh token: {exc}"}
 
     r = await http_client.get(
         f"{s.HH_API_BASE.rstrip('/')}/dictionaries",
         headers={
-            "Authorization": f"Bearer {tok['access_token']}",
+            "Authorization": f"Bearer {access}",
             "Accept": "application/json",
         },
         timeout=15,

--- a/app/api/hh_webhooks.py
+++ b/app/api/hh_webhooks.py
@@ -9,6 +9,7 @@ from typing import Any
 import httpx
 from sqlalchemy.exc import SQLAlchemyError
 
+from app.api.oauth2 import OAuth2Config, ensure_fresh_access
 from app.db.token_store import DbTokenStore
 from app.core.config import get_settings
 
@@ -130,14 +131,26 @@ async def ensure_hh_webhook(client: httpx.AsyncClient) -> None:
         log.warning("HH webhook: нет валидных событий — пропускаю регистрацию")
         return
 
+    s = get_settings()
     for employer_id in owners:
         try:
-            tok = await DbTokenStore("hh", employer_id).load()
-        except SQLAlchemyError:
+            access = await ensure_fresh_access(
+                config=OAuth2Config(
+                    service="hh",
+                    token_url=s.HH_TOKEN_URL,
+                    client_id=s.HH_CLIENT_ID,
+                    client_secret=s.HH_CLIENT_SECRET,
+                    redirect_uri=s.HH_REDIRECT_URI,
+                    use_basic_auth=False,
+                    owner_id=employer_id,
+                ),
+                http_client=client,
+            )
+        except (RuntimeError, SQLAlchemyError):
             continue
 
         headers = {
-            "Authorization": f"Bearer {tok['access_token']}",
+            "Authorization": f"Bearer {access}",
             "Accept": "application/json",
             "Content-Type": "application/json",
             "HH-User-Agent": "hr-bridge/1.0 (+https://hr-bridge.onrender.com; ops@hr-bridge.onrender.com)",

--- a/tests/test_hh_webhooks.py
+++ b/tests/test_hh_webhooks.py
@@ -9,6 +9,14 @@ from app.db import models
 from app.db.token_store import DbTokenStore
 
 
+@pytest.fixture(autouse=True)
+def patch_ensure_fresh_access(monkeypatch):
+    async def fake_ensure(*, config, **kwargs):
+        return f"tok{config.owner_id}"
+
+    monkeypatch.setattr(hh_webhooks, "ensure_fresh_access", fake_ensure)
+
+
 @pytest.mark.asyncio
 async def test_ensure_hh_webhook_uses_first_owner(in_memory_db, monkeypatch):
     # Insert tokens for two employers
@@ -59,6 +67,10 @@ async def test_ensure_hh_webhook_uses_first_owner(in_memory_db, monkeypatch):
 def _set_events(monkeypatch, value: str):
     class Dummy:
         HH_WEBHOOK_EVENTS = value
+        HH_TOKEN_URL = "https://example.com/token"
+        HH_CLIENT_ID = "id"
+        HH_CLIENT_SECRET = "secret"
+        HH_REDIRECT_URI = "http://example.com/cb"
 
     monkeypatch.setattr(hh_webhooks, "get_settings", lambda: Dummy())
 


### PR DESCRIPTION
## Summary
- refresh HH OAuth token during webhook registration
- refresh HH token in admin states endpoint
- adjust HH webhook tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9f8e675748321813340931894b8d3