### PR TITLE
Track last AmoCRM status transitions

### DIFF
--- a/alembic/versions/7f8f2d108a3b_add_lead_status_transitions.py
+++ b/alembic/versions/7f8f2d108a3b_add_lead_status_transitions.py
@@ -1,0 +1,27 @@
+"""add lead status transitions table"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '7f8f2d108a3b'
+down_revision: Union[str, Sequence[str], None] = '9c2466183e7f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'lead_status_transitions',
+        sa.Column('lead_id', sa.BigInteger(), nullable=False),
+        sa.Column('status_id', sa.BigInteger(), nullable=False),
+        sa.Column('ts', sa.BigInteger(), nullable=False),
+        sa.PrimaryKeyConstraint('lead_id'),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table('lead_status_transitions')

--- a/app/api/amo_webhooks.py
+++ b/app/api/amo_webhooks.py
@@ -3,6 +3,7 @@
 from typing import Any, Mapping, cast
 import json
 import logging
+import time
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Request
@@ -13,6 +14,7 @@ from app.services.hh_mapping import load as hh_map_load
 from app.services.queue import RabbitMQClient, rabbitmq
 from app.services.hh_status_sync import sync_hh_status
 from app.store import find_link
+from app.store_status import set_last_transition
 from .utils import events_from_form
 
 logger = logging.getLogger(__name__)
@@ -84,6 +86,7 @@ async def amo_webhook(
     events = await parse_status_events(request)
 
     for lead_id, status_id in events:
+        await set_last_transition(lead_id, status_id, int(time.time()))
         link = await find_link(lead_id)
         if not link:
             logger.warning("NO LINK FOR LEAD %s", lead_id)

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -115,3 +115,13 @@ class EventDedup(Base):
         TIMESTAMP(timezone=True),
         server_default=func.now(),  # pylint: disable=not-callable
     )
+
+
+class LeadStatusTransition(Base):
+    """Stores the last applied status transition for a lead."""
+
+    __tablename__ = "lead_status_transitions"
+
+    lead_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    status_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    ts: Mapped[int] = mapped_column(BigInteger, nullable=False)

--- a/app/events.py
+++ b/app/events.py
@@ -56,6 +56,7 @@ class UpdateStatusPayload(BaseModel):
     lead_id: int | None = None
     status_id: int | None = None
     owner_id: str | None = None
+    ts: int | None = None
 
 
 class UpdateStatus(EventBase):

--- a/app/services/survey_service.py
+++ b/app/services/survey_service.py
@@ -6,6 +6,8 @@ queue client.  The functions wrap lower level helpers and publish messages to
 other services when the survey state changes.
 """
 
+import time
+
 from app.core.config import get_settings
 from app.services.queue import rabbitmq, RabbitMQClient
 from app.store_survey import (
@@ -39,6 +41,7 @@ class SurveyService:
             if bot_kind == "master"
             else s.AMO_STAGE_ID_OPERATOR_NEW
         )
+        ts = int(time.time())
         await _publish_tasks(
             self.queue_client,
             [
@@ -64,6 +67,7 @@ class SurveyService:
                     "payload": {
                         "lead_id": lead_id,
                         "status_id": stage_id,
+                        "ts": ts,
                     },
                 },
             ],
@@ -85,6 +89,7 @@ class SurveyService:
             if bot_kind == "master"
             else s.AMO_STAGE_ID_OPERATOR_SURVEY
         )
+        ts = int(time.time())
         await _publish_tasks(
             self.queue_client,
             [
@@ -110,6 +115,7 @@ class SurveyService:
                     "payload": {
                         "lead_id": lead_id,
                         "status_id": stage_id,
+                        "ts": ts,
                     },
                 },
             ],

