### PR TITLE
Add retry logic for Telegram webhook registration

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -92,6 +92,9 @@ class Settings(BaseSettings):
     TELEGRAM_WEBHOOK_SECRET: str = ""
     TELEGRAM_WEBHOOK_BASE: str = ""
     TELEGRAM_WEBHOOK_MODE: bool = True
+    TELEGRAM_WEBHOOK_TIMEOUT: int = 10
+    TELEGRAM_WEBHOOK_RETRIES: int = 3
+    TELEGRAM_WEBHOOK_RETRY_DELAY: float = 1.0
 
     # Админ
     ADMIN_TOKEN: str = ""  # не обязателен для тестов; проверим в validate_required()

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import time
 
 import uvicorn
 from aiogram import Bot
+from aiogram.exceptions import TelegramNetworkError
 from fastapi import FastAPI, Depends, APIRouter
 
 from app.adapters.amochats import ensure_amo_chats_connected
@@ -77,16 +78,38 @@ async def auto_register_telegram_webhooks() -> None:
     if s.TELEGRAM_OPERATOR_BOT_TOKEN:
         try:
             async with Bot(s.TELEGRAM_OPERATOR_BOT_TOKEN) as o_bot:
-                await o_bot.set_webhook(
-                    url=f"{base}/tg/webhook/operator",
-                    secret_token=secret,
-                    allowed_updates=allowed,
-                    drop_pending_updates=True,
-                )
-                info = await o_bot.get_webhook_info()
-                log.info("Operator webhook set -> %s (pending=%s)", info.url, info.pending_update_count)
+                for attempt in range(s.TELEGRAM_WEBHOOK_RETRIES):
+                    try:
+                        await o_bot.set_webhook(
+                            url=f"{base}/tg/webhook/operator",
+                            secret_token=secret,
+                            allowed_updates=allowed,
+                            drop_pending_updates=True,
+                            request_timeout=s.TELEGRAM_WEBHOOK_TIMEOUT,
+                        )
+                        info = await o_bot.get_webhook_info()
+                        log.info(
+                            "Operator webhook set -> %s (pending=%s)",
+                            info.url,
+                            info.pending_update_count,
+                        )
+                        break
+                    except TelegramNetworkError as e:
+                        log.warning(
+                            "Attempt %d to set operator webhook failed: %s",
+                            attempt + 1,
+                            e,
+                        )
+                        if attempt + 1 == s.TELEGRAM_WEBHOOK_RETRIES:
+                            log.exception(
+                                "Failed to set operator webhook after %d attempts",
+                                s.TELEGRAM_WEBHOOK_RETRIES,
+                            )
+                            raise RuntimeError("Failed to set operator webhook") from e
+                        await asyncio.sleep(s.TELEGRAM_WEBHOOK_RETRY_DELAY)
         except Exception:
             log.exception("Failed to set operator webhook")
+            raise
 
 
 @app.on_event("startup")


### PR DESCRIPTION
## Summary
- make Telegram webhook timeout, retries, and delay configurable via environment variables
- retry operator bot webhook registration and fail clearly after repeated network errors

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c28858d52c8321801593466a16cd57