### PR TITLE
Add AmoChats fallback for chat-contact binding

### DIFF
--- a/app/adapters/amochats.py
+++ b/app/adapters/amochats.py
@@ -123,6 +123,18 @@ async def ensure_amo_chats_connected(log: logging.Logger, client: httpx.AsyncCli
         log.warning("AmoChats connect warning: %s", exc)
 
 
+async def _bind_contact_via_amojo(contact_id: int, chat_id: str, client: httpx.AsyncClient) -> None:
+    """Привязать чат к контакту через AmoChats API (v2) в качестве fallback."""
+    ac = _get_client()
+    path = f"/v2/origin/custom/{ac.scope_id}/contacts"
+    url = _base() + path
+    body = _dump({"contact_id": int(contact_id), "chat_id": str(chat_id)})
+    headers = _build_headers(ac.secret, "POST", path, body, ac.account_id)
+    r = await client.post(url, content=body, headers=headers, timeout=30)
+    if r.status_code >= 400:
+        raise AmoChatsError(f"bind_contact_via_amojo failed {r.status_code}: {r.text}")
+
+
 async def send_text_from_client(
         *, lead_id: int, text: str, tg_user_id: int, tg_user_name: str | None = None,
         conversation_id: str | None = None, client: httpx.AsyncClient,
@@ -276,6 +288,23 @@ async def ensure_chat_created(
             amo = await AmoClient.create(client)
             await amo.bind_chat_to_contact(bind_contact_id, chat_id)
             logger.info("чат привязан к контакту: contact_id=%s chat_id=%s", bind_contact_id, chat_id)
+        except httpx.HTTPStatusError as exc:
+            err_text = exc.response.text if exc.response else ""
+            if "Channel must be linked to your client" in err_text:
+                logger.warning(
+                    "привязка чата к контакту: Channel must be linked to your client; пробуем через AmoChats"
+                )
+                try:
+                    await _bind_contact_via_amojo(bind_contact_id, chat_id, client)
+                    logger.info(
+                        "чат привязан к контакту через AmoChats: contact_id=%s chat_id=%s",
+                        bind_contact_id,
+                        chat_id,
+                    )
+                except Exception:
+                    logger.warning("привязка чата к контакту не удалась", exc_info=True)
+            else:
+                logger.warning("привязка чата к контакту не удалась", exc_info=True)
         except Exception:
             logger.warning("привязка чата к контакту не удалась", exc_info=True)
 

--- a/tests/test_adapters_amochats.py
+++ b/tests/test_adapters_amochats.py
@@ -1,5 +1,6 @@
 import pytest
 import httpx
+import json
 
 from app.adapters import amochats
 
@@ -27,4 +28,83 @@ async def test_env_missing(monkeypatch, call):
     async with httpx.AsyncClient(transport=httpx.MockTransport(lambda r: httpx.Response(200))) as client:
         with pytest.raises(amochats.AmoChatsError):
             await call(client)
+
+
+@pytest.mark.asyncio
+async def test_bind_chat_to_contact_fallback(monkeypatch):
+    class DummyAC:
+        scope_id = "sid"
+        secret = "sec"
+        account_id = "acc"
+        channel_id = "chan"
+        sender_user_amojo_id = "user"
+
+    monkeypatch.setattr(amochats, "_get_client", lambda: DummyAC())
+
+    def handler(request: httpx.Request):
+        if request.url.path == f"/v2/origin/custom/{DummyAC.scope_id}/chats":
+            return httpx.Response(200, json={"chat_id": "chat42"})
+        return httpx.Response(200)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        class DummyAmoClient:
+            @classmethod
+            async def create(cls, http_client):
+                return DummyAmoClient()
+
+            async def bind_chat_to_contact(self, contact_id, chat_id):
+                response = httpx.Response(
+                    400, text="Channel must be linked to your client"
+                )
+                raise httpx.HTTPStatusError(
+                    "error",
+                    request=httpx.Request("POST", "https://example.com"),
+                    response=response,
+                )
+
+        import app.adapters.amo_client as amo_client_module
+
+        monkeypatch.setattr(amo_client_module, "AmoClient", DummyAmoClient)
+
+        called: dict[str, tuple[int, str]] = {}
+
+        async def fake_bind(contact_id: int, chat_id: str, client: httpx.AsyncClient):
+            called["args"] = (contact_id, chat_id)
+
+        monkeypatch.setattr(amochats, "_bind_contact_via_amojo", fake_bind)
+
+        await amochats.ensure_chat_created(
+            lead_id=1,
+            tg_user_id=1,
+            tg_user_name="name",
+            client=client,
+            bind_contact_id=55,
+        )
+
+        assert called["args"] == (55, "chat42")
+
+
+@pytest.mark.asyncio
+async def test_bind_contact_via_amojo(monkeypatch):
+    class DummyAC:
+        scope_id = "sid"
+        secret = "sec"
+        account_id = "acc"
+        channel_id = "chan"
+        sender_user_amojo_id = "user"
+
+    monkeypatch.setattr(amochats, "_get_client", lambda: DummyAC())
+
+    captured: dict[str, str] = {}
+
+    def handler(request: httpx.Request):
+        captured["path"] = request.url.path
+        captured["body"] = request.content.decode()
+        return httpx.Response(200)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await amochats._bind_contact_via_amojo(123, "chatX", client)
+
+    assert captured["path"] == f"/v2/origin/custom/{DummyAC.scope_id}/contacts"
+    assert json.loads(captured["body"]) == {"contact_id": 123, "chat_id": "chatX"}
 


### PR DESCRIPTION
## Summary
- add `_bind_contact_via_amojo` helper to link chats to contacts via AmoChats API
- fall back to AmoChats when v4 chat-contact binding fails with mismatched client
- cover new behavior with tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1cd70802c832182e71d76269a51c1