### PR TITLE
Raise error when token decryption fails

### DIFF
--- a/app/db/token_store.py
+++ b/app/db/token_store.py
@@ -54,8 +54,13 @@ class DbTokenStore:
             try:
                 access = decrypt(access)
                 refresh = decrypt(refresh)
-            except InvalidToken:
-                pass
+            except InvalidToken as e:
+                # If tokens can't be decrypted we shouldn't return the raw ciphertext,
+                # otherwise callers will unknowingly send garbage to upstream APIs.
+                # Raising an explicit error makes the problem visible and allows
+                # callers to trigger a re-authentication flow instead of using an
+                # invalid token.
+                raise RuntimeError("Failed to decrypt stored token") from e
             return {
                 "access_token": access,
                 "refresh_token": refresh,

--- a/tests/test_oauth_token_store.py
+++ b/tests/test_oauth_token_store.py
@@ -4,6 +4,7 @@ import httpx
 
 from app.api import oauth2
 from app.db.token_store import DbTokenStore
+from app.core.crypto import encrypt
 from app.db.db import get_session
 from app.db import models
 from sqlalchemy import insert, select
@@ -65,8 +66,8 @@ async def test_ensure_fresh_access_refreshes_when_expired(in_memory_db):
                 id=1,
                 service="svc",
                 owner_id=None,
-                access_token="old",
-                refresh_token="r1",
+                access_token=encrypt("old"),
+                refresh_token=encrypt("r1"),
                 expires_at=now - 10,
             )
         )
@@ -111,8 +112,8 @@ async def test_ensure_fresh_access_uses_cached_token(in_memory_db, monkeypatch):
                 id=1,
                 service="svc",
                 owner_id=None,
-                access_token="cached",
-                refresh_token="r1",
+                access_token=encrypt("cached"),
+                refresh_token=encrypt("r1"),
                 expires_at=now + 1000,
             )
         )
@@ -168,3 +169,25 @@ async def test_tokens_encrypted_in_db(in_memory_db):
     data = await store.load()
     assert data["access_token"] == "plain"
     assert data["refresh_token"] == "plainr"
+
+
+@pytest.mark.asyncio
+async def test_load_raises_on_invalid_ciphertext(in_memory_db):
+    """Ensure ``load`` fails loudly when tokens cannot be decrypted."""
+
+    async with get_session() as s:
+        await s.execute(
+            insert(models.Token).values(
+                id=1,
+                service="svc",
+                owner_id=None,
+                access_token="bad",  # not a valid Fernet token
+                refresh_token="bad",
+                expires_at=0,
+            )
+        )
+        await s.commit()
+
+    store = DbTokenStore("svc")
+    with pytest.raises(RuntimeError):
+        await store.load()


### PR DESCRIPTION
## Summary
- Raise explicit error in token store when ciphertext cannot be decrypted, preventing encrypted tokens from being used
- Adjust OAuth token store tests to insert encrypted fixtures and add coverage for invalid ciphertext

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c164ac862483218b4831ba93682db6