### PR TITLE
fix: use correct HH OAuth token endpoint

### DIFF
--- a/app/api/oauth.py
+++ b/app/api/oauth.py
@@ -58,7 +58,7 @@ async def hh_callback(
 
     try:
         r = await http_client.post(
-            "https://api.hh.ru/token",
+            s.HH_TOKEN_URL,
             data=data,
             headers={"Accept": "application/json"},
             timeout=30,

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -72,7 +72,7 @@ class Settings(BaseSettings):
     HH_EXPIRES_AT: int = 0
     HH_API_BASE: str = "https://api.hh.ru"
     HH_SET_STATE_PATH: str = "/negotiations/{response_id}/status"
-    HH_TOKEN_URL: str = "https://api.hh.ru/oauth/token"  # унифицировали
+    HH_TOKEN_URL: str = "https://hh.ru/oauth/token"
     HH_USER_AGENT: str = ""
 
     # Avito


### PR DESCRIPTION
## Summary
- use hh.ru domain for HH token refresh and exchange
- reference configured token URL in HH OAuth callback

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1309273448321933ce40906c20916