### PR TITLE
Deduplicate HH send_message by response id

### DIFF
--- a/app/services/worker/hh.py
+++ b/app/services/worker/hh.py
@@ -26,8 +26,6 @@ async def handle_hh_send_message(payload: dict):
     text = payload["text"]
     owner_id = payload.get("owner_id")
 
-    msg_key = payload.get("msg_key")
-
     async def _op():
         logger.info("hh.send_message: %s text=%r", nid, text[:40])
         client = get_http_client()
@@ -38,12 +36,12 @@ async def handle_hh_send_message(payload: dict):
             client=client,
         )
 
-    if msg_key:
-        dedup = calc_key("hh_send_message", msg_key)
-        if not await once(dedup, 72 * 3600, _op):
-            return
-    else:
-        await _op()
+    # Дедупликация теперь основана на идентификаторе отклика,
+    # что предотвращает повторную отправку одинаковых сообщений
+    # одному и тому же кандидату.
+    dedup = calc_key("hh_send_message", nid)
+    if not await once(dedup, 72 * 3600, _op):
+        return
 
 
 async def handle_hh_set_state(payload: dict):

--- a/tests/test_worker_handlers.py
+++ b/tests/test_worker_handlers.py
@@ -40,6 +40,25 @@ async def test_hh_send_message_idempotent(monkeypatch, in_memory_db):
 
 
 @pytest.mark.asyncio
+async def test_hh_send_message_dedup_by_nid(monkeypatch, in_memory_db):
+    calls = []
+
+    async def fake_send_message(response_id, text, employer_id, client):
+        calls.append((response_id, text))
+
+    monkeypatch.setattr(worker_hh.hh_adapt, "send_message", fake_send_message)
+    monkeypatch.setattr(worker_hh, "get_http_client", lambda: object())
+
+    payload1 = {"negotiation_id": "nid", "text": "hi", "msg_key": "k1"}
+    payload2 = {"negotiation_id": "nid", "text": "hi", "msg_key": "k2"}
+
+    await worker_hh.handle_hh_send_message(payload1)
+    await worker_hh.handle_hh_send_message(payload2)
+
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_hh_send_message_external_id(monkeypatch):
     calls = []
 


### PR DESCRIPTION
## Summary
- prevent repeated HH chat messages by deduplicating send_message tasks on negotiation id
- test worker handles duplicate send_message tasks with different msg_keys

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1de52b1c88321a50c3cbd58771c57