### PR TITLE
Fix missing return after HH send_message task

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -46,6 +46,7 @@ async def handle_task(p: dict, attempts: int = 0):
             employer_id=p.get("owner_id"),
             client=get_http_client(),
         )
+        return
 
     if p["platform"] == "avito" and p["action"] == "mark_read":
         await avito_adapt.mark_read(

--- a/tests/test_api_tasks.py
+++ b/tests/test_api_tasks.py
@@ -1,0 +1,26 @@
+import pytest
+from app.api import tasks as api_tasks
+
+@pytest.mark.asyncio
+async def test_handle_task_hh_send_message(monkeypatch):
+    called = {}
+
+    async def fake_send_message(response_id, text, employer_id, client):
+        called['args'] = (response_id, text, employer_id)
+        called['client'] = client
+
+    monkeypatch.setattr(api_tasks.hh_adapt, 'send_message', fake_send_message)
+    monkeypatch.setattr(api_tasks, 'get_http_client', lambda: 'client')
+
+    payload = {
+        'platform': 'hh',
+        'action': 'send_message',
+        'negotiation_id': 'nid',
+        'text': 'hi',
+        'owner_id': 'owner',
+    }
+
+    await api_tasks.handle_task(payload)
+
+    assert called['args'] == ('nid', 'hi', 'owner')
+    assert called['client'] == 'client'


### PR DESCRIPTION
## Summary
- ensure `handle_task` stops after sending HH message to prevent requeueing
- add regression test for HH send_message task handler

## Testing
- `pytest` *(fails: Network is unreachable, unrecognized Avito payload format)*

------
https://chatgpt.com/codex/tasks/task_e_68c1efe9c5dc8321883e4e6c39d3253b