--- a/app/services/worker/amo.py
+++ b/app/services/worker/amo.py
@@ -6,12 +6,14 @@ to perform the actual API call.
 """
 
 import logging
+import time
 
 from httpx import HTTPStatusError
 
 from app.adapters.amo_client import AmoClient
 from app.http_client import get_http_client
 from app.services.dedup import calc_key, once
+from app.store_status import get_last_transition, set_last_transition
 
 logger = logging.getLogger(__name__)
 
@@ -79,15 +81,27 @@ async def handle_amo_update_status(payload: dict) -> None:
 
     Args:
         payload: Must contain ``lead_id`` and ``status_id`` specifying the new
-            status for the lead.
+            status for the lead. Optional ``ts`` marks when the change was
+            requested to avoid applying stale updates.
     """
 
-    logger.info("amo.update_status: %s", payload.get("lead_id"))
+    lead_id = int(payload["lead_id"])
+    status_id = int(payload["status_id"])
+    ts = int(payload.get("ts") or time.time())
+
+    last = await get_last_transition(lead_id)
+    if last and last.ts >= ts:
+        logger.info("amo.update_status: stale transition for lead %s", lead_id)
+        return
+
+    logger.info("amo.update_status: %s", lead_id)
     amo = await AmoClient.create(get_http_client())
     try:
-        await amo.update_status(int(payload["lead_id"]), int(payload["status_id"]))
+        await amo.update_status(lead_id, status_id)
     except HTTPStatusError as err:  # pylint: disable=broad-except
         if err.response is not None and err.response.status_code < 500:
             logger.warning("amo.update_status failed: %s", err)
         else:
             raise
+    else:
+        await set_last_transition(lead_id, status_id, ts)

