### PR TITLE
Use contact-based conversation IDs

### DIFF
--- a/app/adapters/amochats.py
+++ b/app/adapters/amochats.py
@@ -212,21 +212,27 @@ async def ensure_chat_created(
     tg_user_id: int,
     tg_user_name: str | None,
     client: httpx.AsyncClient,
+    contact_id: int | None = None,
     init_text: str | None = None,       # если передан — отправим первым сообщением
     init_as_manager: bool = False,      # False = как кандидат, True = как менеджер
     send_default_system: bool = False,  # если True и init_text не задан — отправим тех.сообщение
 ) -> str:
     """
-    Создаёт (или находит) чат в AmoChats по conversation_id='lead:<lead_id>'.
+    Создаёт (или находит) чат в AmoChats.
+
+    ``conversation_id`` формируется детерминированно: если передан
+    ``contact_id`` — используем ``contact:{contact_id}``, иначе
+    ``lead:{lead_id}``.
+
     При необходимости сразу отправляет первое сообщение.
 
     Возвращает:
-        str: conversation_id (тот же детерминированный 'lead:<lead_id>')
+        str: conversation_id (детерминированный идентификатор чата)
     """
     ac = _get_client()
 
     # стабильный ID чата на стороне интеграции
-    conv_id = f"lead:{lead_id}"
+    conv_id = f"contact:{contact_id}" if contact_id else f"lead:{lead_id}"
 
     # 1) создать/найти чат
     path_chats = f"/v2/origin/custom/{ac.scope_id}/chats"
@@ -243,7 +249,12 @@ async def ensure_chat_created(
     if r.status_code >= 400:
         raise AmoChatsError(f"ensure_chat_created failed {r.status_code}: {r.text}")
 
-    logger.info("ensure_chat_created: ok for lead=%s -> conv_id=%s", lead_id, conv_id)
+    logger.info(
+        "ensure_chat_created: ok for lead=%s contact=%s -> conv_id=%s",
+        lead_id,
+        contact_id,
+        conv_id,
+    )
 
     # 2) при необходимости — отправить первое сообщение в только что созданный чат
     path_msg = f"/v2/origin/custom/{ac.scope_id}"

--- a/app/services/amo_lead_enrichment.py
+++ b/app/services/amo_lead_enrichment.py
@@ -16,8 +16,11 @@ async def enrich_lead(  # pylint: disable=too-many-arguments
     city: str | None,
     vacancy_title: str | None,
     email: str | None,
-) -> None:
-    """Attach extra data to a newly created lead."""
+) -> int | None:
+    """Attach extra data to a newly created lead.
+
+    Returns the ID of the created contact if a contact was created.
+    """
     s = get_settings()
 
     contact_id = None
