### PR TITLE
feat: validate RabbitMQ tasks with Pydantic events

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -76,7 +76,7 @@ async def rmq_test(
     """Publish a test message to RabbitMQ."""
 
     msg = (payload or {}).get("msg", "hi")
-    await queue_client.publish_task({"platform": "debug", "action": "echo", "msg": msg})
+    await queue_client.publish_task({"platform": "debug", "action": "echo", "payload": {"msg": msg}})
     return {"ok": True}
 
 
@@ -137,7 +137,7 @@ async def hh_autofill_admin(
 ):
     """Queue a task that triggers HH autofill."""
 
-    await queue_client.publish_task({"platform": "system", "action": "hh_autofill"})
+    await queue_client.publish_task({"platform": "system", "action": "hh_autofill", "payload": {}})
     return {"ok": True, "queued": True}
 
 

--- a/app/api/amo_webhooks.py
+++ b/app/api/amo_webhooks.py
@@ -60,8 +60,10 @@ async def handle_avito_event(
         {
             "platform": "avito",
             "action": "mark_read",
-            "external_id": ext_id,
-            "owner_id": owner_id,
+            "payload": {
+                "external_id": ext_id,
+                "owner_id": owner_id,
+            },
         }
     )
 

--- a/app/api/api_amochats.py
+++ b/app/api/api_amochats.py
@@ -167,9 +167,11 @@ async def publish_links(
             {
                 "platform": "mirror",
                 "action": "amo_to_tg",
-                "bot_kind": ln.bot_kind,
-                "user_id": ln.user_id,
-                "text": text,
+                "payload": {
+                    "bot_kind": ln.bot_kind,
+                    "user_id": ln.user_id,
+                    "text": text,
+                },
                 "msg_key": key_src,
             }
         )

--- a/app/api/oauth.py
+++ b/app/api/oauth.py
@@ -321,7 +321,7 @@ async def amo_callback(
         )
 
         try:
-            await queue_client.publish_task({"platform": "system", "action": "hh_autofill"})
+            await queue_client.publish_task({"platform": "system", "action": "hh_autofill", "payload": {}})
             logger.info("Queued hh_autofill after amo oauth")
         except aio_exc.AMQPError:
             logger.exception("Failed to queue hh_autofill after amo oauth")

--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -11,6 +11,10 @@ from app.http_client import get_http_client
 
 async def handle_task(p: dict, attempts: int = 0):
     """Process background tasks based on platform and action."""
+    payload = p.get("payload") or {}
+    if p.get("msg_key") is not None:
+        payload.setdefault("msg_key", p["msg_key"])
+
     if p.get("platform") == "system" and p.get("action") == "hh_autofill":
 
         tok = await DbTokenStore("amo").load()
@@ -25,48 +29,48 @@ async def handle_task(p: dict, attempts: int = 0):
         return
 
     if p.get("platform") == "hh" and p.get("action") == "set_state":
-        nid = p.get("negotiation_id") or p.get("external_id")
-        action_id = p.get("action_id") or p.get("target_state")
+        nid = payload.get("negotiation_id") or payload.get("external_id")
+        action_id = payload.get("action_id") or payload.get("target_state")
         if not nid or not action_id:
             raise RuntimeError(f"hh.set_state: missing nid/action_id in {p}")
         await hh_adapt.set_employer_state(
             response_id=nid,
             target_state=action_id,
-            employer_id=p.get("owner_id"),
+            employer_id=payload.get("owner_id"),
             client=get_http_client(),
         )
         return
     if p.get("platform") == "hh" and p.get("action") == "send_message":
-        nid = p.get("negotiation_id") or p.get("external_id")
+        nid = payload.get("negotiation_id") or payload.get("external_id")
         if not nid:
             raise RuntimeError(f"hh.send_message: missing nid in {p}")
         await hh_adapt.send_message(
             response_id=nid,
-            text=p.get("text") or "",
-            employer_id=p.get("owner_id"),
+            text=payload.get("text") or "",
+            employer_id=payload.get("owner_id"),
             client=get_http_client(),
         )
 
     if p["platform"] == "avito" and p["action"] == "mark_read":
         await avito_adapt.mark_read(
-            p["external_id"],
-            owner_id=p.get("owner_id"),
+            payload["external_id"],
+            owner_id=payload.get("owner_id"),
             client=get_http_client(),
         )
         return
 
     if p["platform"] == "avito" and p["action"] == "send_message":
         await avito_adapt.send_message(
-            p["external_id"],
-            p.get("text") or "",
-            owner_id=p.get("owner_id"),
+            payload["external_id"],
+            payload.get("text") or "",
+            owner_id=payload.get("owner_id"),
             client=get_http_client(),
         )
         return
 
     if p["platform"] == "amo" and p["action"] == "amo_create_lead":
         amo = await AmoClient.create(get_http_client())
-        await amo.create_leads(p["lead_body"])
+        await amo.create_leads(payload["lead_body"])
         return
 
     raise RuntimeError(f"Unknown task: {p}")

--- a/app/events.py
+++ b/app/events.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+"""Pydantic schemas describing tasks published to RabbitMQ."""
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class EventBase(BaseModel):
+    """Common fields for all queue events."""
+
+    platform: str
+    action: str
+    payload: BaseModel
+    msg_key: str | None = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class LeadCreatedPayload(BaseModel):
+    """Payload for creating a lead in amoCRM."""
+
+    lead_body: list[dict[str, Any]]
+    ts: int
+
+
+class LeadCreated(EventBase):
+    """Event requesting creation of a lead in amoCRM."""
+
+    action: Literal["amo_create_lead"] = "amo_create_lead"
+    payload: LeadCreatedPayload
+
+
+class SendMessagePayload(BaseModel):
+    """Payload for sending a message to a candidate."""
+
+    external_id: str
+    text: str
+    owner_id: str | None = None
+
+
+class SendMessage(EventBase):
+    """Event requesting to send a message on an external platform."""
+
+    action: Literal["send_message"] = "send_message"
+    payload: SendMessagePayload
+
+
+class UpdateStatusPayload(BaseModel):
+    """Payload for updating status on a platform or in amoCRM."""
+
+    external_id: str | None = None
+    target_state: str | None = None
+    action_id: str | None = None
+    lead_id: int | None = None
+    status_id: int | None = None
+    owner_id: str | None = None
+
+
+class UpdateStatus(EventBase):
+    """Event requesting a status update."""
+
+    action: Literal["set_state", "amo_update_status"]
+    payload: UpdateStatusPayload
+
+
+__all__ = [
+    "LeadCreated",
+    "LeadCreatedPayload",
+    "SendMessage",
+    "SendMessagePayload",
+    "UpdateStatus",
+    "UpdateStatusPayload",
+]

--- a/app/services/hh_status_sync.py
+++ b/app/services/hh_status_sync.py
@@ -15,6 +15,7 @@ from app.adapters.amo_client import AmoClient
 from app.core.config import get_settings
 from app.services.hh_mapping import get as hh_map_get
 from app.services.queue import RabbitMQClient, rabbitmq
+from app.events import UpdateStatus, UpdateStatusPayload
 from app.api.utils import (
     REFUSAL_TEXT_TO_HH,
     is_refusal_code,
@@ -86,15 +87,16 @@ async def sync_hh_status(
                 except httpx.HTTPError:
                     logger.warning("Failed to copy refusal text")
 
-    await queue_client.publish_task(
-        {
-            "platform": "hh",
-            "action": "set_state",
-            "external_id": ext_id,
-            "target_state": final_state,
-            "owner_id": owner_id,
-        }
+    event = UpdateStatus(
+        platform="hh",
+        action="set_state",
+        payload=UpdateStatusPayload(
+            external_id=ext_id,
+            target_state=final_state,
+            owner_id=owner_id,
+        ),
     )
+    await queue_client.publish_task(event.model_dump(exclude_none=True))
 
 
 __all__ = ["sync_hh_status"]

--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -12,6 +12,14 @@ from app.adapters.amo_client import ReauthRequired
 from app.api.oauth2 import OAuth2RefreshError
 from app.core.config import get_settings
 from app.services.queue import rabbitmq, RabbitMQClient
+from app.events import (
+    LeadCreated,
+    LeadCreatedPayload,
+    SendMessage,
+    SendMessagePayload,
+    UpdateStatus,
+    UpdateStatusPayload,
+)
 from app.store import save_link
 from app.api.utils import route_kind
 from app.services import amo_lead_enrichment
@@ -105,16 +113,15 @@ async def create_lead(
     try:
         created = await client.create_leads(body)
     except ReauthRequired:
-        msg_key = f"create_lead:{payload.platform}:{payload.applicant.id}:{payload.vacancy_id}"
-        await queue_client.publish_task(
-            {
-                "platform": payload.platform or "unknown",
-                "action": "amo_create_lead",
-                "lead_body": body,
-                "ts": int(time.time()),
-                "msg_key": msg_key,
-            }
+        msg_key = (
+            f"create_lead:{payload.platform}:{payload.applicant.id}:{payload.vacancy_id}"
         )
+        event = LeadCreated(
+            platform=payload.platform or "unknown",
+            payload=LeadCreatedPayload(lead_body=body, ts=int(time.time())),
+            msg_key=msg_key,
+        )
+        await queue_client.publish_task(event.model_dump(exclude_none=True))
         return None, kind
 
     lead_id = created["_embedded"]["leads"][0]["id"]
@@ -169,37 +176,48 @@ async def send_invite(
     negotiation_id = payload.applicant.id
 
     if platform == "avito" and negotiation_id:
-        msg_key = f"avito:{negotiation_id}:{hashlib.sha256(invite_text_avito.encode()).hexdigest()}"
-        await queue_client.publish_task({
-            "platform": "avito",
-            "action": "send_message",
-            "external_id": negotiation_id,
-            "text": invite_text_avito,
-            "owner_id": payload.owner_id,
-            "msg_key": msg_key,
-        })
+        msg_key = (
+            f"avito:{negotiation_id}:{hashlib.sha256(invite_text_avito.encode()).hexdigest()}"
+        )
+        event = SendMessage(
+            platform="avito",
+            payload=SendMessagePayload(
+                external_id=negotiation_id,
+                text=invite_text_avito,
+                owner_id=payload.owner_id,
+            ),
+            msg_key=msg_key,
+        )
+        await queue_client.publish_task(event.model_dump(exclude_none=True))
 
     if platform == "hh" and negotiation_id:
         # 1) Перевод в этап «Первичный контакт» через action
         state_key = f"hh:set_state:{negotiation_id}:phone_interview"
-        await queue_client.publish_task({
-            "platform": "hh",
-            "action": "set_state",
-            "negotiation_id": negotiation_id,
-            "action_id": "phone_interview",   # PUT /negotiations/phone_interview/{nid}
-            "owner_id": payload.owner_id,
-            "msg_key": state_key,
-        })
+        upd_event = UpdateStatus(
+            platform="hh",
+            action="set_state",
+            payload=UpdateStatusPayload(
+                external_id=negotiation_id,
+                action_id="phone_interview",  # PUT /negotiations/phone_interview/{nid}
+                owner_id=payload.owner_id,
+            ),
+            msg_key=state_key,
+        )
+        await queue_client.publish_task(upd_event.model_dump(exclude_none=True))
         # 2) Сообщение кандидату (form-urlencoded, HH-User-Agent на стороне воркера)
-        msg_key = f"hh:send_message:{negotiation_id}:{hashlib.sha256(invite_text_hh.encode()).hexdigest()}"
-        await queue_client.publish_task({
-            "platform": "hh",
-            "action": "send_message",
-            "negotiation_id": negotiation_id,
-            "text": invite_text_hh,
-            "owner_id": payload.owner_id,
-            "msg_key": msg_key,
-        })
+        msg_key = (
+            f"hh:send_message:{negotiation_id}:{hashlib.sha256(invite_text_hh.encode()).hexdigest()}"
+        )
+        msg_event = SendMessage(
+            platform="hh",
+            payload=SendMessagePayload(
+                external_id=negotiation_id,
+                text=invite_text_hh,
+                owner_id=payload.owner_id,
+            ),
+            msg_key=msg_key,
+        )
+        await queue_client.publish_task(msg_event.model_dump(exclude_none=True))
 
     return deep_link
 

--- a/app/services/survey_service.py
+++ b/app/services/survey_service.py
@@ -45,20 +45,26 @@ class SurveyService:
                 {
                     "platform": "amo",
                     "action": "amo_add_note",
-                    "lead_id": lead_id,
-                    "text": f"[{bot_kind}] Кандидат перешёл в бота (TG {identity}).",
+                    "payload": {
+                        "lead_id": lead_id,
+                        "text": f"[{bot_kind}] Кандидат перешёл в бота (TG {identity}).",
+                    },
                 },
                 {
                     "platform": "amo",
                     "action": "amo_add_tags",
-                    "lead_id": lead_id,
-                    "tags": [s.AMO_TAG_WENT_TO_BOT],
+                    "payload": {
+                        "lead_id": lead_id,
+                        "tags": [s.AMO_TAG_WENT_TO_BOT],
+                    },
                 },
                 {
                     "platform": "amo",
                     "action": "amo_update_status",
-                    "lead_id": lead_id,
-                    "status_id": stage_id,
+                    "payload": {
+                        "lead_id": lead_id,
+                        "status_id": stage_id,
+                    },
                 },
             ],
         )
@@ -85,20 +91,26 @@ class SurveyService:
                 {
                     "platform": "amo",
                     "action": "amo_add_tags",
-                    "lead_id": lead_id,
-                    "tags": [s.AMO_TAG_SURVEY_DONE],
+                    "payload": {
+                        "lead_id": lead_id,
+                        "tags": [s.AMO_TAG_SURVEY_DONE],
+                    },
                 },
                 {
                     "platform": "amo",
                     "action": "amo_add_note",
-                    "lead_id": lead_id,
-                    "text": f"[{bot_kind}] {summary}",
+                    "payload": {
+                        "lead_id": lead_id,
+                        "text": f"[{bot_kind}] {summary}",
+                    },
                 },
                 {
                     "platform": "amo",
                     "action": "amo_update_status",
-                    "lead_id": lead_id,
-                    "status_id": stage_id,
+                    "payload": {
+                        "lead_id": lead_id,
+                        "status_id": stage_id,
+                    },
                 },
             ],
         )

--- a/app/services/worker/mirror.py
+++ b/app/services/worker/mirror.py
@@ -18,6 +18,7 @@ from app.core.retry import with_retry
 from app.http_client import get_http_client
 from app.adapters.amo_client import AmoClient
 from app.services.queue import rabbitmq
+from app.events import UpdateStatus, UpdateStatusPayload
 
 logger = logging.getLogger(__name__)
 
@@ -191,14 +192,15 @@ async def handle_mirror_bot_to_amo(payload: dict):
         if status_id is not None:
             dedup = calc_key("chat_status", f"{lead_id}:{status_id}")
             if await check_and_store(dedup):
-                await rabbitmq.publish_task(
-                    {
-                        "platform": "amo",
-                        "action": "amo_update_status",
-                        "lead_id": int(lead_id),
-                        "status_id": int(status_id),
-                    }
+                event = UpdateStatus(
+                    platform="amo",
+                    action="amo_update_status",
+                    payload=UpdateStatusPayload(
+                        lead_id=int(lead_id),
+                        status_id=int(status_id),
+                    ),
                 )
+                await rabbitmq.publish_task(event.model_dump(exclude_none=True))
 
     if not conv_id:
         raise RuntimeError("bot_to_amo: no conversation_id and no lead_id to create one")

--- a/app/services/worker_rmq.py
+++ b/app/services/worker_rmq.py
@@ -79,7 +79,10 @@ async def handle(
         handler = HANDLERS.get((plat, act))
         if not handler:
             raise RuntimeError(f"unknown task: {payload}")
-        await handler(payload)
+        data = payload.get("payload") or {}
+        if payload.get("msg_key") is not None:
+            data.setdefault("msg_key", payload["msg_key"])
+        await handler(data)
 
     except ReauthRequired as err:
         logger.warning("ReauthRequired: %s", err)

--- a/app/tg_router.py
+++ b/app/tg_router.py
@@ -37,11 +37,13 @@ def make_router(bot_kind: str, queue_client: RabbitMQClient = rabbitmq) -> Dispa
             {
                 "platform": "mirror",
                 "action": "bot_to_amo",
-                "text": text,
-                "user_id": user.id,
-                "user_name": user.username,
-                "conversation_id": conv_id,
-                "lead_id": lead_id,
+                "payload": {
+                    "text": text,
+                    "user_id": user.id,
+                    "user_name": user.username,
+                    "conversation_id": conv_id,
+                    "lead_id": lead_id,
+                },
                 "msg_key": msg_key,
             }
         )
@@ -107,12 +109,14 @@ def make_router(bot_kind: str, queue_client: RabbitMQClient = rabbitmq) -> Dispa
             {
                 "platform": "mirror",
                 "action": "tg_to_amo",
-                "lead_id": lead_id,
-                "text": text,
-                "tg_user_id": user.id,
-                "tg_user_name": user.username,
-                "conversation_id": conv_id,
-                "bot_kind": bot_kind,
+                "payload": {
+                    "lead_id": lead_id,
+                    "text": text,
+                    "tg_user_id": user.id,
+                    "tg_user_name": user.username,
+                    "conversation_id": conv_id,
+                    "bot_kind": bot_kind,
+                },
                 "msg_key": msg_key,
             }
         )

--- a/main.py
+++ b/main.py
@@ -133,7 +133,7 @@ async def on_startup():
         amo_tok = await DbTokenStore("amo").load()
         if amo_tok and amo_tok.get("access_token") and int(amo_tok.get("expires_at", 0)) > int(time.time()) + 30:
             if not load_hh_mapping():
-                await rabbitmq.publish_task({"platform": "system", "action": "hh_autofill"})
+                await rabbitmq.publish_task({"platform": "system", "action": "hh_autofill", "payload": {}})
                 log.info("Queued hh_autofill on startup")
     except Exception:
         log.info("Amo token not ready on startup — hh_autofill will be queued after OAuth")

--- a/tests/test_hh_status_sync.py
+++ b/tests/test_hh_status_sync.py
@@ -33,9 +33,11 @@ async def test_sync_hh_status_basic(monkeypatch):
         {
             "platform": "hh",
             "action": "set_state",
-            "external_id": "nid",
-            "target_state": "phone_interview",
-            "owner_id": "oid",
+            "payload": {
+                "external_id": "nid",
+                "target_state": "phone_interview",
+                "owner_id": "oid",
+            },
         }
     ]
 
@@ -63,4 +65,4 @@ async def test_sync_hh_status_refusal_mapping(monkeypatch):
         queue_client=q,
     )
 
-    assert q.tasks[0]["target_state"] == "discard_no_interaction"
+    assert q.tasks[0]["payload"]["target_state"] == "discard_no_interaction"

--- a/tests/test_lead_processor.py
+++ b/tests/test_lead_processor.py
@@ -97,6 +97,7 @@ async def test_send_invite(queue_mock):
     assert "start=555" in link
     assert queue_mock and queue_mock[0]["platform"] == "hh"
     assert all("msg_key" in task for task in queue_mock)
+    assert all("payload" in task for task in queue_mock)
 
 
 @pytest.mark.asyncio
@@ -124,6 +125,7 @@ async def test_create_lead_reauth_has_msg_key(monkeypatch, queue_mock):
     assert lead_id is None
     assert kind == "master"
     assert queue_mock and "msg_key" in queue_mock[0]
+    assert "payload" in queue_mock[0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_survey_service.py
+++ b/tests/test_survey_service.py
@@ -28,20 +28,26 @@ async def test_start(monkeypatch, queue_mock):
         {
             "platform": "amo",
             "action": "amo_add_note",
-            "lead_id": 10,
-            "text": "[master] Кандидат перешёл в бота (TG id:42).",
+            "payload": {
+                "lead_id": 10,
+                "text": "[master] Кандидат перешёл в бота (TG id:42).",
+            },
         },
         {
             "platform": "amo",
             "action": "amo_add_tags",
-            "lead_id": 10,
-            "tags": [settings.AMO_TAG_WENT_TO_BOT],
+            "payload": {
+                "lead_id": 10,
+                "tags": [settings.AMO_TAG_WENT_TO_BOT],
+            },
         },
         {
             "platform": "amo",
             "action": "amo_update_status",
-            "lead_id": 10,
-            "status_id": settings.AMO_STAGE_ID_MASTER_NEW,
+            "payload": {
+                "lead_id": 10,
+                "status_id": settings.AMO_STAGE_ID_MASTER_NEW,
+            },
         },
     ]
 
@@ -67,20 +73,26 @@ async def test_start_operator(monkeypatch, queue_mock):
         {
             "platform": "amo",
             "action": "amo_add_note",
-            "lead_id": 20,
-            "text": "[operator] Кандидат перешёл в бота (TG id:99).",
+            "payload": {
+                "lead_id": 20,
+                "text": "[operator] Кандидат перешёл в бота (TG id:99).",
+            },
         },
         {
             "platform": "amo",
             "action": "amo_add_tags",
-            "lead_id": 20,
-            "tags": [settings.AMO_TAG_WENT_TO_BOT],
+            "payload": {
+                "lead_id": 20,
+                "tags": [settings.AMO_TAG_WENT_TO_BOT],
+            },
         },
         {
             "platform": "amo",
             "action": "amo_update_status",
-            "lead_id": 20,
-            "status_id": settings.AMO_STAGE_ID_OPERATOR_NEW,
+            "payload": {
+                "lead_id": 20,
+                "status_id": settings.AMO_STAGE_ID_OPERATOR_NEW,
+            },
         },
     ]
 
