### PR TITLE
fix: correct hh state change endpoint

### DIFF
--- a/app/adapters/hh.py
+++ b/app/adapters/hh.py
@@ -50,7 +50,8 @@ async def set_employer_state(
     )
 
     ua = getattr(s, "HH_USER_AGENT", None) or getattr(s, "APP_USER_AGENT", None) or "hr-bridge/1.0 (support@example.com)"
-    url = f"{s.HH_API_BASE.rstrip('/')}/negotiations/{target_state}/{response_id}"
+    # HH API expects negotiation ID first, then action name
+    url = f"{s.HH_API_BASE.rstrip('/')}/negotiations/{response_id}/{target_state}"
 
     await request_with_retry(
         client,

--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -171,7 +171,7 @@ async def send_invite(
             "platform": "hh",
             "action": "set_state",
             "negotiation_id": negotiation_id,
-            "action_id": "phone_interview",   # PUT /negotiations/phone_interview/{nid}
+            "action_id": "phone_interview",   # PUT /negotiations/{nid}/phone_interview
             "owner_id": payload.owner_id,
         })
         # 2) Сообщение кандидату (form-urlencoded, HH-User-Agent на стороне воркера)

--- a/tests/test_adapters_hh.py
+++ b/tests/test_adapters_hh.py
@@ -46,6 +46,29 @@ async def test_hh_send_message_error(monkeypatch, token_mock):
 
 
 @pytest.mark.asyncio
+async def test_hh_set_state(monkeypatch, token_mock):
+    async def fake_with_retry(coro, attempts, is_retryable):
+        return await coro()
+
+    monkeypatch.setattr(hh, "with_retry", fake_with_retry)
+    token = token_mock
+    captured = {}
+
+    def handler(request):
+        captured["method"] = request.method
+        captured["url"] = str(request.url)
+        assert request.headers["Authorization"] == f"Bearer {token}"
+        assert request.headers["Accept"] == "application/json"
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await hh.set_employer_state("resp1", "phone_interview", "emp1", client)
+
+    assert captured["method"] == "PUT"
+    assert captured["url"].endswith("/negotiations/resp1/phone_interview")
+
+
+@pytest.mark.asyncio
 async def test_hh_fetch_applicant_details(monkeypatch, token_mock):
 
     def handler(request):


### PR DESCRIPTION
## Summary
- fix HeadHunter negotiation state change URL order
- add test for set_employer_state
- clarify comment about phone_interview action

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acaa1812208321a1fe4b507e0cd65b