### PR TITLE
Add queue and worker debug logs

### DIFF
--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -121,6 +121,7 @@ class RabbitMQClient:
             await self._ensure()
             assert self._exch is not None
             await self._exch.publish(msg, routing_key="tasks")
+        logger.info("publish_task: %s attempts=%s", payload, attempts)
 
     async def publish_retry(self, payload: dict, attempts: int) -> None:
         """Опубликовать задачу в очередь повтора."""
@@ -141,6 +142,7 @@ class RabbitMQClient:
             await self._chan.default_exchange.publish(
                 msg, routing_key=s.RMQ_RETRY_QUEUE
             )
+        logger.info("publish_retry: %s attempts=%s", payload, attempts)
 
     async def publish_dlq(
         self, payload: dict, attempts: int, error: str | None = None
@@ -158,6 +160,7 @@ class RabbitMQClient:
             await self._ensure()
             assert self._exch is not None
             await self._exch.publish(msg, routing_key="tasks.dlq")
+        logger.warning("publish_dlq: %s attempts=%s error=%s", payload, attempts, error)
 
     async def requeue_dlq(self, count: int) -> int:
         """Переместить до ``count`` сообщений из DLQ обратно в основную очередь.
@@ -238,12 +241,22 @@ class RabbitMQClient:
                                         obj.get("attempts"),
                                     )
                                     attempts = 0
+                                logger.info(
+                                    "consume: received payload=%s attempts=%s",
+                                    payload,
+                                    attempts,
+                                )
 
                                 if expects_attempts:
                                     await handler(payload, attempts)
                                 else:
                                     await handler(payload)
                                 await message.ack()
+                                logger.info(
+                                    "consume: acked payload=%s attempts=%s",
+                                    payload,
+                                    attempts,
+                                )
                             except (
                                 json.JSONDecodeError,
                                 aio_exc.AMQPError,
@@ -268,6 +281,11 @@ class RabbitMQClient:
                                 finally:
                                     if republished:
                                         await message.ack()
+                                        logger.info(
+                                            "consume: acked after republish payload=%s attempts=%s",
+                                            payload,
+                                            cur_attempts,
+                                        )
                 except asyncio.CancelledError:
                     break
                 except aio_exc.AMQPError:  # pragma: no cover - network errors

--- a/app/services/worker_rmq.py
+++ b/app/services/worker_rmq.py
@@ -74,6 +74,12 @@ async def handle(
     try:
         plat = payload.get("platform")
         act = payload.get("action")
+        logger.info(
+            "worker: handle platform=%s action=%s attempts=%s",
+            plat,
+            act,
+            attempts,
+        )
         if not isinstance(plat, str) or not isinstance(act, str):
             raise RuntimeError(f"unknown task: {payload}")
         handler = HANDLERS.get((plat, act))
@@ -83,6 +89,12 @@ async def handle(
         if payload.get("msg_key") is not None:
             data.setdefault("msg_key", payload["msg_key"])
         await handler(data)
+        logger.info(
+            "worker: done platform=%s action=%s attempts=%s",
+            plat,
+            act,
+            attempts,
+        )
 
     except ReauthRequired as err:
         logger.warning("ReauthRequired: %s", err)


### PR DESCRIPTION
## Summary
- log when RabbitMQ tasks are published, retried, or dead-lettered
- log consumption and acknowledgement of tasks
- log worker task start and completion

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1d714b0b483219f51953aa845d5fc