@@ -128,20 +140,26 @@ async def test_finish(bot_kind, stage_attr, stage_value, monkeypatch, queue_mock
         {
             "platform": "amo",
             "action": "amo_add_tags",
-            "lead_id": 33,
-            "tags": [settings.AMO_TAG_SURVEY_DONE],
+            "payload": {
+                "lead_id": 33,
+                "tags": [settings.AMO_TAG_SURVEY_DONE],
+            },
         },
         {
             "platform": "amo",
             "action": "amo_add_note",
-            "lead_id": 33,
-            "text": f"[{bot_kind}] summary",
+            "payload": {
+                "lead_id": 33,
+                "text": f"[{bot_kind}] summary",
+            },
         },
         {
             "platform": "amo",
             "action": "amo_update_status",
-            "lead_id": 33,
-            "status_id": stage_value,
+            "payload": {
+                "lead_id": 33,
+                "status_id": stage_value,
+            },
         },
     ]
     assert deleted == [(3, bot_kind)]

--- a/tests/test_tg_router.py
+++ b/tests/test_tg_router.py
@@ -94,7 +94,7 @@ async def test_start(monkeypatch, queue_mock):
 
     assert sent and "Здравствуйте" in sent[0]["text"]
     assert queue_mock[-1]["action"] == "bot_to_amo"
