### PR TITLE
Support applicant email during AmoCRM lead enrichment

### DIFF
--- a/app/adapters/amo_client.py
+++ b/app/adapters/amo_client.py
@@ -111,15 +111,17 @@ class AmoClient:
         }]
         return await self._request("POST", url, json=body)
 
-    async def create_contact(self, name: str, phone: str | None = None):
-        """Create a contact with an optional phone number."""
+    async def create_contact(
+        self, name: str, phone: str | None = None, email: str | None = None
+    ):
+        """Create a contact with optional phone and email."""
         url = f"{self.base}/api/v4/contacts"
-        body = [{
-            "name": name,
-            **({"custom_fields_values": [
-                {"field_code": "PHONE", "values": [{"value": phone}]}
-            ]} if phone else {}),
-        }]
+        cfv = []
+        if phone:
+            cfv.append({"field_code": "PHONE", "values": [{"value": phone}]})
+        if email:
+            cfv.append({"field_code": "EMAIL", "values": [{"value": email}]})
+        body = [{"name": name, **({"custom_fields_values": cfv} if cfv else {})}]
         return await self._request("POST", url, json=body)
 
     async def link_contact_to_lead(self, lead_id: int, contact_id: int):

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -110,6 +110,7 @@ class Settings(BaseSettings):
     AMO_CF_LEAD_VACANCY_TITLE_ID: int = 0
     AMO_CF_LEAD_APPLICANT_PHONE_ID: int = 0
     AMO_CF_LEAD_APPLICANT_NAME_ID: int = 0
+    AMO_CF_LEAD_APPLICANT_EMAIL_ID: int = 0
     AMO_CF_REFUSAL_REASON_ID: int = 0
 
     def validate_required(self) -> None:

--- a/app/models.py
+++ b/app/models.py
@@ -12,6 +12,7 @@ class Applicant(BaseModel):
     name: str = Field(..., min_length=1)
     phone: str | None = None
     city: str | None = None
+    email: str | None = None
 
     model_config = ConfigDict(extra="allow")
 

--- a/app/services/amo_lead_enrichment.py
+++ b/app/services/amo_lead_enrichment.py
@@ -15,14 +15,15 @@ async def enrich_lead(  # pylint: disable=too-many-arguments
     phone: str | None,
     city: str | None,
     vacancy_title: str | None,
+    email: str | None,
 ) -> None:
     """Attach extra data to a newly created lead."""
     s = get_settings()
 
     contact_id = None
-    if applicant_name or phone:
+    if applicant_name or phone or email:
         try:
-            cr = await amo.create_contact(applicant_name or "Кандидат", phone)
+            cr = await amo.create_contact(applicant_name or "Кандидат", phone, email)
             contact_id = cr["_embedded"]["contacts"][0]["id"]
             await amo.link_contact_to_lead(lead_id, contact_id)
         except Exception as e:  # pragma: no cover - log only  # pylint: disable=broad-exception-caught
@@ -37,6 +38,8 @@ async def enrich_lead(  # pylint: disable=too-many-arguments
         cf[s.AMO_CF_LEAD_APPLICANT_PHONE_ID] = phone or ""
     if s.AMO_CF_LEAD_APPLICANT_NAME_ID:
         cf[s.AMO_CF_LEAD_APPLICANT_NAME_ID] = applicant_name or ""
+    if getattr(s, "AMO_CF_LEAD_APPLICANT_EMAIL_ID", 0):
+        cf[s.AMO_CF_LEAD_APPLICANT_EMAIL_ID] = email or ""
     try:
         await amo.update_lead_custom_fields(lead_id, cf)
     except Exception as e:  # pragma: no cover - log only  # pylint: disable=broad-exception-caught
@@ -48,6 +51,7 @@ async def enrich_lead(  # pylint: disable=too-many-arguments
             s.AMO_CF_LEAD_VACANCY_TITLE_ID,
             s.AMO_CF_LEAD_APPLICANT_PHONE_ID,
             s.AMO_CF_LEAD_APPLICANT_NAME_ID,
+            getattr(s, "AMO_CF_LEAD_APPLICANT_EMAIL_ID", 0),
         ]
     ):
         try:
@@ -56,7 +60,8 @@ async def enrich_lead(  # pylint: disable=too-many-arguments
                 f"• Имя: {applicant_name or '-'}\n"
                 f"• Телефон: {phone or '-'}\n"
                 f"• Город: {city or '-'}\n"
-                f"• Вакансия: {vacancy_title or '-'}"
+                f"• Вакансия: {vacancy_title or '-'}\n"
+                f"• Email: {email or '-'}"
             )
             await amo.add_note(lead_id, note)
         except Exception as e:  # pragma: no cover - log only  # pylint: disable=broad-exception-caught

