### PR TITLE
Fetch HH resume contacts and parse phone/email

### DIFF
--- a/app/adapters/hh.py
+++ b/app/adapters/hh.py
@@ -98,7 +98,7 @@ async def fetch_applicant_details(
     employer_id: Optional[str],
     client: httpx.AsyncClient,
 ) -> dict:
-    """Fetch basic applicant information such as name, city and phone."""
+    """Fetch basic applicant information such as name, city, phone and email."""
     s = get_settings()
     access = await ensure_fresh_access(
         config=OAuth2Config(
@@ -126,26 +126,33 @@ async def fetch_applicant_details(
     if not resume_id:
         return {}
 
-    # 2) resume -> phone, city, full name
+    # 2) resume -> phone, email, city, full name
     resume_resp = await client.get(
-        f"{base_url}/resumes/{resume_id}", headers=headers, timeout=30
+        f"{base_url}/resumes/{resume_id}?with_contacts=true",
+        headers=headers,
+        timeout=30,
     )
     if resume_resp.status_code >= 400:
         return {}
 
     data = resume_resp.json()
     city = (data.get("area") or {}).get("name")
-    phones = (data.get("contact") or {}).get("phones") or (
-        (data.get("contact") or {}).get("phone") or []
-    )
+    contact = data.get("contact") or []
     phone = None
-    if isinstance(phones, list) and phones:
-        phone = phones[0].get("formatted") or phones[0].get("value")
-    elif isinstance(phones, dict):
-        phone = phones.get("formatted") or phones.get("value")
+    email = None
+    for item in contact:
+        kind = item.get("kind")
+        if kind == "phone" and not phone:
+            phone = item.get("contact_value")
+            if not phone:
+                value = item.get("value") or {}
+                if isinstance(value, dict):
+                    phone = value.get("formatted")
+        elif kind == "email" and not email:
+            email = item.get("contact_value") or item.get("value")
 
     name = " ".join(
         [(data.get("first_name") or "").strip(), (data.get("last_name") or "").strip()]
     ).strip() or data.get("title")
 
-    return {"name": name, "city": city, "phone": phone}
+    return {"name": name, "city": city, "phone": phone, "email": email}

--- a/tests/test_adapters_hh.py
+++ b/tests/test_adapters_hh.py
@@ -51,11 +51,15 @@ async def test_hh_fetch_applicant_details(monkeypatch, token_mock):
         if request.url.path.endswith("/negotiations/resp1"):
             return httpx.Response(200, json={"resume": {"id": "res1"}})
         elif request.url.path.endswith("/resumes/res1"):
+            assert request.url.query == b"with_contacts=true"
             return httpx.Response(
                 200,
                 json={
                     "area": {"name": "Moscow"},
-                    "contact": {"phones": [{"formatted": "+1"}]},
+                    "contact": [
+                        {"kind": "phone", "value": {"formatted": "+1"}},
+                        {"kind": "email", "value": "john@example.com"},
+                    ],
                     "first_name": "John",
                     "last_name": "Doe",
                 },
@@ -65,4 +69,9 @@ async def test_hh_fetch_applicant_details(monkeypatch, token_mock):
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         data = await hh.fetch_applicant_details("resp1", "emp1", client)
 
-    assert data == {"name": "John Doe", "city": "Moscow", "phone": "+1"}
+    assert data == {
+        "name": "John Doe",
+        "city": "Moscow",
+        "phone": "+1",
+        "email": "john@example.com",
+    }


### PR DESCRIPTION
## Summary
- retrieve resumes from HeadHunter with `with_contacts=true`
- parse contact list to obtain phone and email
- test hh adapter with new contact format

## Testing
- `pytest tests/test_adapters_hh.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68aabc731d7c8321acb11835b6e2fe0d