### PR TITLE
Add admin recovery endpoints and DLQ requeue capability

### DIFF
--- a/app/api/_webhook_common.py
+++ b/app/api/_webhook_common.py
@@ -23,14 +23,19 @@ async def process_job_board_webhook(
     raw: bytes,
     http_client: httpx.AsyncClient,
     parse_payload: Callable[[bytes], IncomingPayload],
+    *,
+    skip_dedup: bool = False,
 ) -> dict:
     """Process an incoming job board webhook.
 
-    Handles deduplication, payload parsing and lead processing.
+    Handles optional deduplication, payload parsing and lead processing.
+    When ``skip_dedup`` is ``True`` the deduplication step is bypassed which is
+    useful for manual replays via administrative endpoints.
     """
-    key = calc_key(platform, raw)
-    if not await check_and_store(key):
-        return {"ok": True, "duplicate": True}
+    if not skip_dedup:
+        key = calc_key(platform, raw)
+        if not await check_and_store(key):
+            return {"ok": True, "duplicate": True}
 
     try:
         payload = parse_payload(raw)

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -4,7 +4,7 @@ import logging
 import time
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.exc import SQLAlchemyError
 from pydantic import RootModel
 
@@ -21,6 +21,17 @@ from app.db.db import get_session
 from app.db.models import Token
 from sqlalchemy import select
 from app.bootstrap import ensure_tokens
+from app.api._webhook_common import process_job_board_webhook
+from app.services.payload_parsers import (
+    parse_hh_payload,
+    extract_avito_payload,
+    parse_avito_payload,
+)
+from app.services.lead_processor import send_invite
+from app.models import IncomingPayload, Applicant
+from app.store import find_link
+from app.adapters.amo_client import AmoClient
+from app.services.hh_status_sync import sync_hh_status
 
 router = APIRouter()
 admin = APIRouter()
@@ -93,6 +104,84 @@ async def dedup_clean(hours: int = 72) -> dict:
     deleted = await cleanup_older_than(hours * 3600)
     logger.info("dedup cleanup removed=%s hours=%s", deleted, hours)
     return {"ok": True, "removed": deleted, "hours": hours}
+
+
+@admin.post("/dlq/requeue")
+async def dlq_requeue(
+    n: int = 10, queue_client: RabbitMQClient = Depends(lambda: rabbitmq)
+) -> dict:
+    """Requeue up to ``n`` messages from the dead-letter queue."""
+
+    moved = await queue_client.requeue_dlq(n)
+    return {"ok": True, "requeued": moved}
+
+
+@admin.post("/replay/lead")
+async def replay_lead(
+    platform: str,
+    request: Request,
+    http_client: httpx.AsyncClient = Depends(get_http_client),
+) -> dict:
+    """Replay a missed job board webhook without deduplication."""
+
+    if platform not in {"hh", "avito"}:
+        raise HTTPException(status_code=400, detail="unknown platform")
+    parsers = {
+        "hh": parse_hh_payload,
+        "avito": lambda b: parse_avito_payload(extract_avito_payload(b)),
+    }
+    raw = await request.body()
+    parser = parsers[platform]
+    return await process_job_board_webhook(
+        platform, raw, http_client, parser, skip_dedup=True
+    )
+
+
+@admin.post("/replay/survey-invite")
+async def replay_survey_invite(
+    lead_id: int,
+    http_client: httpx.AsyncClient = Depends(get_http_client),
+) -> dict:
+    """Resend Telegram survey invite for the given lead."""
+
+    link = await find_link(lead_id)
+    if not link or not link.get("external_id"):
+        raise HTTPException(status_code=404, detail="lead link not found")
+    amo = await AmoClient.create(http_client)
+    lead = await amo.get_lead(lead_id)
+    s = get_settings()
+    pipeline_id = lead.get("pipeline_id")
+    kind = (
+        "master" if pipeline_id == s.AMO_PIPELINE_ID_MASTER else "operator"
+    )
+    payload = IncomingPayload(
+        platform=link["platform"],
+        owner_id=link.get("owner_id"),
+        vacancy_id=link.get("vacancy_id"),
+        applicant=Applicant(id=str(link["external_id"]), name="replay"),
+        kind=kind,
+    )
+    await send_invite(payload, lead_id)
+    return {"ok": True}
+
+
+@admin.post("/status-sync/lead")
+async def status_sync_lead(
+    lead_id: int,
+    http_client: httpx.AsyncClient = Depends(get_http_client),
+) -> dict:
+    """Synchronize the current lead status with HeadHunter."""
+
+    link = await find_link(lead_id)
+    if not link:
+        raise HTTPException(status_code=404, detail="lead link not found")
+    amo = await AmoClient.create(http_client)
+    lead = await amo.get_lead(lead_id)
+    status_id = lead.get("status_id")
+    if not isinstance(status_id, int):
+        raise HTTPException(status_code=400, detail="invalid status")
+    await sync_hh_status(lead_id, status_id, link, http_client)
+    return {"ok": True, "status_id": status_id}
 
 
 @admin.get("/hh-states")

