### PR TITLE
Embed owner_id into HH webhook URL

### DIFF
--- a/app/api/hh_incoming.py
+++ b/app/api/hh_incoming.py
@@ -15,14 +15,17 @@ router = APIRouter()
 log = logging.getLogger(__name__)  
 
 
-@router.post("/webhooks/hh")
+@router.post("/webhooks/hh/{owner_id}")
 async def webhook_hh(
-    request: Request, http_client: httpx.AsyncClient = Depends(get_http_client)
+    owner_id: str,
+    request: Request,
+    http_client: httpx.AsyncClient = Depends(get_http_client),
 ):
     """Handle HeadHunter webhook events.
 
-    Fetches the raw request body and passes it to the generic job board
-    webhook processor along with the HeadHunter payload parser.
+    The ``owner_id`` is embedded into the webhook URL so that we don't need to
+    perform extra lookups to determine the employer. If the parsed payload lacks
+    ``owner_id``, the value from the URL is used.
     """
     raw = await request.body()
 
@@ -31,7 +34,7 @@ async def webhook_hh(
     ts = None
     try:
         data = json.loads(raw.decode("utf-8", "ignore") or "{}")
-        log.info(f"HH FULL WEBHOOK BODY: {data}") 
+        log.info(f"HH FULL WEBHOOK BODY: {data}")
         obj = (
             data.get("object")
             or data.get("negotiation")
@@ -50,7 +53,13 @@ async def webhook_hh(
         pass
     log.info("HH webhook received nid=%s ts=%s", nid, ts)
     log.debug("HH webhook body: %s", raw.decode("utf-8", "ignore"))
-    return await process_job_board_webhook("hh", raw, http_client, parse_hh_payload)
+
+    def _parser(b: bytes):
+        p = parse_hh_payload(b)
+        p.owner_id = p.owner_id or owner_id
+        return p
+
+    return await process_job_board_webhook("hh", raw, http_client, _parser)
 
 
 __all__ = ["router"]

--- a/app/api/hh_webhook/routes.py
+++ b/app/api/hh_webhook/routes.py
@@ -16,10 +16,11 @@ log = logging.getLogger(__name__)
 
 async def ensure_hh_webhook(client: httpx.AsyncClient) -> None:
     """Создать/обновить подписку HH, идемпотентно (POST/PUT/DELETE при необходимости)."""
-    url = wh_sub._target_url()
-    if not url:
+    url_base = wh_sub._target_url()
+    if not url_base:
         log.info("HH webhook: HH_WEBHOOK_URL пуст — пропускаю регистрацию")
         return
+    url_base = url_base.rstrip("/")
 
     try:
         owners = await DbTokenStore.list_owners("hh")
@@ -36,6 +37,7 @@ async def ensure_hh_webhook(client: httpx.AsyncClient) -> None:
 
     s = get_settings()
     for employer_id in owners:
+        url = f"{url_base}/{employer_id}"
         try:
             access = await ensure_fresh_access(
                 config=OAuth2Config(

--- a/tests/test_hh_incoming.py
+++ b/tests/test_hh_incoming.py
@@ -38,7 +38,7 @@ def test_webhook_success(monkeypatch, client):
     monkeypatch.setattr(_webhook_common, "send_invite", fake_send_invite)
     monkeypatch.setattr(_webhook_common, "tag_lead", fake_tag_lead)
 
-    r = client.post("/webhooks/hh", data=b"{}")
+    r = client.post("/webhooks/hh/1", data=b"{}")
     assert r.status_code == 200
     assert r.json() == {"ok": True, "lead_id": 777}
     assert called["invite"] == 777
@@ -60,7 +60,7 @@ def test_webhook_duplicate(monkeypatch, client):
 
     monkeypatch.setattr(hh_incoming, "parse_hh_payload", fake_parse)
 
-    r = client.post("/webhooks/hh", data=b"{}")
+    r = client.post("/webhooks/hh/1", data=b"{}")
     assert r.status_code == 200
     assert r.json() == {"ok": True, "duplicate": True}
     assert not called
@@ -77,7 +77,7 @@ def test_webhook_bad_payload(monkeypatch, client):
 
     monkeypatch.setattr(hh_incoming, "parse_hh_payload", fake_parse)
 
-    r = client.post("/webhooks/hh", data=b"{}")
+    r = client.post("/webhooks/hh/1", data=b"{}")
     assert r.status_code == 200
     assert r.json() == {"ok": True, "skipped": True}
 
@@ -112,7 +112,7 @@ def test_webhook_ignored(monkeypatch, client):
     monkeypatch.setattr(_webhook_common, "send_invite", fake_send_invite)
     monkeypatch.setattr(_webhook_common, "tag_lead", fake_tag_lead)
 
-    r = client.post("/webhooks/hh", data=b"{}")
+    r = client.post("/webhooks/hh/1", data=b"{}")
     assert r.status_code == 200
     assert r.json() == {"ok": True, "ignored": True, "reason": "no-keywords"}
 
@@ -147,7 +147,7 @@ def test_webhook_queued(monkeypatch, client):
     monkeypatch.setattr(_webhook_common, "send_invite", fake_send_invite)
     monkeypatch.setattr(_webhook_common, "tag_lead", fake_tag_lead)
 
-    r = client.post("/webhooks/hh", data=b"{}")
+    r = client.post("/webhooks/hh/1", data=b"{}")
     assert r.status_code == 200
     assert r.json() == {"ok": True, "queued": True, "reason": "reauth_required"}
 
@@ -164,7 +164,7 @@ def test_webhook_enrich_error(monkeypatch, client):
 
     monkeypatch.setattr(_webhook_common, "enrich_applicant", boom)
 
-    r = client.post("/webhooks/hh", data=b"{}")
+    r = client.post("/webhooks/hh/1", data=b"{}")
     assert r.status_code == 200
     assert r.json() == {"ok": False, "error": "internal_error"}
 
@@ -191,7 +191,7 @@ def test_webhook_create_lead_error(monkeypatch, client):
 
     monkeypatch.setattr(_webhook_common, "create_lead", boom)
 
-    r = client.post("/webhooks/hh", data=b"{}")
+    r = client.post("/webhooks/hh/1", data=b"{}")
     assert r.status_code == 200
     assert r.json() == {"ok": False, "error": "internal_error"}
 
@@ -229,7 +229,7 @@ def test_webhook_tag_error(monkeypatch, client):
     monkeypatch.setattr(_webhook_common, "send_invite", fake_send_invite)
     monkeypatch.setattr(_webhook_common, "tag_lead", boom)
 
-    r = client.post("/webhooks/hh", data=b"{}")
+    r = client.post("/webhooks/hh/1", data=b"{}")
     assert r.status_code == 200
     assert r.json() == {"ok": False, "error": "internal_error"}
     assert called["invite"] == 123

--- a/tests/test_hh_webhooks.py
+++ b/tests/test_hh_webhooks.py
@@ -63,6 +63,7 @@ async def test_ensure_hh_webhook_uses_first_owner(in_memory_db, monkeypatch):
 
     assert captured, "no requests were made"
     assert captured[0].headers.get("Authorization") == "Bearer tok2"
+    assert json.loads(captured[1].content)["url"] == "http://example.com/2"
 
 
 def _set_events(monkeypatch, value: str):
@@ -157,6 +158,7 @@ async def test_ensure_posts_only_valid_events(in_memory_db, monkeypatch):
         await routes.ensure_hh_webhook(client)
 
     assert len(captured) == 2
+    assert json.loads(captured[1].content)["url"] == "http://example.com/1"
     assert json.loads(captured[1].content)["actions"] == [
         {"type": "NEW_NEGOTIATION_VACANCY", "settings": {"vacancies_only_mine": False}}
     ]


### PR DESCRIPTION
## Summary
- add `owner_id` path parameter to HH webhook endpoint and inject it into parsed payloads
- register HH webhooks per owner by appending `owner_id` to callback URL
- update tests for owner-specific webhook handling

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1c45bbb148321b211c74708cd3d09