### PR TITLE
Add admin endpoints to reconfigure job board webhooks

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -15,6 +15,8 @@ from app.services.hh_mapping import load as hh_map_load, set_all as hh_map_set
 from app.services.queue import rabbitmq, RabbitMQClient
 from app.api.oauth2 import OAuth2Config, ensure_fresh_access
 from app.db.token_store import DbTokenStore
+from app.api.hh_webhook import ensure_hh_webhook
+from app.api.avito_webhooks import ensure_avito_webhooks
 
 router = APIRouter()
 admin = APIRouter()
@@ -139,6 +141,22 @@ async def hh_autofill_admin(
 
     await queue_client.publish_task({"platform": "system", "action": "hh_autofill", "payload": {}})
     return {"ok": True, "queued": True}
+
+
+@admin.post("/hh-webhook/ensure")
+async def hh_webhook_ensure(http_client: httpx.AsyncClient = Depends(get_http_client)) -> dict:
+    """Trigger idempotent HH webhook registration."""
+
+    await ensure_hh_webhook(http_client)
+    return {"ok": True}
+
+
+@admin.post("/avito-webhook/ensure")
+async def avito_webhook_ensure(http_client: httpx.AsyncClient = Depends(get_http_client)) -> dict:
+    """Trigger idempotent Avito webhook registration."""
+
+    await ensure_avito_webhooks(http_client)
+    return {"ok": True}
 
 
 __all__ = ["router", "admin"]

--- a/tests/test_admin_webhook_ensure.py
+++ b/tests/test_admin_webhook_ensure.py
@@ -1,0 +1,47 @@
+import httpx
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from app.api import admin as admin_module
+from app.api import build_routers
+from app.core.config import get_settings
+
+
+def _build_client(monkeypatch) -> TestClient:
+    settings = get_settings()
+    monkeypatch.setattr(settings, "ADMIN_TOKEN", SecretStr("secret"))
+    app = FastAPI()
+    _, admin_router = build_routers()
+    app.include_router(admin_router)
+    return TestClient(app)
+
+
+def test_admin_ensure_hh_webhook(monkeypatch):
+    called = []
+
+    async def fake_ensure(client):
+        called.append(client)
+
+    monkeypatch.setattr(admin_module, "ensure_hh_webhook", fake_ensure)
+    client = _build_client(monkeypatch)
+    r = client.post("/admin/hh-webhook/ensure", headers={"X-Admin-Token": "secret"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert len(called) == 1
+    assert isinstance(called[0], httpx.AsyncClient)
+
+
+def test_admin_ensure_avito_webhook(monkeypatch):
+    called = []
+
+    async def fake_ensure(client):
+        called.append(client)
+
+    monkeypatch.setattr(admin_module, "ensure_avito_webhooks", fake_ensure)
+    client = _build_client(monkeypatch)
+    r = client.post("/admin/avito-webhook/ensure", headers={"X-Admin-Token": "secret"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert len(called) == 1
+    assert isinstance(called[0], httpx.AsyncClient)


### PR DESCRIPTION
## Summary
- add admin endpoints to ensure HH and Avito webhooks without restart
- cover manual ensure endpoints with tests

## Testing
- `pytest tests/test_admin_webhook_ensure.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c14d7346c883219e7f57ace07f5e07