### PR TITLE
Handle hh_autofill task and soften Amo error handling

### DIFF
--- a/app/services/worker/amo.py
+++ b/app/services/worker/amo.py
@@ -7,6 +7,8 @@ to perform the actual API call.
 
 import logging
 
+from httpx import HTTPStatusError
+
 from app.adapters.amo_client import AmoClient
 from app.http_client import get_http_client
 
@@ -34,7 +36,13 @@ async def handle_amo_add_note(payload: dict) -> None:
 
     logger.info("amo.add_note: %s", payload.get("lead_id"))
     amo = await AmoClient.create(get_http_client())
-    await amo.add_note(int(payload["lead_id"]), payload["text"])
+    try:
+        await amo.add_note(int(payload["lead_id"]), payload["text"])
+    except HTTPStatusError as err:  # pylint: disable=broad-except
+        if err.response is not None and err.response.status_code < 500:
+            logger.warning("amo.add_note failed: %s", err)
+        else:
+            raise
 
 
 async def handle_amo_add_tags(payload: dict) -> None:
@@ -46,4 +54,10 @@ async def handle_amo_add_tags(payload: dict) -> None:
 
     logger.info("amo.add_tags: %s", payload.get("lead_id"))
     amo = await AmoClient.create(get_http_client())
-    await amo.add_tags(int(payload["lead_id"]), list(payload.get("tags") or []))
+    try:
+        await amo.add_tags(int(payload["lead_id"]), list(payload.get("tags") or []))
+    except HTTPStatusError as err:  # pylint: disable=broad-except
+        if err.response is not None and err.response.status_code < 500:
+            logger.warning("amo.add_tags failed: %s", err)
+        else:
+            raise

--- a/app/services/worker/system.py
+++ b/app/services/worker/system.py
@@ -1,0 +1,23 @@
+"""Handlers for internal system tasks."""
+
+import logging
+import time
+
+from app.db.token_store import DbTokenStore
+from app.http_client import get_http_client
+from app.services.hh_autofill import autofill_hh_mapping
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_system_hh_autofill(payload: dict) -> None:
+    """Build HH status mapping based on AmoCRM pipelines."""
+    logger.info("system.hh_autofill")
+    tok = await DbTokenStore("amo").load()
+    if (
+        not tok
+        or not tok.get("access_token")
+        or int(tok.get("expires_at", 0)) <= int(time.time()) + 30
+    ):
+        raise RuntimeError("amo token missing/expired")
+    await autofill_hh_mapping(get_http_client())

--- a/app/services/worker_rmq.py
+++ b/app/services/worker_rmq.py
@@ -18,6 +18,7 @@ from app.services.worker.amo import (
 )
 from app.services.worker.avito import handle_avito_mark_read, handle_avito_send_message
 from app.services.worker.hh import handle_hh_send_message, handle_hh_set_state
+from app.services.worker.system import handle_system_hh_autofill
 from app.services.worker.mirror import (
     handle_mirror_amo_to_tg,
     handle_mirror_bot_to_amo,
@@ -56,6 +57,7 @@ HANDLERS = {
     ("amo", "amo_create_lead"): handle_amo_create_lead,
     ("amo", "amo_add_note"): handle_amo_add_note,
     ("amo", "amo_add_tags"): handle_amo_add_tags,
+    ("system", "hh_autofill"): handle_system_hh_autofill,
     ("mirror", "amo_to_tg"): handle_mirror_amo_to_tg,
     ("mirror", "tg_to_amo"): handle_mirror_tg_to_amo,
     ("mirror", "bot_to_amo"): handle_mirror_bot_to_amo,


### PR DESCRIPTION
## Summary
- add worker handler for `system.hh_autofill`
- log Amo note and tag errors instead of failing tasks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab2ebda83c8321b081ab6d38b1ee60