### PR TITLE
Handle missing HH tokens gracefully

### DIFF
--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -9,6 +9,7 @@ import httpx
 
 from app.adapters import hh as hh_adapt
 from app.adapters.amo_client import ReauthRequired
+from app.api.oauth2 import OAuth2RefreshError
 from app.core.config import get_settings
 from app.services.queue import rabbitmq, RabbitMQClient
 from app.store import save_link
@@ -38,8 +39,12 @@ async def enrich_applicant(
                     if payload.applicant.name and payload.applicant.name != "кандидат"
                     else extra.get("name") or payload.applicant.name
                 )
-        except (httpx.HTTPError, json.JSONDecodeError) as e:  # pragma: no cover
-            logger.warning("HH: обогащение кандидата %s не удалось: %s", payload.applicant.id, type(e).__name__)
+        except (httpx.HTTPError, json.JSONDecodeError, RuntimeError, OAuth2RefreshError) as e:  # pragma: no cover
+            logger.warning(
+                "HH: обогащение кандидата %s не удалось: %s",
+                payload.applicant.id,
+                type(e).__name__,
+            )
         if payload.vacancy_id and not (payload.vacancy_desc or "").strip():
             try:
                 desc = await hh_adapt.fetch_vacancy_description(
@@ -47,8 +52,12 @@ async def enrich_applicant(
                 )
                 if desc:
                     payload.vacancy_desc = desc
-            except (httpx.HTTPError, json.JSONDecodeError) as e:  # pragma: no cover
-                logger.warning("HH: описание вакансии %s не получено: %s", payload.vacancy_id, type(e).__name__)
+            except (httpx.HTTPError, json.JSONDecodeError, RuntimeError, OAuth2RefreshError) as e:  # pragma: no cover
+                logger.warning(
+                    "HH: описание вакансии %s не получено: %s",
+                    payload.vacancy_id,
+                    type(e).__name__,
+                )
     return payload
 
 

--- a/tests/test_lead_processor.py
+++ b/tests/test_lead_processor.py
@@ -30,6 +30,25 @@ async def test_enrich_applicant(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_enrich_applicant_missing_token(monkeypatch):
+    payload = IncomingPayload(
+        platform="hh",
+        owner_id="o1",
+        applicant=Applicant(id="1", name="кандидат"),
+    )
+
+    async def fail_fetch(applicant_id, owner_id, http_client):
+        raise RuntimeError("missing token")
+
+    monkeypatch.setattr(lead_processor.hh_adapt, "fetch_applicant_details", fail_fetch)
+
+    result = await lead_processor.enrich_applicant(payload, None)
+    assert result.applicant.phone is None
+    assert result.applicant.city is None
+    assert result.applicant.name == "кандидат"
+
+
+@pytest.mark.asyncio
 async def test_create_lead(monkeypatch):
     payload = IncomingPayload(
         platform="hh",


### PR DESCRIPTION
## Summary
- avoid internal errors when HH token is missing by catching RuntimeError and OAuth2RefreshError during applicant enrichment
- add regression test for missing HH token scenario

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1328f3a0083219ddcdda8e8b285b8