### PR TITLE
Fix dedup cleanup interval handling

### DIFF
--- a/app/services/dedup.py
+++ b/app/services/dedup.py
@@ -38,7 +38,7 @@ async def cleanup_older_than(seconds: int = 72 * 3600) -> int:
     async with get_session() as s:
         q = text(
             "DELETE FROM events_dedup WHERE created_at < (NOW() AT TIME ZONE 'utc') - "
-            "(:sec || ' seconds')::interval"
+            "make_interval(secs => :sec)"
         )
         res = await s.execute(q, {"sec": seconds})
         await s.commit()

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,37 @@
+import pytest
+
+from app.services import dedup
+
+
+class DummySession:
+    def __init__(self):
+        self.params = None
+
+    async def execute(self, q, params):
+        self.params = params
+        class Res:
+            rowcount = 0
+        return Res()
+
+    async def commit(self):
+        pass
+
+
+class DummyContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_cleanup_older_than_passes_seconds_as_int(monkeypatch):
+    session = DummySession()
+    monkeypatch.setattr(dedup, "get_session", lambda: DummyContext(session))
+    await dedup.cleanup_older_than(42)
+    assert isinstance(session.params["sec"], int)
+    assert session.params["sec"] == 42


### PR DESCRIPTION
## Summary
- avoid string parameter when cleaning events dedup
- test cleanup function passes numeric interval

## Testing
- `pytest tests/test_dedup.py`
- `pytest` *(fails: Network is unreachable, unrecognized Avito payload format)*

------
https://chatgpt.com/codex/tasks/task_e_68c1eb6190d48321b4a9010a6ea63218