### PR TITLE
Add idempotency keys for queue tasks

### DIFF
--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import time
+import hashlib
 
 import httpx
 
@@ -95,12 +96,14 @@ async def create_lead(
     try:
         created = await client.create_leads(body)
     except ReauthRequired:
+        msg_key = f"create_lead:{payload.platform}:{payload.applicant.id}:{payload.vacancy_id}"
         await queue_client.publish_task(
             {
                 "platform": payload.platform or "unknown",
                 "action": "amo_create_lead",
                 "lead_body": body,
                 "ts": int(time.time()),
+                "msg_key": msg_key,
             }
         )
         return None, kind
@@ -157,30 +160,36 @@ async def send_invite(
     negotiation_id = payload.applicant.id
 
     if platform == "avito" and negotiation_id:
+        msg_key = f"avito:{negotiation_id}:{hashlib.sha256(invite_text_avito.encode()).hexdigest()}"
         await queue_client.publish_task({
             "platform": "avito",
             "action": "send_message",
             "external_id": negotiation_id,
             "text": invite_text_avito,
             "owner_id": payload.owner_id,
+            "msg_key": msg_key,
         })
 
     if platform == "hh" and negotiation_id:
         # 1) Перевод в этап «Первичный контакт» через action
+        state_key = f"hh:set_state:{negotiation_id}:phone_interview"
         await queue_client.publish_task({
             "platform": "hh",
             "action": "set_state",
             "negotiation_id": negotiation_id,
             "action_id": "phone_interview",   # PUT /negotiations/phone_interview/{nid}
             "owner_id": payload.owner_id,
+            "msg_key": state_key,
         })
         # 2) Сообщение кандидату (form-urlencoded, HH-User-Agent на стороне воркера)
+        msg_key = f"hh:send_message:{negotiation_id}:{hashlib.sha256(invite_text_hh.encode()).hexdigest()}"
         await queue_client.publish_task({
             "platform": "hh",
             "action": "send_message",
             "negotiation_id": negotiation_id,
             "text": invite_text_hh,
             "owner_id": payload.owner_id,
+            "msg_key": msg_key,
         })
 
     return deep_link

--- a/app/services/worker/amo.py
+++ b/app/services/worker/amo.py
@@ -11,6 +11,7 @@ from httpx import HTTPStatusError
 
 from app.adapters.amo_client import AmoClient
 from app.http_client import get_http_client
+from app.services.dedup import calc_key, check_and_store
 
 logger = logging.getLogger(__name__)
 
@@ -21,6 +22,13 @@ async def handle_amo_create_lead(payload: dict) -> None:
     Args:
         payload: Mapping with a ``lead_body`` key describing the lead to create.
     """
+
+    msg_key = payload.get("msg_key")
+    if msg_key:
+        dedup = calc_key("amo_create_lead", msg_key)
+        if not await check_and_store(dedup):
+            logger.info("amo.create_lead: duplicate %s -> skip", dedup)
+            return
 
     logger.info("amo.create_lead")
     amo = await AmoClient.create(get_http_client())

--- a/app/services/worker/avito.py
+++ b/app/services/worker/avito.py
@@ -12,6 +12,7 @@ import logging
 
 from app.adapters import avito as avito_adapt
 from app.services.common_request import perform_request
+from app.services.dedup import calc_key, check_and_store
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +24,13 @@ async def handle_avito_send_message(payload: dict) -> None:
         payload: Mapping that must contain the external message ID and text. It
             may optionally include an ``owner_id`` specifying the account.
     """
+
+    msg_key = payload.get("msg_key")
+    if msg_key:
+        dedup = calc_key("avito_send_message", msg_key)
+        if not await check_and_store(dedup):
+            logger.info("avito.send_message: duplicate %s -> skip", dedup)
+            return
 
     logger.info("avito.send_message: %s", payload.get("external_id"))
     await perform_request(

--- a/app/services/worker/hh.py
+++ b/app/services/worker/hh.py
@@ -7,6 +7,7 @@ import logging
 
 from app.adapters import hh as hh_adapt
 from app.http_client import get_http_client
+from app.services.dedup import calc_key, check_and_store
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,13 @@ async def handle_hh_send_message(payload: dict):
     nid = payload["negotiation_id"]
     text = payload["text"]
     owner_id = payload.get("owner_id")
+
+    msg_key = payload.get("msg_key")
+    if msg_key:
+        dedup = calc_key("hh_send_message", msg_key)
+        if not await check_and_store(dedup):
+            logger.info("hh.send_message: duplicate %s -> skip", dedup)
+            return
 
     logger.info("hh.send_message: %s text=%r", nid, text[:40])
     client = get_http_client()
@@ -44,6 +52,13 @@ async def handle_hh_set_state(payload: dict):
     nid = payload["negotiation_id"]
     action_id = payload["action_id"]
     owner_id = payload.get("owner_id")
+
+    msg_key = payload.get("msg_key")
+    if msg_key:
+        dedup = calc_key("hh_set_state", msg_key)
+        if not await check_and_store(dedup):
+            logger.info("hh.set_state: duplicate %s -> skip", dedup)
+            return
 
     logger.info("hh.set_state: %s -> %s", nid, action_id)
     client = get_http_client()

--- a/tests/test_lead_processor.py
+++ b/tests/test_lead_processor.py
@@ -77,6 +77,34 @@ async def test_send_invite(queue_mock):
     link = await lead_processor.send_invite(payload, 555)
     assert "start=555" in link
     assert queue_mock and queue_mock[0]["platform"] == "hh"
+    assert all("msg_key" in task for task in queue_mock)
+
+
+@pytest.mark.asyncio
+async def test_create_lead_reauth_has_msg_key(monkeypatch, queue_mock):
+    payload = IncomingPayload(
+        platform="hh",
+        vacancy_title="Title",
+        vacancy_desc="",
+        raw_text="",
+        applicant=Applicant(id="1", name="John"),
+        owner_id="own",
+        vacancy_id="vac",
+    )
+
+    monkeypatch.setattr(lead_processor, "route_kind", lambda **kw: "master")
+
+    class DummyClient:
+        async def create_leads(self, body):
+            raise lead_processor.ReauthRequired("oops")
+
+        async def add_tags(self, *a, **kw):
+            pass
+
+    lead_id, kind = await lead_processor.create_lead(payload, DummyClient())
+    assert lead_id is None
+    assert kind == "master"
+    assert queue_mock and "msg_key" in queue_mock[0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_worker_handlers.py
+++ b/tests/test_worker_handlers.py
@@ -21,3 +21,74 @@ from app.services.worker import amo as worker_amo
 )
 def test_handler_mapping(key, func):
     assert worker_rmq.HANDLERS[key] is func
+
+
+@pytest.mark.asyncio
+async def test_hh_send_message_idempotent(monkeypatch, in_memory_db):
+    calls = []
+
+    async def fake_send_message(response_id, text, employer_id, client):
+        calls.append((response_id, text))
+
+    monkeypatch.setattr(worker_hh.hh_adapt, "send_message", fake_send_message)
+    monkeypatch.setattr(worker_hh, "get_http_client", lambda: object())
+
+    payload = {"negotiation_id": "nid", "text": "hi", "msg_key": "k1"}
+    await worker_hh.handle_hh_send_message(payload)
+    await worker_hh.handle_hh_send_message(payload)
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_hh_set_state_idempotent(monkeypatch, in_memory_db):
+    calls = []
+
+    async def fake_set_state(response_id, target_state, employer_id, client):
+        calls.append((response_id, target_state))
+
+    monkeypatch.setattr(worker_hh.hh_adapt, "set_employer_state", fake_set_state)
+    monkeypatch.setattr(worker_hh, "get_http_client", lambda: object())
+
+    payload = {"negotiation_id": "nid", "action_id": "state", "msg_key": "k2"}
+    await worker_hh.handle_hh_set_state(payload)
+    await worker_hh.handle_hh_set_state(payload)
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_avito_send_message_idempotent(monkeypatch, in_memory_db):
+    calls = []
+
+    async def fake_send_message(external_id, text, owner_id=None, client=None):
+        calls.append((external_id, text))
+
+    async def fake_perform_request(func, *args, **kwargs):
+        return await func(*args, **kwargs)
+
+    monkeypatch.setattr(worker_avito.avito_adapt, "send_message", fake_send_message)
+    monkeypatch.setattr(worker_avito, "perform_request", fake_perform_request)
+
+    payload = {"external_id": "e1", "text": "t", "msg_key": "k3"}
+    await worker_avito.handle_avito_send_message(payload)
+    await worker_avito.handle_avito_send_message(payload)
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_amo_create_lead_idempotent(monkeypatch, in_memory_db):
+    calls = []
+
+    class DummyClient:
+        async def create_leads(self, body):
+            calls.append(body)
+
+    async def fake_create(cls, http_client):
+        return DummyClient()
+
+    monkeypatch.setattr(worker_amo.AmoClient, "create", classmethod(fake_create))
+    monkeypatch.setattr(worker_amo, "get_http_client", lambda: object())
+
+    payload = {"lead_body": [{"name": "n"}], "msg_key": "k4"}
+    await worker_amo.handle_amo_create_lead(payload)
+    await worker_amo.handle_amo_create_lead(payload)
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- add idempotency keys when queuing lead creation and invite messages
- skip duplicated queue tasks in amo, avito and hh workers
- cover idempotent behaviour with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12980a9988321a4fb08f09bfec4c6