### PR TITLE
Publish status update after chat creation

### DIFF
--- a/app/services/worker/mirror.py
+++ b/app/services/worker/mirror.py
@@ -17,6 +17,7 @@ from app.services import tg_send_with_retry
 from app.core.retry import with_retry
 from app.http_client import get_http_client
 from app.adapters.amo_client import AmoClient
+from app.services.queue import rabbitmq
 
 logger = logging.getLogger(__name__)
 
@@ -144,6 +145,7 @@ async def handle_mirror_bot_to_amo(payload: dict):
     user_name = payload.get("user_name")
     conv_id = payload.get("conversation_id")
     lead_id = payload.get("lead_id")
+    status_id = payload.get("status_id")
 
     http_client = get_http_client()
     text_sent = False
@@ -162,6 +164,17 @@ async def handle_mirror_bot_to_amo(payload: dict):
             is_retryable=lambda e: True,
         )
         text_sent = True
+        if status_id is not None:
+            dedup = calc_key("chat_status", f"{lead_id}:{status_id}")
+            if await check_and_store(dedup):
+                await rabbitmq.publish_task(
+                    {
+                        "platform": "amo",
+                        "action": "amo_update_status",
+                        "lead_id": int(lead_id),
+                        "status_id": int(status_id),
+                    }
+                )
 
     if not conv_id:
         raise RuntimeError("bot_to_amo: no conversation_id and no lead_id to create one")

--- a/tests/test_worker_mirror_status.py
+++ b/tests/test_worker_mirror_status.py
@@ -1,0 +1,40 @@
+import pytest
+
+from app.services.worker import mirror as worker_mirror
+
+
+@pytest.mark.asyncio
+async def test_status_update_on_chat_creation(monkeypatch, queue_mock):
+    async def fake_ensure_chat_created(**kwargs):
+        return "lead:123"
+
+    keys = set()
+
+    async def fake_check_and_store(key):
+        if key in keys:
+            return False
+        keys.add(key)
+        return True
+
+    monkeypatch.setattr(worker_mirror, "ensure_chat_created", fake_ensure_chat_created)
+    monkeypatch.setattr(worker_mirror, "check_and_store", fake_check_and_store)
+
+    payload = {
+        "text": "hi",
+        "user_id": "1",
+        "user_name": "u",
+        "lead_id": "123",
+        "status_id": 777,
+    }
+
+    await worker_mirror.handle_mirror_bot_to_amo(payload)
+    await worker_mirror.handle_mirror_bot_to_amo(payload)
+
+    assert queue_mock == [
+        {
+            "platform": "amo",
+            "action": "amo_update_status",
+            "lead_id": 123,
+            "status_id": 777,
+        }
+    ]


### PR DESCRIPTION
## Summary
- publish amo_update_status when creating a new chat
- avoid duplicate status updates by deduplicating per lead
- test status update after chat creation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac529c711883218bc43e579d480258