@@ -25,9 +28,8 @@ async def enrich_lead(  # pylint: disable=too-many-arguments
         try:
             cr = await amo.create_contact(applicant_name or "Кандидат", phone, email)
             contact_id = cr["_embedded"]["contacts"][0]["id"]
-            await amo.link_contact_to_lead(lead_id, contact_id)
         except Exception as e:  # pragma: no cover - log only  # pylint: disable=broad-exception-caught
-            logger.warning("create/link contact failed: %s", e)
+            logger.warning("create contact failed: %s", e)
 
     cf: dict[int, str] = {}
     if s.AMO_CF_LEAD_CITY_ID:
@@ -66,6 +68,7 @@ async def enrich_lead(  # pylint: disable=too-many-arguments
             await amo.add_note(lead_id, note)
         except Exception as e:  # pragma: no cover - log only  # pylint: disable=broad-exception-caught
             logger.warning("add note (candidate data) error: %s", e)
+    return contact_id
 
 
 __all__ = ["enrich_lead"]

--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -109,7 +109,7 @@ async def create_lead(
 
     lead_id = created["_embedded"]["leads"][0]["id"]
 
-    await amo_lead_enrichment.enrich_lead(
+    contact_id = await amo_lead_enrichment.enrich_lead(
         client,
         lead_id,
         applicant_name=payload.applicant.name,
@@ -126,6 +126,7 @@ async def create_lead(
             lead_id=lead_id,
             tg_user_id=int(tg_user_id),
             tg_user_name=tg_user_name,
+            contact_id=contact_id,
             client=get_http_client(),
         )
         await store_chat.upsert_tg_link(
@@ -135,6 +136,12 @@ async def create_lead(
             await store_chat.set_conversation(
                 int(tg_user_id), kind, conv_id
             )
+
+    if contact_id:
+        try:
+            await client.link_contact_to_lead(lead_id, contact_id)
+        except Exception as e:  # pragma: no cover - log only  # pylint: disable=broad-exception-caught
+            logger.warning("link contact to lead failed: %s", e)
 
     await save_link(
         lead_id=lead_id,

--- a/tests/test_adapters_amochats.py
+++ b/tests/test_adapters_amochats.py
@@ -16,7 +16,7 @@ from app.adapters import amochats
             conversation_id="cid", user_id=1, user_name=None, avatar=None, text="hi", client=client
         ),
         lambda client: amochats.ensure_chat_created(
-            lead_id=1, tg_user_id=1, tg_user_name=None, client=client
+            lead_id=1, tg_user_id=1, tg_user_name=None, client=client, contact_id=2
         ),
     ],
 )

--- a/tests/test_amo_lead_enrichment.py
+++ b/tests/test_amo_lead_enrichment.py
@@ -34,7 +34,7 @@ async def test_enrich_lead_updates_fields(monkeypatch):
     monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_NAME_ID", 4)
     monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_EMAIL_ID", 5)
 
-    await amo_lead_enrichment.enrich_lead(
+    contact_id = await amo_lead_enrichment.enrich_lead(
         amo,
         10,
         applicant_name="Ivan",
@@ -50,6 +50,8 @@ async def test_enrich_lead_updates_fields(monkeypatch):
     )
     assert "add_note" not in amo.calls
     assert amo.calls["create_contact"] == ("Ivan", "123", "i@ex.ru")
+    assert contact_id == 1
+    assert "link_contact_to_lead" not in amo.calls
 
 
 @pytest.mark.asyncio
@@ -62,7 +64,7 @@ async def test_enrich_lead_creates_note_when_no_cfs(monkeypatch):
     monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_NAME_ID", 0)
     monkeypatch.setattr(settings, "AMO_CF_LEAD_APPLICANT_EMAIL_ID", 0)
 
-    await amo_lead_enrichment.enrich_lead(
+    contact_id = await amo_lead_enrichment.enrich_lead(
         amo,
         20,
         applicant_name="Anna",
@@ -83,3 +85,5 @@ async def test_enrich_lead_creates_note_when_no_cfs(monkeypatch):
         and "a@ex.ru" in note
     )
     assert amo.calls["create_contact"] == ("Anna", "456", "a@ex.ru")
+    assert contact_id == 1
+    assert "link_contact_to_lead" not in amo.calls

--- a/tests/test_lead_processor.py
+++ b/tests/test_lead_processor.py
@@ -52,9 +52,13 @@ async def test_create_lead(monkeypatch):
         async def add_tags(self, *a, **kw):
             pass
 
+        async def link_contact_to_lead(self, lead_id, contact_id):
+             called["link"] = (lead_id, contact_id)
+             called["order"].append("link")
+
     async def fake_enrich(*args, **kwargs):
         assert kwargs.get("email") == "j@e.ru"
-        return None
+        return 555
 
     async def fake_save_link(**kwargs):
         return None
@@ -62,17 +66,20 @@ async def test_create_lead(monkeypatch):
     monkeypatch.setattr(lead_processor.amo_lead_enrichment, "enrich_lead", fake_enrich)
     monkeypatch.setattr(lead_processor, "save_link", fake_save_link)
 
-    called = {}
+    called = {"order": []}
 
     async def fake_ensure_chat_created(**kwargs):
+        called["order"].append("chat")
         called["chat"] = kwargs
-        return "lead:321"
+        assert kwargs.get("contact_id") == 555
+        return "contact:555"
 
     async def fake_upsert(user_id, bot_kind, lead_id):
         called["upsert"] = (user_id, bot_kind, lead_id)
 
     async def fake_set_conv(user_id, bot_kind, conversation_id):
         called["conv"] = (user_id, bot_kind, conversation_id)
+        called["order"].append("conv")
 
     monkeypatch.setattr(lead_processor.amochats, "ensure_chat_created", fake_ensure_chat_created)
     monkeypatch.setattr(lead_processor.store_chat, "upsert_tg_link", fake_upsert)
@@ -82,7 +89,9 @@ async def test_create_lead(monkeypatch):
     assert lead_id == 321
     assert kind == "master"
     assert called["upsert"] == (123, "master", 321)
-    assert called["conv"] == (123, "master", "lead:321")
+    assert called["conv"] == (123, "master", "contact:555")
+    assert called["link"] == (321, 555)
+    assert called["order"] == ["chat", "conv", "link"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- return `contact_id` from amo lead enrichment
- create chat using contact-based conversation IDs and link contact after chat creation
- support contact IDs in AmoChats adapter and extend tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ac6613dfdc8321b7ca89abbc2f0cef