-    assert queue_mock[-1]["lead_id"] == 777
+    assert queue_mock[-1]["payload"]["lead_id"] == 777
 
 
 @pytest.mark.asyncio

--- a/tests/test_tg_webhooks.py
+++ b/tests/test_tg_webhooks.py
@@ -286,7 +286,7 @@ def test_webhook_creates_task(monkeypatch, queue_mock):
     r = client.post("/tg/webhook/master", json=update)
     assert r.status_code == 200
     assert queue_mock and queue_mock[0]["action"] == "bot_to_amo"
-    assert queue_mock[0]["lead_id"] == 42
+    assert queue_mock[0]["payload"]["lead_id"] == 42
 
 
 def test_webhook_operator_routing(monkeypatch, queue_mock):
@@ -325,5 +325,5 @@ def test_webhook_operator_routing(monkeypatch, queue_mock):
 
     r = client.post("/tg/webhook/operator", json=update)
     assert r.status_code == 200
-    assert queue_mock and queue_mock[0]["bot_kind"] == "operator"
-    assert queue_mock[0]["lead_id"] == 77
+    assert queue_mock and queue_mock[0]["payload"]["bot_kind"] == "operator"
+    assert queue_mock[0]["payload"]["lead_id"] == 77

--- a/tests/test_worker_mirror_status.py
+++ b/tests/test_worker_mirror_status.py
@@ -34,7 +34,6 @@ async def test_status_update_on_chat_creation(monkeypatch, queue_mock):
         {
             "platform": "amo",
             "action": "amo_update_status",
-            "lead_id": 123,
-            "status_id": 777,
+            "payload": {"lead_id": 123, "status_id": 777},
         }
     ]


### PR DESCRIPTION
## Summary
- introduce typed Pydantic schemas for queue events (LeadCreated, SendMessage, UpdateStatus)
- publish tasks via validated models and wrap data in a `payload` field
- adjust worker routing to unpack event payloads

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c1456fbe3c8321bc58dff584dff1e8