--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -160,6 +160,37 @@ class RabbitMQClient:
             assert self._exch is not None
             await self._exch.publish(msg, routing_key="tasks.dlq")
 
+    async def requeue_dlq(self, count: int) -> int:
+        """Move up to ``count`` messages from the DLQ back to the main queue.
+
+        Returns the number of messages requeued.
+        """
+        if count <= 0:
+            return 0
+        if not self._conn or self._conn.is_closed or not self._chan or self._chan.is_closed:
+            await self._ensure()
+        s = self._s()
+        assert self._chan is not None
+        q_dlq = await self._chan.get_queue(s.RMQ_DLQ_QUEUE)
+        moved = 0
+        for _ in range(count):
+            try:
+                msg = await q_dlq.get(no_ack=False, fail=False)  # type: ignore[call-arg]
+            except aio_exc.QueueEmpty:
+                break
+            if msg is None:
+                break
+            try:
+                obj = json.loads(msg.body.decode())
+                payload = obj.get("payload") or {}
+            except Exception:  # pragma: no cover - defensive
+                payload = {}
+            if payload:
+                await self.publish_task(payload, attempts=0)
+                moved += 1
+            await msg.ack()
+        return moved
+
     async def consume(
         self, handler: Callable[..., Awaitable[None]], max_attempts: int = 10
     ) -> None:

