### PR TITLE
Fix dedup cleanup and retry loop

### DIFF
--- a/app/api/hh_webhook/routes.py
+++ b/app/api/hh_webhook/routes.py
@@ -52,11 +52,12 @@ async def ensure_hh_webhook(client: httpx.AsyncClient) -> None:
         except (RuntimeError, SQLAlchemyError):
             continue
 
+        user_agent = getattr(s, "HH_USER_AGENT", None) or "hr-bridge/1.0 (+https://hr-bridge.onrender.com)"
         headers = {
             "Authorization": f"Bearer {access}",
             "Accept": "application/json",
             "Content-Type": "application/json",
-            "User-Agent": s.HH_USER_AGENT or "hr-bridge/1.0 (+https://hr-bridge.onrender.com)",
+            "User-Agent": user_agent,
         }
 
         try:

--- a/app/services/dedup.py
+++ b/app/services/dedup.py
@@ -40,8 +40,8 @@ async def cleanup_older_than(seconds: int = 72 * 3600) -> int:
     """Удалить записи дедупликации старше указанного количества секунд."""
     async with get_session() as s:
         q = text(
-            "DELETE FROM events_dedup WHERE created_at < (NOW() AT TIME ZONE 'utc') - "
-            "(:sec || ' seconds')::interval"
+            "DELETE FROM events_dedup "
+            "WHERE created_at < (NOW() AT TIME ZONE 'utc') - (:sec * INTERVAL '1 second')"
         )
         res = await s.execute(q, {"sec": seconds})
         await s.commit()

--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -130,7 +130,7 @@ async def _republish_from_queue(queue_name: str) -> int:
     queue = await chan.get_queue(queue_name)
     count = 0
     while True:
-        msg = await queue.get(fail=False, timeout=0)
+        msg = await queue.get(fail=False)
         if msg is None:
             break
         try:


### PR DESCRIPTION
## Summary
- fix dedup cleanup query to avoid type mismatches
- avoid timeout errors when republishing tasks from DLQ
- use default HH user-agent if settings omit it

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c18f5958748321b81f000ab17df162