### PR TITLE
Register mirror and amo tasks

### DIFF
--- a/app/api/tasks.py
+++ b/app/api/tasks.py
@@ -4,9 +4,19 @@ import time as _time
 
 from app.adapters import avito as avito_adapt, hh as hh_adapt
 from app.adapters.amo_client import AmoClient
-from app.services.hh_autofill import autofill_hh_mapping
 from app.db.token_store import DbTokenStore
 from app.http_client import get_http_client
+from app.services.hh_autofill import autofill_hh_mapping
+from app.services.worker.amo import (
+    handle_amo_add_note,
+    handle_amo_add_tags,
+    handle_amo_update_status,
+)
+from app.services.worker.mirror import (
+    handle_mirror_amo_to_tg,
+    handle_mirror_bot_to_amo,
+    handle_mirror_tg_to_amo,
+)
 
 
 async def handle_task(p: dict, attempts: int = 0):
@@ -68,6 +78,30 @@ async def handle_task(p: dict, attempts: int = 0):
     if p["platform"] == "amo" and p["action"] == "amo_create_lead":
         amo = await AmoClient.create(get_http_client())
         await amo.create_leads(p["lead_body"])
+        return
+
+    if p.get("platform") == "amo" and p.get("action") == "amo_add_note":
+        await handle_amo_add_note(p)
+        return
+
+    if p.get("platform") == "amo" and p.get("action") == "amo_add_tags":
+        await handle_amo_add_tags(p)
+        return
+
+    if p.get("platform") == "amo" and p.get("action") == "amo_update_status":
+        await handle_amo_update_status(p)
+        return
+
+    if p.get("platform") == "mirror" and p.get("action") == "amo_to_tg":
+        await handle_mirror_amo_to_tg(p)
+        return
+
+    if p.get("platform") == "mirror" and p.get("action") == "tg_to_amo":
+        await handle_mirror_tg_to_amo(p)
+        return
+
+    if p.get("platform") == "mirror" and p.get("action") == "bot_to_amo":
+        await handle_mirror_bot_to_amo(p)
         return
 
     raise RuntimeError(f"Unknown task: {p}")

--- a/tests/test_api_tasks.py
+++ b/tests/test_api_tasks.py
@@ -24,3 +24,41 @@ async def test_handle_task_hh_send_message(monkeypatch):
 
     assert called['args'] == ('nid', 'hi', 'owner')
     assert called['client'] == 'client'
+
+
+@pytest.mark.asyncio
+async def test_handle_task_mirror_tg_to_amo(monkeypatch):
+    called = {}
+
+    async def fake_handler(payload):
+        called['payload'] = payload
+
+    monkeypatch.setattr(api_tasks, 'handle_mirror_tg_to_amo', fake_handler)
+
+    payload = {
+        'platform': 'mirror',
+        'action': 'tg_to_amo',
+    }
+
+    await api_tasks.handle_task(payload)
+
+    assert called['payload'] is payload
+
+
+@pytest.mark.asyncio
+async def test_handle_task_amo_add_note(monkeypatch):
+    called = {}
+
+    async def fake_handler(payload):
+        called['payload'] = payload
+
+    monkeypatch.setattr(api_tasks, 'handle_amo_add_note', fake_handler)
+
+    payload = {
+        'platform': 'amo',
+        'action': 'amo_add_note',
+    }
+
+    await api_tasks.handle_task(payload)
+
+    assert called['payload'] is payload


### PR DESCRIPTION
## Summary
- expand task dispatcher to handle amo note/tag/status updates and mirror message relays
- cover new task types with unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c26f0c737c83219db3aad78dcc629c