### PR TITLE
feat: add database-backed task queue

### DIFF
--- a/alembic/versions/ee1b2ca2553f_add_tasks_table.py
+++ b/alembic/versions/ee1b2ca2553f_add_tasks_table.py
@@ -1,0 +1,38 @@
+"""add tasks table
+
+Revision ID: ee1b2ca2553f
+Revises: 9c2466183e7f
+Create Date: 2025-08-20 20:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'ee1b2ca2553f'
+down_revision: Union[str, Sequence[str], None] = '9c2466183e7f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'tasks',
+        sa.Column('task_id', sa.Text(), primary_key=True, nullable=False),
+        sa.Column('candidate_id', sa.Text(), nullable=False),
+        sa.Column('payload', sa.JSON(), nullable=False),
+        sa.Column('status', sa.Text(), nullable=False, server_default='pending'),
+        sa.Column('attempts', sa.Integer(), nullable=False, server_default='0'),
+        sa.Column('created_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+    )
+    op.create_index(op.f('ix_tasks_status'), 'tasks', ['status'], unique=False)
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_index(op.f('ix_tasks_status'), table_name='tasks')
+    op.drop_table('tasks')

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from sqlalchemy import BigInteger, Text, Integer, TIMESTAMP, UniqueConstraint
+from sqlalchemy import BigInteger, Text, Integer, TIMESTAMP, UniqueConstraint, JSON
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
+from typing import Any
 from .base import Base
 
 
@@ -115,3 +116,25 @@ class EventDedup(Base):
         TIMESTAMP(timezone=True),
         server_default=func.now(),  # pylint: disable=not-callable
     )
+
+
+class Task(Base):
+    """Background tasks with idempotent processing semantics."""
+
+    __tablename__ = "tasks"
+
+    task_id: Mapped[str] = mapped_column(Text, primary_key=True)
+    candidate_id: Mapped[str] = mapped_column(Text, nullable=False)
+    payload: Mapped[dict[str, Any]] = mapped_column(JSON, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False, index=True, default="pending")
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),  # pylint: disable=not-callable
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),  # pylint: disable=not-callable
+        onupdate=func.now(),  # pylint: disable=not-callable
+    )
+

--- a/app/services/db_task_queue.py
+++ b/app/services/db_task_queue.py
@@ -1,0 +1,61 @@
+"""Database-backed task queue ensuring idempotent processing."""
+
+from __future__ import annotations
+
+from typing import Any, Awaitable, Callable, Dict
+
+from sqlalchemy import select
+from sqlalchemy.dialects.postgresql import insert
+
+from app.db import get_session
+from app.db.models import Task
+
+
+async def enqueue_task(task_id: str, candidate_id: str, payload: Dict[str, Any]) -> Task:
+    """Insert a new task if it doesn't exist and return it."""
+    async with get_session() as session:
+        stmt = (
+            insert(Task)
+            .values(task_id=task_id, candidate_id=candidate_id, payload=payload)
+            .on_conflict_do_nothing(index_elements=[Task.task_id])
+        )
+        await session.execute(stmt)
+        await session.commit()
+
+    async with get_session() as session:
+        return (
+            await session.execute(select(Task).where(Task.task_id == task_id))
+        ).scalar_one()
+
+
+async def process_next_task(handler: Callable[[Dict[str, Any]], Awaitable[None]]) -> bool:
+    """Fetch the next pending task and process it with ``handler``.
+
+    Returns ``True`` if a task was processed, otherwise ``False``.
+    If ``handler`` raises an exception, the task is returned to ``pending``
+    and the exception is propagated.
+    """
+    async with get_session() as session:
+        row = (
+            await session.execute(
+                select(Task)
+                .where(Task.status == "pending")
+                .order_by(Task.created_at)
+                .with_for_update(skip_locked=True)
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        if row is None:
+            await session.commit()
+            return False
+        try:
+            await handler(row.payload)
+        except Exception:  # pylint: disable=broad-except
+            row.attempts += 1
+            row.status = "pending"
+            await session.commit()
+            raise
+        else:
+            row.status = "done"
+            await session.commit()
+            return True

--- a/tests/test_db_task_queue.py
+++ b/tests/test_db_task_queue.py
@@ -1,0 +1,46 @@
+import pytest
+from sqlalchemy import select, func
+
+from app.services.db_task_queue import enqueue_task, process_next_task
+from app.db import get_session
+from app.db.models import Task
+
+
+@pytest.mark.asyncio
+async def test_enqueue_unique(in_memory_db):
+    await enqueue_task("task1", "cand1", {"msg": "hello"})
+    await enqueue_task("task1", "cand1", {"msg": "hello again"})
+    async with get_session() as session:
+        cnt = await session.scalar(select(func.count()).select_from(Task))
+        assert cnt == 1
+
+
+@pytest.mark.asyncio
+async def test_process_next_task_success(in_memory_db):
+    await enqueue_task("task1", "cand1", {"msg": "hi"})
+
+    async def handler(payload):
+        assert payload["msg"] == "hi"
+
+    processed = await process_next_task(handler)
+    assert processed is True
+    async with get_session() as session:
+        row = (await session.execute(select(Task).where(Task.task_id == "task1"))).scalar_one()
+        assert row.status == "done"
+        assert row.attempts == 0
+
+
+@pytest.mark.asyncio
+async def test_process_next_task_failure_keeps_pending(in_memory_db):
+    await enqueue_task("task1", "cand1", {"msg": "boom"})
+
+    async def handler(payload):
+        raise RuntimeError("fail")
+
+    with pytest.raises(RuntimeError):
+        await process_next_task(handler)
+
+    async with get_session() as session:
+        row = (await session.execute(select(Task).where(Task.task_id == "task1"))).scalar_one()
+        assert row.status == "pending"
+        assert row.attempts == 1


### PR DESCRIPTION
## Summary
- add persistent `tasks` table to track background jobs
- implement db-backed task queue helpers and migration
- cover queue behavior with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c265e2b4c08321b37b44e3d068a4ba