### PR TITLE
Refactor survey AmoCRM updates to task queue

### DIFF
--- a/app/adapters/amo_client.py
+++ b/app/adapters/amo_client.py
@@ -164,3 +164,10 @@ class AmoClient:
         url = f"{self.base}/api/v4/contacts/chats"
         body = [{"contact_id": int(contact_id), "chat_id": str(chat_id)}]
         return await self._request("POST", url, json=body)
+
+    async def get_pipeline_statuses(self, pipeline_id: int) -> list[dict]:
+        """Return statuses for the specified pipeline."""
+
+        url = f"{self.base}/api/v4/leads/pipelines/{int(pipeline_id)}"
+        data = await self._request("GET", url)
+        return (data.get("_embedded") or {}).get("statuses") or []

--- a/app/services/hh_autofill.py
+++ b/app/services/hh_autofill.py
@@ -10,7 +10,7 @@ import httpx
 from sqlalchemy.exc import SQLAlchemyError
 
 from app.core.config import get_settings
-from app.db.token_store import DbTokenStore
+from app.adapters.amo_client import AmoClient
 from app.services.hh_mapping import load as hh_map_load, set_all as hh_map_set
 
 log = logging.getLogger(__name__)
@@ -37,25 +37,13 @@ async def _fetch_pipeline_statuses(
     client: httpx.AsyncClient,
 ) -> list[dict]:
     try:
-        tok = await DbTokenStore("amo").load()
+        amo = await AmoClient.create(client)
     except (RuntimeError, SQLAlchemyError) as e:
         log.warning("hh-autofill: no amo token: %s", e)
         return []
 
-    s = get_settings()
-    url = s.AMO_BASE_URL.rstrip("/") + f"/api/v4/leads/pipelines/{pipeline_id}"
     try:
-        r = await client.get(
-            url,
-            headers={
-                "Authorization": f"Bearer {tok['access_token']}",
-                "Accept": "application/json",
-            },
-            timeout=20,
-        )
-        r.raise_for_status()
-        pj = r.json() or {}
-        return (pj.get("_embedded") or {}).get("statuses") or []
+        return await amo.get_pipeline_statuses(int(pipeline_id))
     except (httpx.HTTPError, ValueError) as e:
         log.warning("hh-autofill: cannot fetch pipeline %s: %s", pipeline_id, e)
         return []

--- a/app/services/survey.py
+++ b/app/services/survey.py
@@ -6,9 +6,6 @@ prompts and summaries for a short survey and formatting Telegram identities.
 
 from aiogram.types import Message
 
