### PR TITLE
feat: add admin token management endpoints

### DIFF
--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -17,6 +17,10 @@ from app.api.oauth2 import OAuth2Config, ensure_fresh_access
 from app.db.token_store import DbTokenStore
 from app.api.hh_webhook import ensure_hh_webhook
 from app.api.avito_webhooks import ensure_avito_webhooks
+from app.db.db import get_session
+from app.db.models import Token
+from sqlalchemy import select
+from app.bootstrap import ensure_tokens
 
 router = APIRouter()
 admin = APIRouter()
@@ -156,6 +160,89 @@ async def avito_webhook_ensure(http_client: httpx.AsyncClient = Depends(get_http
     """Trigger idempotent Avito webhook registration."""
 
     await ensure_avito_webhooks(http_client)
+    return {"ok": True}
+
+
+@admin.get("/tokens/owners")
+async def tokens_owners() -> dict:
+    """Return all token owners with service and expiration."""
+
+    async with get_session() as s:
+        rows = (await s.execute(select(Token.service, Token.owner_id, Token.expires_at))).all()
+    items = [
+        {"service": r[0], "owner_id": r[1], "expires_at": r[2]} for r in rows
+    ]
+    return {"ok": True, "items": items}
+
+
+@admin.post("/tokens/refresh")
+async def tokens_refresh(
+    platform: str,
+    http_client: httpx.AsyncClient = Depends(get_http_client),
+) -> dict:
+    """Refresh access tokens for all owners of *platform*."""
+
+    if platform not in {"hh", "avito", "amo"}:
+        raise HTTPException(status_code=400, detail="unknown platform")
+
+    s = get_settings()
+    cfg: dict[str, object] = {
+        "token_url": "",
+        "client_id": "",
+        "client_secret": "",
+        "redirect_uri": None,
+        "use_basic_auth": False,
+    }
+    if platform == "hh":
+        cfg.update(
+            {
+                "token_url": s.HH_TOKEN_URL,
+                "client_id": s.HH_CLIENT_ID,
+                "client_secret": s.HH_CLIENT_SECRET.get_secret_value(),
+                "redirect_uri": s.HH_REDIRECT_URI,
+            }
+        )
+    elif platform == "avito":
+        cfg.update(
+            {
+                "token_url": s.AVITO_TOKEN_URL,
+                "client_id": s.AVITO_CLIENT_ID,
+                "client_secret": s.AVITO_CLIENT_SECRET.get_secret_value(),
+                "redirect_uri": s.AVITO_REDIRECT_URI,
+                "use_basic_auth": True,
+            }
+        )
+    else:  # amo
+        cfg.update(
+            {
+                "token_url": s.AMO_BASE_URL.rstrip("/") + "/oauth2/access_token",
+                "client_id": s.AMO_CLIENT_ID,
+                "client_secret": s.AMO_CLIENT_SECRET.get_secret_value(),
+                "redirect_uri": s.AMO_REDIRECT_URI,
+            }
+        )
+
+    owners = [None] if platform == "amo" else await DbTokenStore.list_owners(platform)
+    refreshed: list[str | None] = []
+    errors: dict[str, str] = {}
+    for owner_id in owners:
+        try:
+            await ensure_fresh_access(
+                config=OAuth2Config(service=platform, owner_id=owner_id, **cfg),
+                margin_sec=10**9,
+                http_client=http_client,
+            )
+            refreshed.append(owner_id)
+        except Exception as exc:  # pragma: no cover - defensive
+            errors[str(owner_id)] = str(exc)
+    return {"ok": True, "refreshed": refreshed, "errors": errors}
+
+
+@admin.post("/tokens/ensure")
+async def tokens_ensure() -> dict:
+    """Reload tokens from environment variables."""
+
+    await ensure_tokens()
     return {"ok": True}
 
 

--- a/tests/test_admin_tokens.py
+++ b/tests/test_admin_tokens.py
@@ -1,0 +1,139 @@
+import asyncio
+
+import httpx
+import pytest
+from fastapi import APIRouter, Depends, FastAPI
+from pydantic import SecretStr
+
+from app.core.guards import require_admin
+from app.db.db import get_session
+from app.db import models
+from sqlalchemy import insert
+
+
+@pytest.fixture
+def app(monkeypatch):
+    """Application exposing admin token endpoints."""
+
+    from app.api import admin as admin_module
+
+    class Dummy:
+        ADMIN_TOKEN = SecretStr("adm")
+        HH_TOKEN_URL = "https://example.com/hh/token"
+        HH_CLIENT_ID = "id"
+        HH_CLIENT_SECRET = SecretStr("secret")
+        HH_REDIRECT_URI = "http://example.com/hh"
+        AVITO_TOKEN_URL = "https://example.com/avito/token"
+        AVITO_CLIENT_ID = "aid"
+        AVITO_CLIENT_SECRET = SecretStr("asecret")
+        AVITO_REDIRECT_URI = "http://example.com/avito"
+        AMO_BASE_URL = "https://amo.example.com"
+        AMO_CLIENT_ID = "amoid"
+        AMO_CLIENT_SECRET = SecretStr("amosecret")
+        AMO_REDIRECT_URI = "http://example.com/amo"
+
+    monkeypatch.setattr("app.core.guards.get_settings", lambda: Dummy())
+    monkeypatch.setattr(admin_module, "get_settings", lambda: Dummy())
+
+    app = FastAPI()
+    admin_router = APIRouter(prefix="/admin", dependencies=[Depends(require_admin)])
+    admin_router.include_router(admin_module.admin)
+    app.include_router(admin_router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_tokens_owners_returns_all(app, in_memory_db):
+    async with get_session() as s:
+        await s.execute(
+            insert(models.Token).values(
+                id=1,
+                service="hh",
+                owner_id="1",
+                access_token="a",
+                refresh_token="r",
+                expires_at=10,
+            )
+        )
+        await s.execute(
+            insert(models.Token).values(
+                id=2,
+                service="avito",
+                owner_id="2",
+                access_token="a2",
+                refresh_token="r2",
+                expires_at=20,
+            )
+        )
+        await s.commit()
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.get("/admin/tokens/owners", headers={"X-Admin-Token": "adm"})
+    assert r.status_code == 200
+    data = r.json()
+    assert data["ok"] is True
+    services = {(it["service"], it["owner_id"]) for it in data["items"]}
+    assert services == {("hh", "1"), ("avito", "2")}
+
+
+@pytest.mark.asyncio
+async def test_tokens_refresh_calls_ensure(app, in_memory_db, monkeypatch):
+    async with get_session() as s:
+        await s.execute(
+            insert(models.Token).values(
+                id=1,
+                service="hh",
+                owner_id="1",
+                access_token="a1",
+                refresh_token="r1",
+                expires_at=0,
+            )
+        )
+        await s.execute(
+            insert(models.Token).values(
+                id=2,
+                service="hh",
+                owner_id="2",
+                access_token="a2",
+                refresh_token="r2",
+                expires_at=0,
+            )
+        )
+        await s.commit()
+
+    called = []
+
+    async def fake_ensure_fresh_access(*, config, **kwargs):
+        called.append(config.owner_id)
+        return "tok"
+
+    from app.api import admin as admin_module
+
+    monkeypatch.setattr(admin_module, "ensure_fresh_access", fake_ensure_fresh_access)
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.post(
+            "/admin/tokens/refresh", params={"platform": "hh"}, headers={"X-Admin-Token": "adm"}
+        )
+    assert r.status_code == 200
+    assert set(called) == {"1", "2"}
+
+
+@pytest.mark.asyncio
+async def test_tokens_ensure_calls_bootstrap(app, monkeypatch):
+    called = False
+
+    async def fake_ensure_tokens():
+        nonlocal called
+        called = True
+
+    from app.api import admin as admin_module
+
+    monkeypatch.setattr(admin_module, "ensure_tokens", fake_ensure_tokens)
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.post("/admin/tokens/ensure", headers={"X-Admin-Token": "adm"})
+    assert r.status_code == 200
+    assert r.json() == {"ok": True}
+    assert called is True
+


### PR DESCRIPTION
## Summary
- add endpoints to list, refresh, and reload stored OAuth tokens
- cover admin token utilities with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c14fa70e088321a4f136189d3c0e64