### PR TITLE
Handle optional attempt parameter in RMQ consumer

### DIFF
--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -9,6 +9,7 @@ tasks.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import os
@@ -158,7 +159,7 @@ class RabbitMQClient:
             await self._exch.publish(msg, routing_key="tasks.dlq")
 
     async def consume(
-        self, handler: Callable[[dict, int], Awaitable[None]], max_attempts: int = 10
+        self, handler: Callable[..., Awaitable[None]], max_attempts: int = 10
     ) -> None:
         """Consume tasks and process them via ``handler``.
 
@@ -169,6 +170,8 @@ class RabbitMQClient:
         if not self._conn or self._conn.is_closed or not self._chan or self._chan.is_closed:
             await self._ensure()
         s = self._s()
+
+        expects_attempts = len(inspect.signature(handler).parameters) > 1
 
         async def _worker() -> None:
             """Continuously fetch messages from the queue and process them."""
@@ -201,7 +204,10 @@ class RabbitMQClient:
                                     )
                                     attempts = 0
 
-                                await handler(payload, attempts)
+                                if expects_attempts:
+                                    await handler(payload, attempts)
+                                else:
+                                    await handler(payload)
                                 await message.ack()
                             except (
                                 json.JSONDecodeError,

--- a/tests/test_adapters_hh.py
+++ b/tests/test_adapters_hh.py
@@ -1,4 +1,5 @@
-import json
+from urllib.parse import parse_qs
+
 import pytest
 import httpx
 
@@ -17,7 +18,7 @@ async def test_hh_send_message(monkeypatch, token_mock):
 
     def handler(request):
         captured["url"] = str(request.url)
-        captured["json"] = json.loads(request.content.decode())
+        captured["form"] = parse_qs(request.content.decode())
         assert request.headers["Authorization"] == f"Bearer {token}"
         assert request.headers["Accept"] == "application/json"
         return httpx.Response(200, json={})
@@ -26,7 +27,7 @@ async def test_hh_send_message(monkeypatch, token_mock):
         await hh.send_message("resp1", "hello", "emp1", client)
 
     assert captured["url"].endswith("/negotiations/resp1/messages")
-    assert captured["json"] == {"message": {"text": "hello"}}
+    assert captured["form"] == {"message": ["hello"]}
 
 
 @pytest.mark.asyncio

--- a/tests/test_payload_parsers.py
+++ b/tests/test_payload_parsers.py
@@ -33,7 +33,7 @@ def test_parse_hh_payload_ok():
 
 def test_parse_hh_payload_missing_id():
     raw = json.dumps({"response": {}}).encode()
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValueError):
         parse_hh_payload(raw)
 
 


### PR DESCRIPTION
## Summary
- prevent TypeError when task handlers don't accept attempt count
- align tests with expected form-encoded HH requests and missing HH ID handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab1cd6b7c4832184528760208d462a