### PR TITLE
Secure token storage and expand routing tests

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -8,7 +8,8 @@ needed.
 
 from functools import lru_cache
 from typing import Optional
-from pydantic import SecretStr
+from cryptography.fernet import Fernet
+from pydantic import SecretStr, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -17,6 +18,12 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(
         env_file=".env", env_file_encoding="utf-8", extra="ignore"
+    )
+
+    # Общие
+    ENVIRONMENT: str = "dev"
+    TOKEN_ENCRYPTION_KEY: SecretStr = Field(
+        default_factory=lambda: SecretStr(Fernet.generate_key().decode())
     )
 
     # RMQ

--- a/app/core/crypto.py
+++ b/app/core/crypto.py
@@ -1,0 +1,29 @@
+"""Utilities for encrypting and decrypting sensitive data."""
+
+from functools import lru_cache
+from cryptography.fernet import Fernet
+from pydantic import SecretStr
+
+from .config import get_settings
+
+
+@lru_cache
+def get_cipher() -> Fernet:
+    """Return a configured Fernet cipher based on settings."""
+    s = get_settings()
+    key_field: SecretStr = s.TOKEN_ENCRYPTION_KEY
+    key = key_field.get_secret_value().encode()
+    return Fernet(key)
+
+
+def encrypt(plaintext: str) -> str:
+    """Encrypt ``plaintext`` using Fernet cipher."""
+    return get_cipher().encrypt(plaintext.encode()).decode()
+
+
+def decrypt(token: str) -> str:
+    """Decrypt previously encrypted ``token``."""
+    return get_cipher().decrypt(token.encode()).decode()
+
+
+__all__ = ["get_cipher", "encrypt", "decrypt"]

--- a/app/core/logging_setup.py
+++ b/app/core/logging_setup.py
@@ -6,6 +6,18 @@ import sys
 from pythonjsonlogger import jsonlogger
 
 
