### PR TITLE
Add API, RabbitMQ, and Postgres services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,37 +1,91 @@
+x-common-env: &common-env
+  PYTHONUNBUFFERED: "1"
+  RABBITMQ_URL: ${RABBITMQ_URL}
+  RMQ_EXCHANGE: bridge
+  RMQ_TASK_QUEUE: bridge.tasks
+  RMQ_RETRY_QUEUE: bridge.tasks.retry
+  RMQ_RETRY_TTL_MS: 5000
+
+  DATABASE_URL: ${DATABASE_URL}
+
+  AMO_BASE_URL: ${AMO_BASE_URL}
+  AMO_CLIENT_ID: ${AMO_CLIENT_ID}
+  AMO_CLIENT_SECRET: ${AMO_CLIENT_SECRET}
+  AMO_REDIRECT_URI: ${AMO_REDIRECT_URI}
+  HH_USER_AGENT: ${HH_USER_AGENT}
+
+  AMO_PIPELINE_ID_MASTER: ${AMO_PIPELINE_ID_MASTER}
+  AMO_STAGE_ID_MASTER_NEW: ${AMO_STAGE_ID_MASTER_NEW}
+  AMO_STAGE_ID_MASTER_SURVEY: ${AMO_STAGE_ID_MASTER_SURVEY}
+  AMO_PIPELINE_ID_OPERATOR: ${AMO_PIPELINE_ID_OPERATOR}
+  AMO_STAGE_ID_OPERATOR_NEW: ${AMO_STAGE_ID_OPERATOR_NEW}
+  AMO_STAGE_ID_OPERATOR_SURVEY: ${AMO_STAGE_ID_OPERATOR_SURVEY}
+  ADMIN_TOKEN: ${ADMIN_TOKEN}
+
+  AMO_CHATS_SCOPE_ID: ${AMO_CHATS_SCOPE_ID}
+  AMO_CHATS_SECRET: ${AMO_CHATS_SECRET}
+  AMO_CHATS_CHANNEL_ID: ${AMO_CHATS_CHANNEL_ID}
+  AMO_CHATS_ACCOUNT_ID: ${AMO_CHATS_ACCOUNT_ID}
+  AMO_CHATS_SENDER_USER_AMOJO_ID: ${AMO_CHATS_SENDER_USER_AMOJO_ID}
+
 services:
+  api:
+    build: .
+    command: uvicorn main:app --host 0.0.0.0 --port 8000
+    environment:
+      <<: *common-env
+    depends_on:
+      - rabbitmq
+      - postgres
+    ports:
+      - "8000:8000"
+    networks:
+      - app
+    restart: unless-stopped
+
   worker:
     build: .
     command: python -u -m app.services.worker_rmq
     environment:
-      PYTHONUNBUFFERED: "1"
-      RABBITMQ_URL: ${RABBITMQ_URL}
-      RMQ_EXCHANGE: bridge
-      RMQ_TASK_QUEUE: bridge.tasks
-      RMQ_RETRY_QUEUE: bridge.tasks.retry
-      RMQ_RETRY_TTL_MS: 5000
-
-      DATABASE_URL: ${DATABASE_URL}
-
-      AMO_BASE_URL: ${AMO_BASE_URL}
-      AMO_CLIENT_ID: ${AMO_CLIENT_ID}
-      AMO_CLIENT_SECRET: ${AMO_CLIENT_SECRET}
-      AMO_REDIRECT_URI: ${AMO_REDIRECT_URI}
-      HH_USER_AGENT: ${HH_USER_AGENT}
-
-      AMO_PIPELINE_ID_MASTER: ${AMO_PIPELINE_ID_MASTER}
-      AMO_STAGE_ID_MASTER_NEW: ${AMO_STAGE_ID_MASTER_NEW}
-      AMO_STAGE_ID_MASTER_SURVEY: ${AMO_STAGE_ID_MASTER_SURVEY}
-      AMO_PIPELINE_ID_OPERATOR: ${AMO_PIPELINE_ID_OPERATOR}
-      AMO_STAGE_ID_OPERATOR_NEW: ${AMO_STAGE_ID_OPERATOR_NEW}
-      AMO_STAGE_ID_OPERATOR_SURVEY: ${AMO_STAGE_ID_OPERATOR_SURVEY}
-      ADMIN_TOKEN: ${ADMIN_TOKEN}
-
-      AMO_CHATS_SCOPE_ID: ${AMO_CHATS_SCOPE_ID}
-      AMO_CHATS_SECRET: ${AMO_CHATS_SECRET}
-      AMO_CHATS_CHANNEL_ID: ${AMO_CHATS_CHANNEL_ID}
-      AMO_CHATS_ACCOUNT_ID: ${AMO_CHATS_ACCOUNT_ID}
-      AMO_CHATS_SENDER_USER_AMOJO_ID: ${AMO_CHATS_SENDER_USER_AMOJO_ID}
-
+      <<: *common-env
+    depends_on:
+      - rabbitmq
+      - postgres
+    networks:
+      - app
     restart: unless-stopped
 
+  rabbitmq:
+    image: rabbitmq:3-management
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-guest}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:-guest}
+    ports:
+      - "5672:5672"
+      - "15672:15672"
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    networks:
+      - app
+    restart: unless-stopped
 
+  postgres:
+    image: postgres:14
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - app
+    restart: unless-stopped
+
+volumes:
+  rabbitmq_data:
+  postgres_data:
+
+networks:
+  app:


### PR DESCRIPTION
## Summary
- add API service using uvicorn
- add RabbitMQ and Postgres services with volumes and network
- share database, queue and token env vars via YAML anchor

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c125e012dc8321b5bd83b6d32ea260