### PR TITLE
Gracefully handle missing HH negotiations

### DIFF
--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -126,22 +126,20 @@ async def create_lead(
         except Exception as e:  # pragma: no cover
             logger.warning("force create contact failed: %s", e)
 
-    if contact_id:
-        try:
-            await client.link_contact_to_lead(lead_id, contact_id)
-        except Exception as e:  # pragma: no cover
-            logger.warning("link contact to lead failed: %s", e)
-
     tg_user_id = getattr(payload, "tg_user_id", None)
     if tg_user_id:
         tg_user_name = getattr(payload, "tg_user_name", None)
-        conv_id, amo_uuid = await amochats.ensure_chat_created(
+        result = await amochats.ensure_chat_created(
             lead_id=lead_id,
             tg_user_id=int(tg_user_id),
             tg_user_name=tg_user_name,
             contact_id=contact_id,
             client=get_http_client(),
         )
+        if isinstance(result, tuple):
+            conv_id, amo_uuid = result
+        else:
+            conv_id, amo_uuid = result, None
         await store_chat.upsert_tg_link(user_id=int(tg_user_id), bot_kind=kind, lead_id=lead_id)
         if conv_id:
             await store_chat.set_conversation(int(tg_user_id), kind, conv_id)
@@ -152,6 +150,11 @@ async def create_lead(
                 await client.attach_chat_to_contact(int(contact_id), amo_uuid)
             except Exception as e:  # pragma: no cover
                 logger.warning("attach chat to contact failed: %s", e)
+    if contact_id:
+        try:
+            await client.link_contact_to_lead(lead_id, contact_id)
+        except Exception as e:  # pragma: no cover
+            logger.warning("link contact to lead failed: %s", e)
 
     await save_link(
         lead_id=lead_id,

--- a/app/services/worker/hh.py
+++ b/app/services/worker/hh.py
@@ -25,12 +25,18 @@ async def handle_hh_send_message(payload: dict):
 
     logger.info("hh.send_message: %s text=%r", nid, text[:40])
     client = get_http_client()
-    await hh_adapt.send_message(
-        response_id=nid,
-        text=text,
-        employer_id=owner_id,
-        client=client,
-    )
+    try:
+        await hh_adapt.send_message(
+            response_id=nid,
+            text=text,
+            employer_id=owner_id,
+            client=client,
+        )
+    except hh_adapt.HHError as err:  # pragma: no cover - network errors
+        if "topic_not_found" in str(err):
+            logger.warning("hh.send_message: topic not found %s", nid)
+            return
+        raise
 
 
 async def handle_hh_set_state(payload: dict):
@@ -47,9 +53,15 @@ async def handle_hh_set_state(payload: dict):
 
     logger.info("hh.set_state: %s -> %s", nid, action_id)
     client = get_http_client()
-    await hh_adapt.set_employer_state(
-        response_id=nid,
-        target_state=action_id,
-        employer_id=owner_id,
-        client=client,
-    )
+    try:
+        await hh_adapt.set_employer_state(
+            response_id=nid,
+            target_state=action_id,
+            employer_id=owner_id,
+            client=client,
+        )
+    except hh_adapt.HHError as err:  # pragma: no cover - network errors
+        if "topic_not_found" in str(err):
+            logger.warning("hh.set_state: topic not found %s", nid)
+            return
+        raise

--- a/app/services/worker/mirror.py
+++ b/app/services/worker/mirror.py
@@ -9,7 +9,12 @@ dictionary with details specific to the direction of the mirror.
 import logging
 from aiogram import Bot
 
-from app.adapters.amochats import send_text_from_manager, ensure_chat_created, send_text_from_client
+from app.adapters.amochats import (
+    send_text_from_manager,
+    ensure_chat_created,
+    send_text_from_client,
+    AmoChatsError,
+)
 from app.core.config import get_settings
 from app.services.dedup import check_and_store, calc_key
 from app.store_chat import set_conversation
@@ -134,22 +139,29 @@ async def handle_mirror_bot_to_amo(payload: dict):
         raise RuntimeError("bot_to_amo: lead_id is required to create/attach chat")
 
     http_client = get_http_client()
-    amo = await AmoClient.create(http_client)
-
-    # основной контакт сделки
-    lead = await amo.get_lead(int(lead_id))
-    main_contact_id = (((lead.get("_embedded") or {}).get("contacts")) or [{}])[0].get("id")
+    amo = None
+    main_contact_id = None
+    try:
+        amo = await AmoClient.create(http_client)
+        lead = await amo.get_lead(int(lead_id))
+        main_contact_id = (((lead.get("_embedded") or {}).get("contacts")) or [{}])[0].get("id")
+    except Exception as err:  # pragma: no cover - network or token errors
+        logger.warning("amo client unavailable: %s", err)
 
     # создать чат, получить uuid, привязать к контакту
     if not conv_id:
-        conv_id, amo_uuid = await ensure_chat_created(
+        result = await ensure_chat_created(
             lead_id=int(lead_id),
             tg_user_id=user_id,
             tg_user_name=user_name,
             client=http_client,
             contact_id=main_contact_id,
         )
-        if main_contact_id and amo_uuid:
+        if isinstance(result, tuple):
+            conv_id, amo_uuid = result
+        else:
+            conv_id, amo_uuid = result, None
+        if amo and main_contact_id and amo_uuid:
             await amo.attach_chat_to_contact(int(main_contact_id), amo_uuid)
 
         # опционально сменить статус после первой инициализации
@@ -164,15 +176,18 @@ async def handle_mirror_bot_to_amo(payload: dict):
                 })
 
     # отправить сообщение после привязки
-    await with_retry(
-        lambda: send_text_from_client(
-            lead_id=int(lead_id),
-            text=text,
-            tg_user_id=user_id,
-            tg_user_name=user_name,
-            conversation_id=conv_id,
-            client=http_client,
-        ),
-        attempts=6,
-        is_retryable=lambda e: True,
-    )
+    try:
+        await with_retry(
+            lambda: send_text_from_client(
+                lead_id=int(lead_id),
+                text=text,
+                tg_user_id=user_id,
+                tg_user_name=user_name,
+                conversation_id=conv_id,
+                client=http_client,
+            ),
+            attempts=6,
+            is_retryable=lambda e: True,
+        )
+    except AmoChatsError as err:  # pragma: no cover - configuration errors
+        logger.warning("amochats send failed: %s", err)

--- a/tests/test_worker_hh.py
+++ b/tests/test_worker_hh.py
@@ -1,0 +1,28 @@
+import pytest
+
+from app.services.worker import hh as worker_hh
+from app.adapters import hh as hh_adapt
+
+
+@pytest.mark.asyncio
+async def test_send_message_topic_not_found(monkeypatch):
+    async def fake_send_message(*args, **kwargs):
+        raise hh_adapt.HHError("topic_not_found")
+
+    monkeypatch.setattr(hh_adapt, "send_message", fake_send_message)
+    monkeypatch.setattr(worker_hh, "get_http_client", lambda: None)
+
+    payload = {"negotiation_id": "nid", "text": "hello"}
+    await worker_hh.handle_hh_send_message(payload)
+
+
+@pytest.mark.asyncio
+async def test_set_state_topic_not_found(monkeypatch):
+    async def fake_set_state(*args, **kwargs):
+        raise hh_adapt.HHError("topic_not_found")
+
+    monkeypatch.setattr(hh_adapt, "set_employer_state", fake_set_state)
+    monkeypatch.setattr(worker_hh, "get_http_client", lambda: None)
+
+    payload = {"negotiation_id": "nid", "action_id": "phone_interview"}
+    await worker_hh.handle_hh_set_state(payload)


### PR DESCRIPTION
## Summary
- Avoid failing HH worker tasks when negotiation no longer exists
- Robustify chat creation and contact linking order
- Handle missing AMO/AmoChats configuration more defensively
- Add tests for HH worker error handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac76760bac8321be23eb9836d57cad