--- a/app/services/worker/mirror.py
+++ b/app/services/worker/mirror.py
@@ -7,6 +7,7 @@ dictionary with details specific to the direction of the mirror.
 """
 
 import logging
+import time
 from aiogram import Bot
 
 from app.adapters.amochats import send_text_from_manager, ensure_chat_created, send_text_from_client
@@ -198,6 +199,7 @@ async def handle_mirror_bot_to_amo(payload: dict):
                     payload=UpdateStatusPayload(
                         lead_id=int(lead_id),
                         status_id=int(status_id),
+                        ts=int(time.time()),
                     ),
                 )
                 await rabbitmq.publish_task(event.model_dump(exclude_none=True))

--- a/app/store_status.py
+++ b/app/store_status.py
@@ -1,0 +1,32 @@
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from app.db import get_session
+from app.db.models import LeadStatusTransition
+
+
+async def get_last_transition(lead_id: int) -> Optional[LeadStatusTransition]:
+    """Return last stored transition for a lead if present."""
+    async with get_session() as s:
+        return (
+            await s.execute(
+                select(LeadStatusTransition).where(LeadStatusTransition.lead_id == lead_id)
+            )
+        ).scalar_one_or_none()
+
+
+async def set_last_transition(lead_id: int, status_id: int, ts: int) -> None:
+    """Store the latest applied transition for a lead."""
+    async with get_session() as s:
+        stmt = (
+            pg_insert(LeadStatusTransition)
+            .values(lead_id=lead_id, status_id=status_id, ts=ts)
+            .on_conflict_do_update(
+                index_elements=[LeadStatusTransition.lead_id],
+                set_={"status_id": status_id, "ts": ts},
+            )
+        )
+        await s.execute(stmt)
+        await s.commit()

--- a/tests/test_survey_service.py
+++ b/tests/test_survey_service.py
@@ -24,32 +24,29 @@ async def test_start(monkeypatch, queue_mock):
     await svc.start(1, "master", 10, "id:42")
 
     assert called == [(1, "master", 10)]
-    assert queue_mock == [
-        {
-            "platform": "amo",
-            "action": "amo_add_note",
-            "payload": {
-                "lead_id": 10,
-                "text": "[master] Кандидат перешёл в бота (TG id:42).",
-            },
+    assert len(queue_mock) == 3
+    assert queue_mock[0] == {
+        "platform": "amo",
+        "action": "amo_add_note",
+        "payload": {
+            "lead_id": 10,
+            "text": "[master] Кандидат перешёл в бота (TG id:42).",
         },
-        {
-            "platform": "amo",
-            "action": "amo_add_tags",
-            "payload": {
-                "lead_id": 10,
-                "tags": [settings.AMO_TAG_WENT_TO_BOT],
-            },
+    }
+    assert queue_mock[1] == {
+        "platform": "amo",
+        "action": "amo_add_tags",
+        "payload": {
+            "lead_id": 10,
+            "tags": [settings.AMO_TAG_WENT_TO_BOT],
         },
-        {
-            "platform": "amo",
-            "action": "amo_update_status",
-            "payload": {
-                "lead_id": 10,
-                "status_id": settings.AMO_STAGE_ID_MASTER_NEW,
-            },
-        },
-    ]
+    }
+    last = queue_mock[2]
+    assert last["platform"] == "amo"
+    assert last["action"] == "amo_update_status"
+    assert last["payload"]["lead_id"] == 10
+    assert last["payload"]["status_id"] == settings.AMO_STAGE_ID_MASTER_NEW
+    assert isinstance(last["payload"]["ts"], int)
 
 
 @pytest.mark.asyncio
@@ -69,32 +66,29 @@ async def test_start_operator(monkeypatch, queue_mock):
     await svc.start(2, "operator", 20, "id:99")
 
     assert called == [(2, "operator", 20)]
-    assert queue_mock == [
-        {
-            "platform": "amo",
-            "action": "amo_add_note",
-            "payload": {
-                "lead_id": 20,
-                "text": "[operator] Кандидат перешёл в бота (TG id:99).",
-            },
+    assert len(queue_mock) == 3
+    assert queue_mock[0] == {
+        "platform": "amo",
+        "action": "amo_add_note",
+        "payload": {
+            "lead_id": 20,
+            "text": "[operator] Кандидат перешёл в бота (TG id:99).",
         },
-        {
-            "platform": "amo",
-            "action": "amo_add_tags",
-            "payload": {
-                "lead_id": 20,
-                "tags": [settings.AMO_TAG_WENT_TO_BOT],
-            },
+    }
+    assert queue_mock[1] == {
+        "platform": "amo",
+        "action": "amo_add_tags",
+        "payload": {
+            "lead_id": 20,
+            "tags": [settings.AMO_TAG_WENT_TO_BOT],
         },
-        {
-            "platform": "amo",
-            "action": "amo_update_status",
-            "payload": {
-                "lead_id": 20,
-                "status_id": settings.AMO_STAGE_ID_OPERATOR_NEW,
-            },
-        },
-    ]
+    }
+    last = queue_mock[2]
+    assert last["platform"] == "amo"
+    assert last["action"] == "amo_update_status"
+    assert last["payload"]["lead_id"] == 20
+    assert last["payload"]["status_id"] == settings.AMO_STAGE_ID_OPERATOR_NEW
+    assert isinstance(last["payload"]["ts"], int)
 
 
 @pytest.mark.asyncio
@@ -135,31 +129,27 @@ async def test_finish(bot_kind, stage_attr, stage_value, monkeypatch, queue_mock
 
     svc = SurveyService()
     await svc.finish(3, bot_kind, 33, "summary")
-
-    assert queue_mock == [
-        {
-            "platform": "amo",
-            "action": "amo_add_tags",
-            "payload": {
-                "lead_id": 33,
-                "tags": [settings.AMO_TAG_SURVEY_DONE],
-            },
+    assert len(queue_mock) == 3
+    assert queue_mock[0] == {
+        "platform": "amo",
+        "action": "amo_add_tags",
+        "payload": {
+            "lead_id": 33,
+            "tags": [settings.AMO_TAG_SURVEY_DONE],
         },
-        {
-            "platform": "amo",
-            "action": "amo_add_note",
-            "payload": {
-                "lead_id": 33,
-                "text": f"[{bot_kind}] summary",
-            },
+    }
+    assert queue_mock[1] == {
+        "platform": "amo",
+        "action": "amo_add_note",
+        "payload": {
+            "lead_id": 33,
+            "text": f"[{bot_kind}] summary",
         },
-        {
-            "platform": "amo",
-            "action": "amo_update_status",
-            "payload": {
-                "lead_id": 33,
-                "status_id": stage_value,
-            },
-        },
-    ]
+    }
+    last = queue_mock[2]
+    assert last["platform"] == "amo"
+    assert last["action"] == "amo_update_status"
+    assert last["payload"]["lead_id"] == 33
+    assert last["payload"]["status_id"] == stage_value
+    assert isinstance(last["payload"]["ts"], int)
     assert deleted == [(3, bot_kind)]

--- a/tests/test_worker_amo_update_status.py
+++ b/tests/test_worker_amo_update_status.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import types
 import pytest
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -19,9 +20,49 @@ async def test_handle_amo_update_status(monkeypatch):
     async def fake_create(cls, http_client):
         return DummyAmo()
 
+    async def fake_get_last_transition(lead_id):
+        captured['checked'] = lead_id
+        return None
+
+    async def fake_set_last_transition(lead_id, status_id, ts):
+        captured['saved'] = (lead_id, status_id, ts)
+
     monkeypatch.setattr(worker_amo.AmoClient, 'create', classmethod(fake_create))
     monkeypatch.setattr(worker_amo, 'get_http_client', lambda: None)
+    monkeypatch.setattr(worker_amo, 'get_last_transition', fake_get_last_transition)
+    monkeypatch.setattr(worker_amo, 'set_last_transition', fake_set_last_transition)
 
-    await worker_amo.handle_amo_update_status({'lead_id': '1', 'status_id': '2'})
+    await worker_amo.handle_amo_update_status({'lead_id': '1', 'status_id': '2', 'ts': 100})
 
-    assert captured == {'lead_id': 1, 'status_id': 2}
+    assert captured['lead_id'] == 1
+    assert captured['status_id'] == 2
+    assert captured['checked'] == 1
+    assert captured['saved'] == (1, 2, 100)
+
+
+@pytest.mark.asyncio
+async def test_handle_amo_update_status_stale(monkeypatch):
+    called = {}
+
+    class DummyAmo:
+        async def update_status(self, lead_id, status_id):
+            called['updated'] = True
+
+    async def fake_create(cls, http_client):
+        called['created'] = True
+        return DummyAmo()
+
+    async def fake_get_last_transition(lead_id):
+        return types.SimpleNamespace(ts=200)
+
+    async def fake_set_last_transition(lead_id, status_id, ts):
+        called['saved'] = True
+
+    monkeypatch.setattr(worker_amo.AmoClient, 'create', classmethod(fake_create))
+    monkeypatch.setattr(worker_amo, 'get_http_client', lambda: None)
+    monkeypatch.setattr(worker_amo, 'get_last_transition', fake_get_last_transition)
+    monkeypatch.setattr(worker_amo, 'set_last_transition', fake_set_last_transition)
+
+    await worker_amo.handle_amo_update_status({'lead_id': '1', 'status_id': '2', 'ts': 100})
+
+    assert called == {}

--- a/tests/test_worker_mirror_status.py
+++ b/tests/test_worker_mirror_status.py
@@ -29,11 +29,10 @@ async def test_status_update_on_chat_creation(monkeypatch, queue_mock):
 
     await worker_mirror.handle_mirror_bot_to_amo(payload)
     await worker_mirror.handle_mirror_bot_to_amo(payload)
-
-    assert queue_mock == [
-        {
-            "platform": "amo",
-            "action": "amo_update_status",
-            "payload": {"lead_id": 123, "status_id": 777},
-        }
-    ]
+    assert len(queue_mock) == 1
+    item = queue_mock[0]
+    assert item["platform"] == "amo"
+    assert item["action"] == "amo_update_status"
+    assert item["payload"]["lead_id"] == 123
+    assert item["payload"]["status_id"] == 777
+    assert isinstance(item["payload"]["ts"], int)


### PR DESCRIPTION
## Summary
- Persist last AmoCRM status per lead to avoid overwriting manual manager changes
- Carry timestamps with status update tasks and skip outdated transitions
- Store manager-triggered status changes from Amo webhooks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c147115f008321a30d73a8ac77d6b5