### PR TITLE
Use route templates for metrics aggregation

### DIFF
--- a/app/core/middleware.py
+++ b/app/core/middleware.py
@@ -28,39 +28,44 @@ class LoggingMiddleware(BaseHTTPMiddleware):  # pylint: disable=too-few-public-m
         except Exception:  # pylint: disable=broad-except
             process_time = time.time() - start_time
             status_code = 500
+            route = request.scope.get("route")
+            path_template = getattr(route, "path", request.url.path)
             log.exception(
                 "request",
                 extra={
                     "method": request.method,
-                    "path": request.url.path,
+                    "path": path_template,
                     "status_code": status_code,
                     "duration": process_time,
                 },
             )
             REQUEST_COUNT.labels(
-                request.method, request.url.path, str(status_code)
+                request.method, path_template, str(status_code)
             ).inc()
-            REQUEST_LATENCY.labels(request.method, request.url.path).observe(
+            REQUEST_LATENCY.labels(request.method, path_template).observe(
                 process_time
             )
             raise
 
         process_time = time.time() - start_time
 
+        route = request.scope.get("route")
+        path_template = getattr(route, "path", request.url.path)
+
         log.info(
             "request",
             extra={
                 "method": request.method,
-                "path": request.url.path,
+                "path": path_template,
                 "status_code": response.status_code,
                 "duration": process_time,
             },
         )
 
         REQUEST_COUNT.labels(
-            request.method, request.url.path, str(response.status_code)
+            request.method, path_template, str(response.status_code)
         ).inc()
-        REQUEST_LATENCY.labels(request.method, request.url.path).observe(process_time)
+        REQUEST_LATENCY.labels(request.method, path_template).observe(process_time)
         return response
 
 

--- a/tests/test_logging_middleware.py
+++ b/tests/test_logging_middleware.py
@@ -1,0 +1,39 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from prometheus_client import generate_latest
+from prometheus_client.parser import text_string_to_metric_families
+
+from app.core.middleware import LoggingMiddleware, REQUEST_COUNT, REQUEST_LATENCY
+
+
+def test_metrics_aggregated_by_route_template():
+    REQUEST_COUNT.clear()
+    REQUEST_LATENCY.clear()
+
+    app = FastAPI()
+    app.add_middleware(LoggingMiddleware)
+
+    @app.get("/items/{item_id}")
+    async def read_item(item_id: int):
+        return {"id": item_id}
+
+    client = TestClient(app)
+    client.get("/items/1")
+    client.get("/items/2")
+
+    metrics = generate_latest().decode()
+    families = list(text_string_to_metric_families(metrics))
+    family = next(f for f in families if f.name == "http_requests")
+    samples = [s for s in family.samples if s.name == "http_requests_total"]
+
+    paths = {s.labels["path"] for s in samples}
+    assert "/items/{item_id}" in paths
+    assert "/items/1" not in paths
+    assert "/items/2" not in paths
+
+    sample = next(
+        s
+        for s in samples
+        if s.labels["path"] == "/items/{item_id}" and s.labels["status"] == "200"
+    )
+    assert sample.value == 2


### PR DESCRIPTION
## Summary
- derive path template from `request.scope['route']` in `LoggingMiddleware`
- log and collect metrics using route templates instead of real paths
- test that HTTP metrics aggregate counts by route

## Testing
- `pytest tests/test_logging_middleware.py::test_metrics_aggregated_by_route_template -q`

------
https://chatgpt.com/codex/tasks/task_e_68c123d7f594832180e80618d36f310c