--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -31,6 +31,7 @@ async def enrich_applicant(
             if extra:
                 payload.applicant.phone = payload.applicant.phone or extra.get("phone")
                 payload.applicant.city = payload.applicant.city or extra.get("city")
+                payload.applicant.email = payload.applicant.email or extra.get("email")
                 payload.applicant.name = (
                     payload.applicant.name
                     if payload.applicant.name and payload.applicant.name != "кандидат"
@@ -108,6 +109,7 @@ async def create_lead(
         phone=payload.applicant.phone,
         city=payload.applicant.city,
         vacancy_title=payload.vacancy_title,
+        email=payload.applicant.email,
     )
 
     await save_link(

--- a/tests/test_amo_lead_enrichment.py
+++ b/tests/test_amo_lead_enrichment.py
@@ -10,8 +10,8 @@ class DummyAmo:
     def __init__(self):
         self.calls = {}
 
-    async def create_contact(self, name, phone):
-        self.calls["create_contact"] = (name, phone)
+    async def create_contact(self, name, phone, email):
+        self.calls["create_contact"] = (name, phone, email)
         return {"_embedded": {"contacts": [{"id": 1}]}}
 
     async def link_contact_to_lead(self, lead_id, contact_id):
@@ -32,6 +32,7 @@ async def test_enrich_lead_updates_fields(monkeypatch):
     monkeypatch.setattr(settings, "AMO_CF_LEAD_VACANCY_TITLE_ID", 2)
     monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_PHONE_ID", 3)
     monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_NAME_ID", 4)
+    monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_EMAIL_ID", 5)
 
     await amo_lead_enrichment.enrich_lead(
         amo,
@@ -40,13 +41,15 @@ async def test_enrich_lead_updates_fields(monkeypatch):
         phone="123",
         city="Moscow",
         vacancy_title="Plumber",
+        email="i@ex.ru",
     )
 
     assert amo.calls["update_lead_custom_fields"] == (
         10,
-        {1: "Moscow", 2: "Plumber", 3: "123", 4: "Ivan"},
+        {1: "Moscow", 2: "Plumber", 3: "123", 4: "Ivan", 5: "i@ex.ru"},
     )
     assert "add_note" not in amo.calls
+    assert amo.calls["create_contact"] == ("Ivan", "123", "i@ex.ru")
 
 
 @pytest.mark.asyncio
@@ -57,6 +60,7 @@ async def test_enrich_lead_creates_note_when_no_cfs(monkeypatch):
     monkeypatch.setattr(settings, "AMO_CF_LEAD_VACANCY_TITLE_ID", 0)
     monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_PHONE_ID", 0)
     monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_NAME_ID", 0)
+    monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_EMAIL_ID", 0)
 
     await amo_lead_enrichment.enrich_lead(
         amo,
@@ -65,9 +69,17 @@ async def test_enrich_lead_creates_note_when_no_cfs(monkeypatch):
         phone="456",
         city="SPb",
         vacancy_title="Operator",
+        email="a@ex.ru",
     )
 
     assert "add_note" in amo.calls
     lead_id, note = amo.calls["add_note"]
     assert lead_id == 20
-    assert "Anna" in note and "456" in note and "SPb" in note and "Operator" in note
+    assert (
+        "Anna" in note
+        and "456" in note
+        and "SPb" in note
+        and "Operator" in note
+        and "a@ex.ru" in note
+    )
+    assert amo.calls["create_contact"] == ("Anna", "456", "a@ex.ru")

--- a/tests/test_lead_processor.py
+++ b/tests/test_lead_processor.py
@@ -13,7 +13,12 @@ async def test_enrich_applicant(monkeypatch):
     )
 
     async def fake_fetch(applicant_id, owner_id, http_client):
-        return {"phone": "123", "city": "Moscow", "name": "Ivan"}
+        return {
+            "phone": "123",
+            "city": "Moscow",
+            "name": "Ivan",
+            "email": "ivan@example.com",
+        }
 
     monkeypatch.setattr(lead_processor.hh_adapt, "fetch_applicant_details", fake_fetch)
 
@@ -21,6 +26,7 @@ async def test_enrich_applicant(monkeypatch):
     assert result.applicant.phone == "123"
     assert result.applicant.city == "Moscow"
     assert result.applicant.name == "Ivan"
+    assert result.applicant.email == "ivan@example.com"
 
 
 @pytest.mark.asyncio
@@ -30,7 +36,7 @@ async def test_create_lead(monkeypatch):
         vacancy_title="Title",
         vacancy_desc="",
         raw_text="",
-        applicant=Applicant(id="1", name="John"),
+        applicant=Applicant(id="1", name="John", email="j@e.ru"),
         owner_id="own",
         vacancy_id="vac",
     )
@@ -45,6 +51,7 @@ async def test_create_lead(monkeypatch):
             pass
 
     async def fake_enrich(*args, **kwargs):
+        assert kwargs.get("email") == "j@e.ru"
         return None
 
     async def fake_save_link(**kwargs):


### PR DESCRIPTION
## Summary
- store applicant email in models and enrich-applicant step
- pass email to AmoCRM lead enrichment and contact creation
- add config and tests for email custom field or note

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aabd8453d88321a54ffe66d32a329b