### PR TITLE
Reduce sensitive webhook logging

### DIFF
--- a/app/api/_webhook_common.py
+++ b/app/api/_webhook_common.py
@@ -35,7 +35,8 @@ async def process_job_board_webhook(
     try:
         payload = parse_payload(raw)
     except ValueError as exc:
-        logger.warning("%s webhook: %s; payload=%s", platform, exc, raw)
+        logger.warning("%s webhook: %s", platform, exc)
+        logger.debug("%s webhook body: %s", platform, raw)
         return {"ok": True, "skipped": True}
 
     try:

--- a/app/api/hh_incoming.py
+++ b/app/api/hh_incoming.py
@@ -1,6 +1,8 @@
 """Endpoints handling incoming HeadHunter webhooks."""
 
+import json
 import logging
+
 import httpx
 from fastapi import APIRouter, Depends, Request
 
@@ -23,10 +25,30 @@ async def webhook_hh(
     webhook processor along with the HeadHunter payload parser.
     """
     raw = await request.body()
+
+    # Log a short summary at info level and keep the full body for debug logs.
+    nid = None
+    ts = None
     try:
-        log.info("HH webhook received raw: %s", raw.decode("utf-8"))
+        data = json.loads(raw.decode("utf-8", "ignore") or "{}")
+        obj = (
+            data.get("object")
+            or data.get("negotiation")
+            or data.get("response")
+            or data.get("payload")
+            or {}
+        )
+        nid = (
+            obj.get("topic_id")
+            or obj.get("id")
+            or obj.get("negotiation_id")
+            or data.get("response_id")
+        )
+        ts = data.get("event_time") or data.get("timestamp")
     except Exception:
-        log.info("HH webhook received raw (binary): %s", raw)
+        pass
+    log.info("HH webhook received nid=%s ts=%s", nid, ts)
+    log.debug("HH webhook body: %s", raw.decode("utf-8", "ignore"))
     return await process_job_board_webhook("hh", raw, http_client, parse_hh_payload)
 
 


### PR DESCRIPTION
## Summary
- log only HeadHunter webhook summary at info level; move full body to debug
- avoid logging raw body for malformed job board webhooks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c13c49597c8321a7d493657dd5fb75