### PR TITLE
Create AmoChats chat when new lead has Telegram info

### DIFF
--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -6,14 +6,16 @@ import time
 
 import httpx
 
-from app.adapters import hh as hh_adapt
+from app.adapters import hh as hh_adapt, amochats
 from app.adapters.amo_client import ReauthRequired
 from app.core.config import get_settings
 from app.services.queue import rabbitmq, RabbitMQClient
 from app.store import save_link
+from app import store_chat
 from app.api.utils import route_kind
 from app.services import amo_lead_enrichment
 from app.models import IncomingPayload
+from app.http_client import get_http_client
 
 logger = logging.getLogger(__name__)
 
@@ -116,6 +118,23 @@ async def create_lead(
         vacancy_title=payload.vacancy_title,
         email=payload.applicant.email,
     )
+
+    tg_user_id = getattr(payload, "tg_user_id", None)
+    if tg_user_id:
+        tg_user_name = getattr(payload, "tg_user_name", None)
+        conv_id = await amochats.ensure_chat_created(
+            lead_id=lead_id,
+            tg_user_id=int(tg_user_id),
+            tg_user_name=tg_user_name,
+            client=get_http_client(),
+        )
+        await store_chat.upsert_tg_link(
+            user_id=int(tg_user_id), bot_kind=kind, lead_id=lead_id
+        )
+        if conv_id:
+            await store_chat.set_conversation(
+                int(tg_user_id), kind, conv_id
+            )
 
     await save_link(
         lead_id=lead_id,

--- a/tests/test_lead_processor.py
+++ b/tests/test_lead_processor.py
@@ -39,6 +39,8 @@ async def test_create_lead(monkeypatch):
         applicant=Applicant(id="1", name="John", email="j@e.ru"),
         owner_id="own",
         vacancy_id="vac",
+        tg_user_id=123,
+        tg_user_name="tg",
     )
 
     monkeypatch.setattr(lead_processor, "route_kind", lambda **kw: "master")
@@ -60,9 +62,27 @@ async def test_create_lead(monkeypatch):
     monkeypatch.setattr(lead_processor.amo_lead_enrichment, "enrich_lead", fake_enrich)
     monkeypatch.setattr(lead_processor, "save_link", fake_save_link)
 
+    called = {}
+
+    async def fake_ensure_chat_created(**kwargs):
+        called["chat"] = kwargs
+        return "lead:321"
+
+    async def fake_upsert(user_id, bot_kind, lead_id):
+        called["upsert"] = (user_id, bot_kind, lead_id)
+
+    async def fake_set_conv(user_id, bot_kind, conversation_id):
+        called["conv"] = (user_id, bot_kind, conversation_id)
+
+    monkeypatch.setattr(lead_processor.amochats, "ensure_chat_created", fake_ensure_chat_created)
+    monkeypatch.setattr(lead_processor.store_chat, "upsert_tg_link", fake_upsert)
+    monkeypatch.setattr(lead_processor.store_chat, "set_conversation", fake_set_conv)
+
     lead_id, kind = await lead_processor.create_lead(payload, DummyClient())
     assert lead_id == 321
     assert kind == "master"
+    assert called["upsert"] == (123, "master", 321)
+    assert called["conv"] == (123, "master", "lead:321")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- create or locate AmoChats conversation after enriching newly created leads
- persist Telegram user ↔ lead mapping and conversation id
- test that chat linking is triggered with Telegram data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac60c3e02483218a3b83ce466b9ccf