-from app.core.config import get_settings
-from app.services.queue import rabbitmq, RabbitMQClient
-
 
 def parse_start_arg(text: str) -> int | None:
     """Extract integer ``/start`` argument from ``text``.
@@ -56,39 +53,3 @@ def pretty_tg_identity(m: Message) -> str:
     if not user:
         return "id:unknown"
     return f"@{user.username}" if user.username else f"id:{user.id}"
-
-
-async def mark_went_to_bot_async(
-    lead_id: int,
-    bot_kind: str,
-    identity: str,
-    queue_client: RabbitMQClient = rabbitmq,
-):
-    """Переносим на воркер: добавляем заметку и тег через RMQ."""
-    s = get_settings()
-
-    await queue_client.publish_task({
-        "platform": "amo",
-        "action": "amo_add_note",
-        "lead_id": lead_id,
-        "text": f"[{bot_kind}] Кандидат перешёл в бота (TG {identity}).",
-    })
-    await queue_client.publish_task({
-        "platform": "amo",
-        "action": "amo_add_tags",
-        "lead_id": lead_id,
-        "tags": [s.AMO_TAG_WENT_TO_BOT],
-    })
-    stage_id = (
-        s.AMO_STAGE_ID_MASTER_NEW
-        if bot_kind == "master"
-        else s.AMO_STAGE_ID_OPERATOR_NEW
-    )
-    await queue_client.publish_task(
-        {
-            "platform": "amo",
-            "action": "amo_update_status",
-            "lead_id": lead_id,
-            "status_id": stage_id,
-        }
-    )

--- a/app/services/survey_service.py
+++ b/app/services/survey_service.py
@@ -14,7 +14,13 @@ from app.store_survey import (
     store_answer_and_advance,
     delete_survey,
 )
-from app.services.survey import mark_went_to_bot_async
+
+
+async def _publish_tasks(queue_client: RabbitMQClient, tasks: list[dict]) -> None:
+    """Publish a sequence of tasks to the queue client."""
+
+    for payload in tasks:
+        await queue_client.publish_task(payload)
 
 
 class SurveyService:
@@ -27,7 +33,35 @@ class SurveyService:
     async def start(self, user_id: int, bot_kind: str, lead_id: int, identity: str) -> None:
         """Start or reset survey and mark that user went to bot."""
         await start_or_reset_survey(user_id, bot_kind, lead_id)
-        await mark_went_to_bot_async(lead_id, bot_kind, identity, self.queue_client)
+        s = get_settings()
+        stage_id = (
+            s.AMO_STAGE_ID_MASTER_NEW
+            if bot_kind == "master"
+            else s.AMO_STAGE_ID_OPERATOR_NEW
+        )
+        await _publish_tasks(
+            self.queue_client,
+            [
+                {
+                    "platform": "amo",
+                    "action": "amo_add_note",
+                    "lead_id": lead_id,
+                    "text": f"[{bot_kind}] Кандидат перешёл в бота (TG {identity}).",
+                },
+                {
+                    "platform": "amo",
+                    "action": "amo_add_tags",
+                    "lead_id": lead_id,
+                    "tags": [s.AMO_TAG_WENT_TO_BOT],
+                },
+                {
+                    "platform": "amo",
+                    "action": "amo_update_status",
+                    "lead_id": lead_id,
+                    "status_id": stage_id,
+                },
+            ],
+        )
 
     async def get(self, user_id: int, bot_kind: str):
         """Fetch the current survey state for the given user and bot."""
@@ -40,29 +74,32 @@ class SurveyService:
     async def finish(self, user_id: int, bot_kind: str, lead_id: int, summary: str) -> None:
         """Finalize the survey and send results to the queue client."""
         s = get_settings()
-        await self.queue_client.publish_task({
-            "platform": "amo",
-            "action": "amo_add_tags",
-            "lead_id": lead_id,
-            "tags": [s.AMO_TAG_SURVEY_DONE],
-        })
-        await self.queue_client.publish_task({
-            "platform": "amo",
-            "action": "amo_add_note",
-            "lead_id": lead_id,
-            "text": f"[{bot_kind}] {summary}",
-        })
         stage_id = (
             s.AMO_STAGE_ID_MASTER_SURVEY
             if bot_kind == "master"
             else s.AMO_STAGE_ID_OPERATOR_SURVEY
         )
-        await self.queue_client.publish_task(
-            {
-                "platform": "amo",
-                "action": "amo_update_status",
-                "lead_id": lead_id,
-                "status_id": stage_id,
-            }
+        await _publish_tasks(
+            self.queue_client,
+            [
+                {
+                    "platform": "amo",
+                    "action": "amo_add_tags",
+                    "lead_id": lead_id,
+                    "tags": [s.AMO_TAG_SURVEY_DONE],
+                },
+                {
+                    "platform": "amo",
+                    "action": "amo_add_note",
+                    "lead_id": lead_id,
+                    "text": f"[{bot_kind}] {summary}",
+                },
+                {
+                    "platform": "amo",
+                    "action": "amo_update_status",
+                    "lead_id": lead_id,
+                    "status_id": stage_id,
+                },
+            ],
         )
         await delete_survey(user_id, bot_kind)

--- a/tests/test_adapters_amo_client.py
+++ b/tests/test_adapters_amo_client.py
@@ -40,3 +40,27 @@ async def test_update_status(monkeypatch):
     assert captured["method"] == "PATCH"
     assert captured["url"].path == "/api/v4/leads"
     assert captured["json"] == [{"id": 123, "status_id": 456}]
+
+
+@pytest.mark.asyncio
+async def test_get_pipeline_statuses(monkeypatch):
+    class DummySettings:
+        AMO_BASE_URL = "https://example.com"
+
+    monkeypatch.setattr(amo_client_module, "get_settings", lambda: DummySettings())
+
+    tokens = {"access_token": "acc", "refresh_token": "ref", "expires_at": 10**10}
+    captured = {}
+
+    def handler(request):
+        captured["method"] = request.method
+        captured["url"] = request.url
+        return httpx.Response(200, json={"_embedded": {"statuses": [{"id": 1}]}})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        amo = AmoClient(tokens, DummyStore(), client)
+        statuses = await amo.get_pipeline_statuses(321)
+
+    assert captured["method"] == "GET"
+    assert captured["url"].path == "/api/v4/leads/pipelines/321"
+    assert statuses == [{"id": 1}]


### PR DESCRIPTION
## Summary
- publish amo tag and status changes via queue in survey service
- centralize AmoCRM pipeline status lookup through AmoClient
- test AmoClient pipeline status helper

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c13d3be7a08321b3b57fceca7db1d9