### PR TITLE
Enrich HH leads with vacancy description

### DIFF
--- a/app/adapters/hh.py
+++ b/app/adapters/hh.py
@@ -4,10 +4,16 @@ from typing import Optional
 
 import httpx
 
-from app.api.oauth2 import OAuth2Config, ensure_fresh_access
 from app.core.config import get_settings
 from app.core.retry import with_retry
 from ._requests import request_with_retry
+
+
+async def ensure_fresh_access(*args, **kwargs):
+    """Lazy proxy to OAuth2 token refresh to avoid import cycles."""
+    from app.api.oauth2 import ensure_fresh_access as _ensure
+
+    return await _ensure(*args, **kwargs)
 
 
 class HHError(Exception):
@@ -21,6 +27,8 @@ async def set_employer_state(
     client: httpx.AsyncClient,
 ) -> None:
     """Set the negotiation state for a given employer."""
+    from app.api.oauth2 import OAuth2Config
+
     s = get_settings()
     config = OAuth2Config(
         service="hh",
@@ -60,6 +68,8 @@ async def send_message(
     client: httpx.AsyncClient,
 ) -> None:
     """Send a message to an applicant within a negotiation."""
+    from app.api.oauth2 import OAuth2Config
+
     s = get_settings()
     access = await ensure_fresh_access(
         config=OAuth2Config(
@@ -99,6 +109,8 @@ async def fetch_applicant_details(
     client: httpx.AsyncClient,
 ) -> dict:
     """Fetch basic applicant information such as name, city, phone and email."""
+    from app.api.oauth2 import OAuth2Config
+
     s = get_settings()
     access = await ensure_fresh_access(
         config=OAuth2Config(
@@ -156,3 +168,35 @@ async def fetch_applicant_details(
     ).strip() or data.get("title")
 
     return {"name": name, "city": city, "phone": phone, "email": email}
+
+
+async def fetch_vacancy_description(
+    vacancy_id: str,
+    employer_id: Optional[str],
+    client: httpx.AsyncClient,
+) -> str:
+    """Fetch vacancy description text."""
+    from app.api.oauth2 import OAuth2Config
+
+    s = get_settings()
+    access = await ensure_fresh_access(
+        config=OAuth2Config(
+            service="hh",
+            token_url=s.HH_TOKEN_URL,
+            client_id=s.HH_CLIENT_ID,
+            client_secret=s.HH_CLIENT_SECRET,
+            redirect_uri=s.HH_REDIRECT_URI,
+            use_basic_auth=False,
+            owner_id=employer_id,
+        ),
+        http_client=client,
+    )
+
+    resp = await client.get(
+        f"{s.HH_API_BASE.rstrip('/')}/vacancies/{vacancy_id}",
+        headers={"Authorization": f"Bearer {access}", "Accept": "application/json"},
+        timeout=30,
+    )
+    if resp.status_code >= 400:
+        return ""
+    return resp.json().get("description") or ""

--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -11,7 +11,6 @@ from app.adapters.amo_client import ReauthRequired
 from app.core.config import get_settings
 from app.services.queue import rabbitmq, RabbitMQClient
 from app.store import save_link
-from app.api.utils import route_kind
 from app.services import amo_lead_enrichment
 from app.models import IncomingPayload
 
@@ -22,8 +21,8 @@ async def enrich_applicant(
     payload: IncomingPayload, http_client: httpx.AsyncClient
 ) -> IncomingPayload:
     """Enrich applicant data from HeadHunter if possible."""
+    owner_id = payload.owner_id
     if payload.platform == "hh" and payload.applicant.id:
-        owner_id = payload.owner_id
         try:
             extra = await hh_adapt.fetch_applicant_details(
                 payload.applicant.id, owner_id, http_client
@@ -43,6 +42,23 @@ async def enrich_applicant(
                 payload.applicant.id,
                 type(e).__name__,
             )
+    if (
+        payload.platform == "hh"
+        and not payload.vacancy_desc
+        and payload.vacancy_id
+    ):
+        try:
+            desc = await hh_adapt.fetch_vacancy_description(
+                payload.vacancy_id, owner_id, http_client
+            )
+            if desc:
+                payload.vacancy_desc = desc
+        except (httpx.HTTPError, json.JSONDecodeError) as e:  # pragma: no cover - log only
+            logger.warning(
+                "HH vacancy fetch failed for vacancy %s: %s",
+                payload.vacancy_id,
+                type(e).__name__,
+            )
     return payload
 
 
@@ -53,6 +69,7 @@ async def create_lead(
 ) -> tuple[int | None, str]:
     """Create lead in AmoCRM and return (lead_id, kind)."""
     s = get_settings()
+    from app.api.utils import route_kind
 
     kind = route_kind(
         desc=payload.vacancy_desc or "",
@@ -128,6 +145,7 @@ async def send_invite(
 ) -> str:
     """Send invite link to applicant via platform-specific channels."""
     s = get_settings()
+    from app.api.utils import route_kind
 
     kind = payload.kind or route_kind(
         desc=payload.vacancy_desc or "",

--- a/tests/test_lead_processor.py
+++ b/tests/test_lead_processor.py
@@ -30,6 +30,53 @@ async def test_enrich_applicant(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_enrich_applicant_vacancy_desc(monkeypatch):
+    payload = IncomingPayload(
+        platform="hh",
+        owner_id="o1",
+        vacancy_id="vac1",
+        vacancy_desc="",
+        applicant=Applicant(id="1", name="кандидат"),
+    )
+
+    async def fake_fetch_applicant_details(applicant_id, owner_id, http_client):
+        return {}
+
+    async def fake_fetch_vacancy_description(vacancy_id, employer_id, client):
+        return "Test #мастер vacancy"
+
+    monkeypatch.setattr(
+        lead_processor.hh_adapt, "fetch_applicant_details", fake_fetch_applicant_details
+    )
+    monkeypatch.setattr(
+        lead_processor.hh_adapt, "fetch_vacancy_description", fake_fetch_vacancy_description
+    )
+
+    result = await lead_processor.enrich_applicant(payload, None)
+    assert result.vacancy_desc == "Test #мастер vacancy"
+
+    class DummyClient:
+        async def create_leads(self, body):
+            return {"_embedded": {"leads": [{"id": 321}]}}
+
+        async def add_tags(self, *a, **kw):
+            pass
+
+    async def fake_enrich(*args, **kwargs):
+        return None
+
+    async def fake_save_link(**kwargs):
+        return None
+
+    monkeypatch.setattr(lead_processor.amo_lead_enrichment, "enrich_lead", fake_enrich)
+    monkeypatch.setattr(lead_processor, "save_link", fake_save_link)
+
+    lead_id, kind = await lead_processor.create_lead(result, DummyClient())
+    assert lead_id == 321
+    assert kind == "master"
+
+
+@pytest.mark.asyncio
 async def test_create_lead(monkeypatch):
     payload = IncomingPayload(
         platform="hh",
@@ -41,7 +88,7 @@ async def test_create_lead(monkeypatch):
         vacancy_id="vac",
     )
 
-    monkeypatch.setattr(lead_processor, "route_kind", lambda **kw: "master")
+    monkeypatch.setattr("app.api.utils.route_kind", lambda **kw: "master")
 
     class DummyClient:
         async def create_leads(self, body):


### PR DESCRIPTION
## Summary
- add HH adapter helper to fetch vacancy descriptions
- enrich applicants with vacancy description when missing
- test HH vacancy enrichment and lead routing

## Testing
- `pytest tests/test_lead_processor.py -q`
- `pytest tests/test_adapters_hh.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aac36f59ec8321be6b9540f0fb594d