+class SensitiveFilter(logging.Filter):  # pylint: disable=too-few-public-methods
+    """Mask sensitive fields like tokens or secrets in logs."""
+
+    KEYWORDS = ("token", "secret", "password")
+
+    def filter(self, record: logging.LogRecord) -> bool:  # pragma: no cover - simple
+        for key in list(record.__dict__):
+            if any(k in key.lower() for k in self.KEYWORDS):
+                setattr(record, key, "***")
+        return True
+
+
 def setup_logging(level: str = "INFO") -> None:
     """Configure root logger with JSON formatting.
 
@@ -24,4 +36,5 @@ def setup_logging(level: str = "INFO") -> None:
         json_ensure_ascii=False,
     )
     handler.setFormatter(formatter)
+    handler.addFilter(SensitiveFilter())
     root.handlers = [handler]

--- a/app/db/token_store.py
+++ b/app/db/token_store.py
@@ -5,9 +5,11 @@ from typing import Optional, TypedDict
 
 from sqlalchemy import insert, select, update
 from sqlalchemy.exc import SQLAlchemyError
+from cryptography.fernet import InvalidToken
 
 from .db import get_session
 from .models import Token
+from app.core.crypto import encrypt, decrypt
 
 
 class TokenData(TypedDict):
@@ -47,9 +49,16 @@ class DbTokenStore:
                 raise RuntimeError(
                     f"Token for service={self.service} owner={self.owner_id or '-'} not found"
                 )
+            access = row.access_token
+            refresh = row.refresh_token
+            try:
+                access = decrypt(access)
+                refresh = decrypt(refresh)
+            except InvalidToken:
+                pass
             return {
-                "access_token": row.access_token,
-                "refresh_token": row.refresh_token,
+                "access_token": access,
+                "refresh_token": refresh,
                 "expires_at": row.expires_at,
             }
 
@@ -67,8 +76,8 @@ class DbTokenStore:
             values = {
                 "service": self.service,
                 "owner_id": self.owner_id,
-                "access_token": data["access_token"],
-                "refresh_token": data["refresh_token"],
+                "access_token": encrypt(data["access_token"]),
+                "refresh_token": encrypt(data["refresh_token"]),
                 "expires_at": data["expires_at"],
             }
 

--- a/main.py
+++ b/main.py
@@ -26,7 +26,21 @@ from app.services.queue import rabbitmq
 log = logging.getLogger(__name__)
 setup_logging("INFO")
 
-app = FastAPI(title="Recruiting Bridge")
+settings = get_settings()
+docs_url = None
+redoc_url = None
+openapi_url = None
+if settings.ENVIRONMENT != "prod":
+    docs_url = "/docs"
+    redoc_url = "/redoc"
+    openapi_url = "/openapi.json"
+
+app = FastAPI(
+    title="Recruiting Bridge",
+    docs_url=docs_url,
+    redoc_url=redoc_url,
+    openapi_url=openapi_url,
+)
 app.add_middleware(LoggingMiddleware)
 app.add_route("/metrics", metrics_endpoint)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pytest-asyncio
 aiosqlite
 python-json-logger
 prometheus_client
+cryptography

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from app.api.utils import route_kind
+from app.api.utils import route_kind, events_from_form
 
 
 @pytest.mark.parametrize(
@@ -25,3 +25,17 @@ def test_route_kind_positive(desc, raw, expected):
 )
 def test_route_kind_negative(desc):
     assert route_kind(desc=desc) == "ignore"
+
+
+def test_route_kind_master_priority():
+    assert route_kind(desc="#оператор #мастер") == "master"
+
+
+def test_events_from_form():
+    form = {
+        "leads[status][0][id]": "1",
+        "leads[status][0][status_id]": "10",
+        "leads[status][1][id]": "2",
+        "leads[status][1][status_id]": "20",
+    }
+    assert events_from_form(form) == [(1, 10), (2, 20)]

--- a/tests/test_oauth_token_store.py
+++ b/tests/test_oauth_token_store.py
@@ -6,7 +6,7 @@ from app.api import oauth2
 from app.db.token_store import DbTokenStore
 from app.db.db import get_session
 from app.db import models
-from sqlalchemy import insert
+from sqlalchemy import insert, select
 
 
 @pytest.mark.asyncio
@@ -137,3 +137,34 @@ async def test_ensure_fresh_access_uses_cached_token(in_memory_db, monkeypatch):
 
     assert token == "cached"
     assert called is False
+
+
+@pytest.mark.asyncio
+async def test_tokens_encrypted_in_db(in_memory_db):
+    async with get_session() as s:
+        await s.execute(
+            insert(models.Token).values(
+                id=1,
+                service="svc",
+                owner_id=None,
+                access_token="x",
+                refresh_token="y",
+                expires_at=0,
+            )
+        )
+        await s.commit()
+
+    store = DbTokenStore("svc")
+    await store.save(
+        {"access_token": "plain", "refresh_token": "plainr", "expires_at": 1}
+    )
+
+    async with get_session() as s:
+        row = (
+            await s.execute(select(models.Token).where(models.Token.service == "svc"))
+        ).scalar_one()
+        assert row.access_token != "plain" and row.refresh_token != "plainr"
+
+    data = await store.load()
+    assert data["access_token"] == "plain"
+    assert data["refresh_token"] == "plainr"

--- a/tests/test_worker_mirror_messages.py
+++ b/tests/test_worker_mirror_messages.py
@@ -1,0 +1,77 @@
+import pytest
+from types import SimpleNamespace
+
+from app.services.worker import mirror as worker_mirror
+from pydantic import SecretStr
+
+
+@pytest.mark.asyncio
+async def test_handle_mirror_amo_to_tg(monkeypatch):
+    calls = []
+
+    async def fake_send(bot, uid, text):
+        calls.append((bot.token, uid, text))
+
+    class DummyBot:
+        def __init__(self, token):
+            self.token = token
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class DummySettings:
+        TELEGRAM_MASTER_BOT_TOKEN = SecretStr("m_token")
+        TELEGRAM_OPERATOR_BOT_TOKEN = SecretStr("o_token")
+
+    monkeypatch.setattr(worker_mirror, "tg_send_with_retry", fake_send)
+    monkeypatch.setattr(worker_mirror, "Bot", DummyBot)
+    monkeypatch.setattr(worker_mirror, "get_settings", lambda: DummySettings())
+
+    payload = {"bot_kind": "master", "user_id": "42", "text": "hi"}
+    await worker_mirror.handle_mirror_amo_to_tg(payload)
+
+    assert calls == [("m_token", 42, "hi")]
+
+
+@pytest.mark.asyncio
+async def test_handle_mirror_tg_to_amo(monkeypatch):
+    calls = {"note": [], "send": [], "set_conv": []}
+
+    class DummyAmo:
+        async def add_note(self, lead_id, text):
+            calls["note"].append((lead_id, text))
+
+    async def fake_create(client):
+        return DummyAmo()
+
+    async def fake_send_text_from_client(**kwargs):
+        calls["send"].append(kwargs)
+        return "cid"
+
+    async def fake_set_conversation(user_id, bot_kind, conv_id):
+        calls["set_conv"].append((user_id, bot_kind, conv_id))
+
+    async def fake_with_retry(func, *args, **kwargs):
+        return await func()
+
+    monkeypatch.setattr(worker_mirror, "AmoClient", SimpleNamespace(create=fake_create))
+    monkeypatch.setattr(worker_mirror, "send_text_from_client", fake_send_text_from_client)
+    monkeypatch.setattr(worker_mirror, "set_conversation", fake_set_conversation)
+    monkeypatch.setattr(worker_mirror, "get_http_client", lambda: object())
+    monkeypatch.setattr(worker_mirror, "with_retry", fake_with_retry)
+
+    payload = {
+        "lead_id": "1",
+        "text": "hello",
+        "tg_user_id": "2",
+        "bot_kind": "master",
+        "tg_user_name": "u",
+    }
+    await worker_mirror.handle_mirror_tg_to_amo(payload)
+
+    assert calls["note"] == [(1, "[TG->master] hello")]
+    assert calls["send"][0]["lead_id"] == 1
+    assert calls["set_conv"] == [(2, "master", "cid")]


### PR DESCRIPTION
## Summary
- encrypt tokens at rest and mask sensitive logs
- disable FastAPI docs in prod via ENVIRONMENT setting
- add tests for routing keywords, webhook parsing and message mirroring

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c12bec65c08321baf3935c58a59831