### PR TITLE
Add idempotent helper for worker operations

### DIFF
--- a/app/services/dedup.py
+++ b/app/services/dedup.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import hashlib
-from typing import Any, cast
+import logging
+from typing import Any, Awaitable, Callable, cast
 
 from sqlalchemy import text
 from sqlalchemy.dialects.postgresql import insert
@@ -11,6 +12,8 @@ from sqlalchemy.engine import CursorResult
 
 from app.db import get_session
 from app.db.models import EventDedup
+
+logger = logging.getLogger(__name__)
 
 
 def calc_key(source: str, payload: str | bytes) -> str:
@@ -43,3 +46,25 @@ async def cleanup_older_than(seconds: int = 72 * 3600) -> int:
         res = await s.execute(q, {"sec": seconds})
         await s.commit()
         return cast(CursorResult[Any], res).rowcount or 0
+
+
+async def once(dedup_key: str, ttl: int, operation: Callable[[], Awaitable[Any]]) -> bool:
+    """Run ``operation`` once for ``dedup_key`` within a TTL window.
+
+    The key is stored using :func:`check_and_store`.  If the key was already
+    present, the operation is skipped and ``False`` is returned.
+
+    Args:
+        dedup_key: Unique identifier for the operation.
+        ttl: Time-to-live for deduplication entries, in seconds.
+        operation: Coroutine function to execute when the key is new.
+
+    Returns:
+        ``True`` if the operation was executed, ``False`` otherwise.
+    """
+
+    if not await check_and_store(dedup_key):
+        logger.info("once: duplicate %s -> skip", dedup_key)
+        return False
+    await operation()
+    return True

--- a/app/services/worker/amo.py
+++ b/app/services/worker/amo.py
@@ -11,7 +11,7 @@ from httpx import HTTPStatusError
 
 from app.adapters.amo_client import AmoClient
 from app.http_client import get_http_client
-from app.services.dedup import calc_key, check_and_store
+from app.services.dedup import calc_key, once
 
 logger = logging.getLogger(__name__)
 
@@ -24,15 +24,18 @@ async def handle_amo_create_lead(payload: dict) -> None:
     """
 
     msg_key = payload.get("msg_key")
+
+    async def _op():
+        logger.info("amo.create_lead")
+        amo = await AmoClient.create(get_http_client())
+        await amo.create_leads(payload["lead_body"])
+
     if msg_key:
         dedup = calc_key("amo_create_lead", msg_key)
-        if not await check_and_store(dedup):
-            logger.info("amo.create_lead: duplicate %s -> skip", dedup)
+        if not await once(dedup, 72 * 3600, _op):
             return
-
-    logger.info("amo.create_lead")
-    amo = await AmoClient.create(get_http_client())
-    await amo.create_leads(payload["lead_body"])
+    else:
+        await _op()
 
 
 async def handle_amo_add_note(payload: dict) -> None:

--- a/app/services/worker/avito.py
+++ b/app/services/worker/avito.py
@@ -12,7 +12,7 @@ import logging
 
 from app.adapters import avito as avito_adapt
 from app.services.common_request import perform_request
-from app.services.dedup import calc_key, check_and_store
+from app.services.dedup import calc_key, once
 
 logger = logging.getLogger(__name__)
 
@@ -26,19 +26,22 @@ async def handle_avito_send_message(payload: dict) -> None:
     """
 
     msg_key = payload.get("msg_key")
+
+    async def _op():
+        logger.info("avito.send_message: %s", payload.get("external_id"))
+        await perform_request(
+            avito_adapt.send_message,
+            payload["external_id"],
+            payload["text"],
+            owner_id=payload.get("owner_id"),
+        )
+
     if msg_key:
         dedup = calc_key("avito_send_message", msg_key)
-        if not await check_and_store(dedup):
-            logger.info("avito.send_message: duplicate %s -> skip", dedup)
+        if not await once(dedup, 72 * 3600, _op):
             return
-
-    logger.info("avito.send_message: %s", payload.get("external_id"))
-    await perform_request(
-        avito_adapt.send_message,
-        payload["external_id"],
-        payload["text"],
-        owner_id=payload.get("owner_id"),
-    )
+    else:
+        await _op()
 
 
 async def handle_avito_mark_read(payload: dict) -> None:

--- a/app/services/worker/hh.py
+++ b/app/services/worker/hh.py
@@ -7,7 +7,7 @@ import logging
 
 from app.adapters import hh as hh_adapt
 from app.http_client import get_http_client
-from app.services.dedup import calc_key, check_and_store
+from app.services.dedup import calc_key, once
 
 logger = logging.getLogger(__name__)
 
@@ -25,20 +25,23 @@ async def handle_hh_send_message(payload: dict):
     owner_id = payload.get("owner_id")
 
     msg_key = payload.get("msg_key")
+
+    async def _op():
+        logger.info("hh.send_message: %s text=%r", nid, text[:40])
+        client = get_http_client()
+        await hh_adapt.send_message(
+            response_id=nid,
+            text=text,
+            employer_id=owner_id,
+            client=client,
+        )
+
     if msg_key:
         dedup = calc_key("hh_send_message", msg_key)
-        if not await check_and_store(dedup):
-            logger.info("hh.send_message: duplicate %s -> skip", dedup)
+        if not await once(dedup, 72 * 3600, _op):
             return
-
-    logger.info("hh.send_message: %s text=%r", nid, text[:40])
-    client = get_http_client()
-    await hh_adapt.send_message(
-        response_id=nid,
-        text=text,
-        employer_id=owner_id,
-        client=client,
-    )
+    else:
+        await _op()
 
 
 async def handle_hh_set_state(payload: dict):
@@ -54,17 +57,20 @@ async def handle_hh_set_state(payload: dict):
     owner_id = payload.get("owner_id")
 
     msg_key = payload.get("msg_key")
+
+    async def _op():
+        logger.info("hh.set_state: %s -> %s", nid, action_id)
+        client = get_http_client()
+        await hh_adapt.set_employer_state(
+            response_id=nid,
+            target_state=action_id,
+            employer_id=owner_id,
+            client=client,
+        )
+
     if msg_key:
         dedup = calc_key("hh_set_state", msg_key)
-        if not await check_and_store(dedup):
-            logger.info("hh.set_state: duplicate %s -> skip", dedup)
+        if not await once(dedup, 72 * 3600, _op):
             return
-
-    logger.info("hh.set_state: %s -> %s", nid, action_id)
-    client = get_http_client()
-    await hh_adapt.set_employer_state(
-        response_id=nid,
-        target_state=action_id,
-        employer_id=owner_id,
-        client=client,
-    )
+    else:
+        await _op()


### PR DESCRIPTION
## Summary
- add `once` helper to run operations only once per key
- use `once` in amo, avito and hh workers for idempotent message handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c14406fdd083219cd4ad5b44b8dea8