### PR TITLE
Handle hh worker payload using external_id

### DIFF
--- a/app/services/worker/hh.py
+++ b/app/services/worker/hh.py
@@ -16,11 +16,13 @@ async def handle_hh_send_message(payload: dict):
     """Отправить сообщение кандидату.
 
     payload:
-        negotiation_id (str) — ID отклика/приглашения (nid)
+        negotiation_id | external_id (str) — ID отклика/приглашения (nid)
         text (str) — текст сообщения
         owner_id (str|None) — работодатель/менеджер
     """
-    nid = payload["negotiation_id"]
+    nid = payload.get("negotiation_id") or payload.get("external_id")
+    if not nid:
+        raise KeyError("negotiation_id")
     text = payload["text"]
     owner_id = payload.get("owner_id")
 
@@ -48,11 +50,13 @@ async def handle_hh_set_state(payload: dict):
     """Перевести отклик на следующий этап.
 
     payload:
-        negotiation_id (str) — ID отклика/приглашения (nid)
+        negotiation_id | external_id (str) — ID отклика/приглашения (nid)
         action_id (str) — действие, например 'phone_interview', 'interview'
         owner_id (str|None) — работодатель/менеджер
     """
-    nid = payload["negotiation_id"]
+    nid = payload.get("negotiation_id") or payload.get("external_id")
+    if not nid:
+        raise KeyError("negotiation_id")
     action_id = payload["action_id"]
     owner_id = payload.get("owner_id")
 

--- a/tests/test_worker_handlers.py
+++ b/tests/test_worker_handlers.py
@@ -40,6 +40,21 @@ async def test_hh_send_message_idempotent(monkeypatch, in_memory_db):
 
 
 @pytest.mark.asyncio
+async def test_hh_send_message_external_id(monkeypatch):
+    calls = []
+
+    async def fake_send_message(response_id, text, employer_id, client):
+        calls.append((response_id, text))
+
+    monkeypatch.setattr(worker_hh.hh_adapt, "send_message", fake_send_message)
+    monkeypatch.setattr(worker_hh, "get_http_client", lambda: object())
+
+    payload = {"external_id": "nid", "text": "hi"}
+    await worker_hh.handle_hh_send_message(payload)
+    assert calls == [("nid", "hi")]
+
+
+@pytest.mark.asyncio
 async def test_hh_set_state_idempotent(monkeypatch, in_memory_db):
     calls = []
 
@@ -53,6 +68,21 @@ async def test_hh_set_state_idempotent(monkeypatch, in_memory_db):
     await worker_hh.handle_hh_set_state(payload)
     await worker_hh.handle_hh_set_state(payload)
     assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_hh_set_state_external_id(monkeypatch):
+    calls = []
+
+    async def fake_set_state(response_id, target_state, employer_id, client):
+        calls.append((response_id, target_state))
+
+    monkeypatch.setattr(worker_hh.hh_adapt, "set_employer_state", fake_set_state)
+    monkeypatch.setattr(worker_hh, "get_http_client", lambda: object())
+
+    payload = {"external_id": "nid", "action_id": "state"}
+    await worker_hh.handle_hh_set_state(payload)
+    assert calls == [("nid", "state")]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- accept `external_id` alias for `negotiation_id` in hh worker handlers
- cover worker handlers with tests using `external_id`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c1da60386883219dc9542db9a2d7bb