### PR TITLE
feat: update survey status after completion

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -38,8 +38,10 @@ class Settings(BaseSettings):
     # IDшники воронок/стадий — как Optional[int]
     AMO_PIPELINE_ID_MASTER: Optional[int] = None
     AMO_STAGE_ID_MASTER_NEW: Optional[int] = None
+    AMO_STAGE_ID_MASTER_SURVEY: Optional[int] = None
     AMO_PIPELINE_ID_OPERATOR: Optional[int] = None
     AMO_STAGE_ID_OPERATOR_NEW: Optional[int] = None
+    AMO_STAGE_ID_OPERATOR_SURVEY: Optional[int] = None
 
     # Теги/роутинг
     AMO_TAG_WENT_TO_BOT: str = "Перешел в бота"
@@ -123,8 +125,10 @@ class Settings(BaseSettings):
             ("AMO_REDIRECT_URI", self.AMO_REDIRECT_URI),
             ("AMO_PIPELINE_ID_MASTER", self.AMO_PIPELINE_ID_MASTER),
             ("AMO_STAGE_ID_MASTER_NEW", self.AMO_STAGE_ID_MASTER_NEW),
+            ("AMO_STAGE_ID_MASTER_SURVEY", self.AMO_STAGE_ID_MASTER_SURVEY),
             ("AMO_PIPELINE_ID_OPERATOR", self.AMO_PIPELINE_ID_OPERATOR),
             ("AMO_STAGE_ID_OPERATOR_NEW", self.AMO_STAGE_ID_OPERATOR_NEW),
+            ("AMO_STAGE_ID_OPERATOR_SURVEY", self.AMO_STAGE_ID_OPERATOR_SURVEY),
             ("ADMIN_TOKEN", self.ADMIN_TOKEN),
             # AmoChats — если включено автоподключение/использование
             (

--- a/app/services/survey_service.py
+++ b/app/services/survey_service.py
@@ -52,4 +52,17 @@ class SurveyService:
             "lead_id": lead_id,
             "text": f"[{bot_kind}] {summary}",
         })
+        stage_id = (
+            s.AMO_STAGE_ID_MASTER_SURVEY
+            if bot_kind == "master"
+            else s.AMO_STAGE_ID_OPERATOR_SURVEY
+        )
+        await self.queue_client.publish_task(
+            {
+                "platform": "amo",
+                "action": "amo_update_status",
+                "lead_id": lead_id,
+                "status_id": stage_id,
+            }
+        )
         await delete_survey(user_id, bot_kind)

--- a/tests/test_survey_service.py
+++ b/tests/test_survey_service.py
@@ -105,16 +105,24 @@ async def test_store_answer(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_finish(monkeypatch, queue_mock):
+@pytest.mark.parametrize(
+    "bot_kind, stage_attr, stage_value",
+    [
+        ("master", "AMO_STAGE_ID_MASTER_SURVEY", 5),
+        ("operator", "AMO_STAGE_ID_OPERATOR_SURVEY", 6),
+    ],
+)
+async def test_finish(bot_kind, stage_attr, stage_value, monkeypatch, queue_mock):
     deleted = []
 
-    async def fake_delete(user_id, bot_kind):
-        deleted.append((user_id, bot_kind))
+    async def fake_delete(user_id, b_kind):
+        deleted.append((user_id, b_kind))
 
     monkeypatch.setattr("app.services.survey_service.delete_survey", fake_delete)
+    monkeypatch.setattr(settings, stage_attr, stage_value)
 
     svc = SurveyService()
-    await svc.finish(3, "b3", 33, "summary")
+    await svc.finish(3, bot_kind, 33, "summary")
 
     assert queue_mock == [
         {
@@ -127,7 +135,13 @@ async def test_finish(monkeypatch, queue_mock):
             "platform": "amo",
             "action": "amo_add_note",
             "lead_id": 33,
-            "text": "[b3] summary",
+            "text": f"[{bot_kind}] summary",
+        },
+        {
+            "platform": "amo",
+            "action": "amo_update_status",
+            "lead_id": 33,
+            "status_id": stage_value,
         },
     ]
-    assert deleted == [(3, "b3")]
+    assert deleted == [(3, bot_kind)]


### PR DESCRIPTION
## Summary
- add AMO survey stage identifiers to settings and validation
- update SurveyService to push status change when survey finishes
- cover new status update with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac51b8a3ac8321856a2d458b7c6a73