### PR TITLE
Log Avito webhook payload

### DIFF
--- a/app/api/avito_incoming.py
+++ b/app/api/avito_incoming.py
@@ -1,11 +1,14 @@
 """Endpoints handling incoming Avito webhooks."""
 
+import logging
 import httpx
 from fastapi import APIRouter, Depends, Request
 
 from app.api._webhook_common import process_job_board_webhook
 from app.http_client import get_http_client
 from app.services.payload_parsers import extract_avito_payload, parse_avito_payload
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
@@ -16,6 +19,8 @@ async def webhook_avito(
 ):
     """Handle incoming Avito webhook requests."""
     raw = await request.body()
+
+    logger.info("Received Avito webhook with payload size %d", len(raw))
 
     def parse(raw_bytes: bytes):
         return parse_avito_payload(extract_avito_payload(raw_bytes))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,7 @@ async def in_memory_db(monkeypatch):
 @pytest.fixture
 def app(monkeypatch):
     """FastAPI application with essential routers for tests."""
-    from app.api import hh_incoming
+    from app.api import hh_incoming, avito_incoming
 
     application = FastAPI()
 
@@ -93,7 +93,9 @@ def app(monkeypatch):
             return object()
 
     monkeypatch.setattr(hh_incoming, "AmoClient", DummyAmoClient, raising=False)
+    monkeypatch.setattr(avito_incoming, "AmoClient", DummyAmoClient, raising=False)
     application.include_router(hh_incoming.router)
+    application.include_router(avito_incoming.router)
     return application
 
 

--- a/tests/test_avito_incoming.py
+++ b/tests/test_avito_incoming.py
@@ -1,0 +1,17 @@
+import logging
+
+from app.api import avito_incoming
+
+
+def test_webhook_logs(monkeypatch, client, caplog):
+    async def fake_process(platform, raw, http_client, parse):
+        return {"ok": True}
+
+    monkeypatch.setattr(avito_incoming, "process_job_board_webhook", fake_process)
+
+    with caplog.at_level(logging.INFO, logger=avito_incoming.logger.name):
+        r = client.post("/webhooks/avito", data=b"payload")
+
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert any("Received Avito webhook" in record.message for record in caplog.records)


### PR DESCRIPTION
## Summary
- add module-level logger for Avito webhooks
- log incoming payload size before processing
- test Avito webhook logging and include router in test app

## Testing
- `pytest`
- `pytest tests/test_avito_incoming.py::test_webhook_logs -q`
- `pytest tests/test_hh_incoming.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68accd8d0dc48321a2bb9a950d94ad63