### PR TITLE
Filter HH webhook by action type

### DIFF
--- a/app/services/payload_parsers.py
+++ b/app/services/payload_parsers.py
@@ -23,6 +23,10 @@ def parse_hh_payload(raw: bytes, owner_id: str | None = None) -> IncomingPayload
         logger.warning("HH payload parse error: %s", exc)
         raise ValueError("invalid json") from exc
 
+    action_type = str(data.get("action_type") or "").strip()
+    if action_type and action_type != "NEW_NEGOTIATION_VACANCY":
+        raise ValueError(f"unsupported action_type: {action_type}")
+
     obj = (
             data.get("object")
             or data.get("negotiation")

--- a/tests/test_payload_parsers.py
+++ b/tests/test_payload_parsers.py
@@ -41,6 +41,7 @@ def test_parse_hh_payload_new_negotiation():
     raw = json.dumps(
         {
             "id": "notification1",
+            "action_type": "NEW_NEGOTIATION_VACANCY",
             "payload": {
                 "topic_id": "topic1",
                 "resume_id": "resume1",
@@ -57,6 +58,23 @@ def test_parse_hh_payload_new_negotiation():
     assert payload.vacancy_id == "vac1"
     assert payload.applicant.id == "topic1"
     assert payload.applicant.name == "кандидат"
+
+
+def test_parse_hh_payload_unsupported_action():
+    raw = json.dumps(
+        {
+            "id": "notification2",
+            "action_type": "NEGOTIATION_EMPLOYER_STATE_CHANGE",
+            "payload": {
+                "topic_id": "topic1",
+                "vacancy_id": "vac1",
+                "employer_id": "emp1",
+            },
+        }
+    ).encode()
+
+    with pytest.raises(ValueError):
+        parse_hh_payload(raw)
 
 
 def test_parse_hh_payload_bad_json():


### PR DESCRIPTION
## Summary
- ignore HH webhook events except `NEW_NEGOTIATION_VACANCY`
- add tests for supported and unsupported HH action types

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c27588e56483219d5c026a1302f57d