### PR TITLE
Handle client disconnects for HH webhook

### DIFF
--- a/app/api/hh_incoming.py
+++ b/app/api/hh_incoming.py
@@ -2,7 +2,8 @@
 
 import logging
 import httpx
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, Response
+from starlette.requests import ClientDisconnect
 
 from app.api._webhook_common import process_job_board_webhook
 from app.http_client import get_http_client
@@ -24,7 +25,13 @@ async def webhook_hh(
     Fetches the raw request body and passes it to the generic job board
     webhook processor along with the HeadHunter payload parser.
     """
-    raw = await request.body()
+    if request.method == "HEAD" or request.headers.get("content-length") in (None, "0"):
+        raw = b""
+    else:
+        try:
+            raw = await request.body()
+        except ClientDisconnect:
+            return Response(status_code=400)
     try:
         log.info("HH webhook received raw: %s", raw.decode("utf-8"))
     except Exception:

--- a/tests/test_hh_incoming.py
+++ b/tests/test_hh_incoming.py
@@ -1,5 +1,7 @@
 from app.api import hh_incoming, _webhook_common
 from app.models import IncomingPayload, Applicant
+from fastapi import Request
+from starlette.requests import ClientDisconnect
 
 
 def _payload() -> IncomingPayload:
@@ -233,3 +235,38 @@ def test_webhook_tag_error(monkeypatch, client):
     assert r.status_code == 200
     assert r.json() == {"ok": False, "error": "internal_error"}
     assert called["invite"] == 123
+
+
+def test_webhook_empty_body(monkeypatch, client):
+    async def fake_check(key):
+        return True
+
+    monkeypatch.setattr(_webhook_common, "check_and_store", fake_check)
+
+    async def fake_body(self):
+        raise AssertionError("body should not be read")
+
+    monkeypatch.setattr(Request, "body", fake_body)
+
+    r = client.post("/webhooks/hh/1")
+    assert r.status_code == 200
+    assert r.json() == {"ok": True, "skipped": True}
+
+
+def test_webhook_client_disconnect(monkeypatch, client):
+    called = {}
+
+    async def fake_check(key):
+        called["called"] = True
+        return True
+
+    monkeypatch.setattr(_webhook_common, "check_and_store", fake_check)
+
+    async def fake_body(self):
+        raise ClientDisconnect()
+
+    monkeypatch.setattr(Request, "body", fake_body)
+
+    r = client.post("/webhooks/hh/1", data=b"{}")
+    assert r.status_code == 400
+    assert "called" not in called


### PR DESCRIPTION
## Summary
- safely read HH webhook requests by guarding against empty bodies and disconnected clients
- add regression tests for empty body and client disconnect scenarios

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c28751383c832195761a21fbb9fb61