### PR TITLE
feat: support amo status updates

### DIFF
--- a/app/adapters/amo_client.py
+++ b/app/adapters/amo_client.py
@@ -130,6 +130,12 @@ class AmoClient:
         body = [{"to_entity_id": contact_id, "to_entity_type": "contacts"}]
         return await self._request("POST", url, json=body)
 
+    async def update_status(self, lead_id: int, status_id: int):
+        """Update the status of a lead."""
+        url = f"{self.base}/api/v4/leads"
+        body = [{"id": lead_id, "status_id": status_id}]
+        return await self._request("PATCH", url, json=body)
+
     async def update_lead_custom_fields(self, lead_id: int, fields: dict[int, str]):
         """Update custom field values for a lead."""
         if not fields:

--- a/app/services/worker/amo.py
+++ b/app/services/worker/amo.py
@@ -61,3 +61,22 @@ async def handle_amo_add_tags(payload: dict) -> None:
             logger.warning("amo.add_tags failed: %s", err)
         else:
             raise
+
+
+async def handle_amo_update_status(payload: dict) -> None:
+    """Update lead status in amoCRM.
+
+    Args:
+        payload: Must contain ``lead_id`` and ``status_id`` specifying the new
+            status for the lead.
+    """
+
+    logger.info("amo.update_status: %s", payload.get("lead_id"))
+    amo = await AmoClient.create(get_http_client())
+    try:
+        await amo.update_status(int(payload["lead_id"]), int(payload["status_id"]))
+    except HTTPStatusError as err:  # pylint: disable=broad-except
+        if err.response is not None and err.response.status_code < 500:
+            logger.warning("amo.update_status failed: %s", err)
+        else:
+            raise

--- a/app/services/worker_rmq.py
+++ b/app/services/worker_rmq.py
@@ -15,6 +15,7 @@ from app.services.worker.amo import (
     handle_amo_add_note,
     handle_amo_add_tags,
     handle_amo_create_lead,
+    handle_amo_update_status,
 )
 from app.services.worker.avito import handle_avito_mark_read, handle_avito_send_message
 from app.services.worker.hh import handle_hh_send_message, handle_hh_set_state
@@ -57,6 +58,7 @@ HANDLERS = {
     ("amo", "amo_create_lead"): handle_amo_create_lead,
     ("amo", "amo_add_note"): handle_amo_add_note,
     ("amo", "amo_add_tags"): handle_amo_add_tags,
+    ("amo", "amo_update_status"): handle_amo_update_status,
     ("system", "hh_autofill"): handle_system_hh_autofill,
     ("mirror", "amo_to_tg"): handle_mirror_amo_to_tg,
     ("mirror", "tg_to_amo"): handle_mirror_tg_to_amo,

--- a/tests/test_adapters_amo_client.py
+++ b/tests/test_adapters_amo_client.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import json
+import pytest
+import httpx
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.adapters.amo_client import AmoClient
+import app.adapters.amo_client as amo_client_module
+
+
+class DummyStore:
+    async def save(self, data):  # pragma: no cover - not used but required
+        pass
+
+
+@pytest.mark.asyncio
+async def test_update_status(monkeypatch):
+    class DummySettings:
+        AMO_BASE_URL = "https://example.com"
+
+    monkeypatch.setattr(amo_client_module, "get_settings", lambda: DummySettings())
+
+    tokens = {"access_token": "acc", "refresh_token": "ref", "expires_at": 10**10}
+    captured = {}
+
+    def handler(request):
+        captured["method"] = request.method
+        captured["url"] = request.url
+        captured["json"] = json.loads(request.content.decode())
+        assert request.headers["Authorization"] == "Bearer acc"
+        assert request.headers["Accept"] == "application/json"
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        amo = AmoClient(tokens, DummyStore(), client)
+        await amo.update_status(123, 456)
+
+    assert captured["method"] == "PATCH"
+    assert captured["url"].path == "/api/v4/leads"
+    assert captured["json"] == [{"id": 123, "status_id": 456}]

--- a/tests/test_worker_amo_update_status.py
+++ b/tests/test_worker_amo_update_status.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import pytest
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from app.services.worker import amo as worker_amo
+
+
+@pytest.mark.asyncio
+async def test_handle_amo_update_status(monkeypatch):
+    captured = {}
+
+    class DummyAmo:
+        async def update_status(self, lead_id, status_id):
+            captured['lead_id'] = lead_id
+            captured['status_id'] = status_id
+
+    async def fake_create(cls, http_client):
+        return DummyAmo()
+
+    monkeypatch.setattr(worker_amo.AmoClient, 'create', classmethod(fake_create))
+    monkeypatch.setattr(worker_amo, 'get_http_client', lambda: None)
+
+    await worker_amo.handle_amo_update_status({'lead_id': '1', 'status_id': '2'})
+
+    assert captured == {'lead_id': 1, 'status_id': 2}

--- a/tests/test_worker_handlers.py
+++ b/tests/test_worker_handlers.py
@@ -7,6 +7,7 @@ from app.services import worker_rmq
 from app.services.worker import hh as worker_hh
 from app.services.worker import avito as worker_avito
 from app.services.worker import mirror as worker_mirror
+from app.services.worker import amo as worker_amo
 
 
 @pytest.mark.parametrize(
@@ -15,6 +16,7 @@ from app.services.worker import mirror as worker_mirror
         (("hh", "send_message"), worker_hh.handle_hh_send_message),
         (("avito", "send_message"), worker_avito.handle_avito_send_message),
         (("mirror", "amo_to_tg"), worker_mirror.handle_mirror_amo_to_tg),
+        (("amo", "amo_update_status"), worker_amo.handle_amo_update_status),
     ],
 )
 def test_handler_mapping(key, func):


### PR DESCRIPTION
## Summary
- add AmoClient.update_status to patch lead status
- handle amo_update_status worker action and register in RMQ
- cover update_status logic with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac4ed7918483218bc7869f6b7640cf