### PR TITLE
Support mirror bot_to_amo tasks

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -7,6 +7,7 @@ from app.adapters.amo_client import AmoClient
 from app.services.hh_autofill import autofill_hh_mapping
 from app.db.token_store import DbTokenStore
 from app.http_client import get_http_client
+from app.services.worker.mirror import handle_mirror_bot_to_amo
 
 
 async def handle_task(p: dict, attempts: int = 0):
@@ -71,6 +72,10 @@ async def handle_task(p: dict, attempts: int = 0):
     if p["platform"] == "amo" and p["action"] == "amo_create_lead":
         amo = await AmoClient.create(get_http_client())
         await amo.create_leads(payload["lead_body"])
+        return
+
+    if p.get("platform") == "mirror" and p.get("action") == "bot_to_amo":
+        await handle_mirror_bot_to_amo(payload)
         return
 
     raise RuntimeError(f"Unknown task: {p}")

--- a/tests/test_api_tasks_mirror.py
+++ b/tests/test_api_tasks_mirror.py
@@ -1,0 +1,22 @@
+import pytest
+
+import app.api.tasks as tasks
+
+
+@pytest.mark.asyncio
+async def test_handle_task_mirror_bot_to_amo(monkeypatch):
+    called = {}
+
+    async def fake_handle(payload):
+        called["payload"] = payload
+
+    monkeypatch.setattr(tasks, "handle_mirror_bot_to_amo", fake_handle)
+
+    msg = {
+        "platform": "mirror",
+        "action": "bot_to_amo",
+        "payload": {"text": "hi"},
+        "msg_key": "k1",
+    }
+    await tasks.handle_task(msg)
+    assert called["payload"] == {"text": "hi", "msg_key": "k1"}


### PR DESCRIPTION
## Summary
- handle mirror bot-to-amo tasks in RMQ consumer
- add regression test for mirror bot-to-amo routing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c19f4ff83c832180307bda7b59d03a