--- a/tests/test_admin_manual_tools.py
+++ b/tests/test_admin_manual_tools.py
@@ -1,0 +1,145 @@
+import httpx
+import pytest
+from fastapi import APIRouter, Depends, FastAPI
+from pydantic import SecretStr
+
+from app.core.guards import require_admin
+
+
+class DummySettings:
+    ADMIN_TOKEN = SecretStr("adm")
+    AMO_PIPELINE_ID_MASTER = 1
+    AMO_PIPELINE_ID_OPERATOR = 2
+
+
+@pytest.fixture
+def app(monkeypatch):
+    from app.api import admin as admin_module
+
+    settings = DummySettings()
+    monkeypatch.setattr("app.core.guards.get_settings", lambda: settings)
+    monkeypatch.setattr(admin_module, "get_settings", lambda: settings)
+
+    app = FastAPI()
+    admin_router = APIRouter(prefix="/admin", dependencies=[Depends(require_admin)])
+    admin_router.include_router(admin_module.admin)
+    app.include_router(admin_router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_dlq_requeue_calls_queue_client(app, monkeypatch):
+    from app.api import admin as admin_module
+
+    class DummyQueue:
+        def __init__(self):
+            self.called = None
+
+        async def requeue_dlq(self, n):
+            self.called = n
+            return 3
+
+    q = DummyQueue()
+    monkeypatch.setattr(admin_module, "rabbitmq", q)
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.post(
+            "/admin/dlq/requeue", params={"n": 5}, headers={"X-Admin-Token": "adm"}
+        )
+    assert r.status_code == 200
+    assert q.called == 5
+    assert r.json()["requeued"] == 3
+
+
+@pytest.mark.asyncio
+async def test_replay_lead_skip_dedup(app, monkeypatch):
+    from app.api import admin as admin_module
+
+    async def fake_process(platform, raw, http_client, parser, *, skip_dedup=False):
+        return {
+            "platform": platform,
+            "raw": raw.decode(),
+            "skip": skip_dedup,
+            "parsed": parser(b"{}"),
+        }
+
+    def fake_parse(raw):
+        return {"raw": raw.decode()}
+
+    monkeypatch.setattr(admin_module, "process_job_board_webhook", fake_process)
+    monkeypatch.setattr(admin_module, "parse_hh_payload", fake_parse)
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.post(
+            "/admin/replay/lead", params={"platform": "hh"}, content=b"{}", headers={"X-Admin-Token": "adm"}
+        )
+    data = r.json()
+    assert data["platform"] == "hh"
+    assert data["skip"] is True
+
+
+@pytest.mark.asyncio
+async def test_replay_survey_invite(app, monkeypatch):
+    from app.api import admin as admin_module
+
+    async def fake_find_link(lead_id):
+        return {"platform": "hh", "owner_id": "o", "vacancy_id": "v", "external_id": "nid"}
+
+    class DummyAmo:
+        async def get_lead(self, lead_id):
+            return {"pipeline_id": 1}
+
+    async def fake_create(client):
+        return DummyAmo()
+
+    called = {}
+
+    async def fake_send_invite(payload, lead_id):
+        called["payload"] = payload
+        called["lead_id"] = lead_id
+
+    monkeypatch.setattr(admin_module, "find_link", fake_find_link)
+    monkeypatch.setattr(admin_module.AmoClient, "create", classmethod(lambda cls, client: fake_create(client)))
+    monkeypatch.setattr(admin_module, "send_invite", fake_send_invite)
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.post(
+            "/admin/replay/survey-invite", params={"lead_id": 42}, headers={"X-Admin-Token": "adm"}
+        )
+    assert r.status_code == 200
+    assert called["lead_id"] == 42
+    assert called["payload"].applicant.id == "nid"
+    assert called["payload"].kind == "master"
+
+
+@pytest.mark.asyncio
+async def test_status_sync_lead(app, monkeypatch):
+    from app.api import admin as admin_module
+
+    async def fake_find_link(lead_id):
+        return {"platform": "hh", "owner_id": "o", "external_id": "nid"}
+
+    class DummyAmo:
+        async def get_lead(self, lead_id):
+            return {"status_id": 10}
+
+    async def fake_create(client):
+        return DummyAmo()
+
+    called = {}
+
+    async def fake_sync(lead_id, status_id, link, http_client):
+        called.update(lead_id=lead_id, status_id=status_id, link=link)
+
+    monkeypatch.setattr(admin_module, "find_link", fake_find_link)
+    monkeypatch.setattr(admin_module.AmoClient, "create", classmethod(lambda cls, client: fake_create(client)))
+    monkeypatch.setattr(admin_module, "sync_hh_status", fake_sync)
+
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+        r = await client.post(
+            "/admin/status-sync/lead", params={"lead_id": 5}, headers={"X-Admin-Token": "adm"}
+        )
+    assert r.status_code == 200
+    assert called["lead_id"] == 5
+    assert called["status_id"] == 10
+    assert called["link"]["external_id"] == "nid"


### PR DESCRIPTION
## Summary
- allow admin to requeue messages from the dead-letter queue
- support replaying missed webhooks, resending survey invites, and syncing lead status
- add skip-dedup option in webhook processor

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c150e47aa483219141ef3d139b7ff9