### PR TITLE
Handle AmoChats client conversation IDs

### DIFF
--- a/app/api/api_amochats.py
+++ b/app/api/api_amochats.py
@@ -133,18 +133,24 @@ async def links_from_ext_id(
 
 
 async def resolve_links(
-        conv_ref_id: str | None, lead_id: int | None, sender: dict, receiver: dict
+        conv_ref_id: str | None,
+        client_conv_id: str | None,
+        lead_id: int | None,
+        sender: dict,
+        receiver: dict,
 ):
-    """Resolve links based on conversation, lead, or external identifiers."""
+    """Resolve links using conversation IDs, lead mapping, or external identifiers."""
     links = []
     if conv_ref_id:
         links = await get_by_conversation(conv_ref_id)
+    if not links and client_conv_id:
+        links = await get_by_conversation(client_conv_id)
     if not links and lead_id:
         links = await get_by_lead(lead_id)
-        if links and conv_ref_id:
-            await set_conv_for_links(links, conv_ref_id)
+        if links and (conv_ref_id or client_conv_id):
+            await set_conv_for_links(links, conv_ref_id or client_conv_id)
     if not links:
-        links = await links_from_ext_id(conv_ref_id, sender, receiver)
+        links = await links_from_ext_id(conv_ref_id or client_conv_id, sender, receiver)
     return links
 
 
@@ -209,12 +215,13 @@ async def amochats_in(
     )
 
     lead_id = parse_lead_id(client_id)
-    links = await resolve_links(conv_ref_id, lead_id, sender, receiver)
+    links = await resolve_links(conv_ref_id, client_id, lead_id, sender, receiver)
 
     logger.info(
-        "amo-chats links found: %d (conv=%s lead=%s)",
+        "amo-chats links found: %d (conv=%s client_conv=%s lead=%s)",
         len(links),
         conv_ref_id,
+        client_id,
         lead_id,
     )
 

--- a/tests/test_api_amochats.py
+++ b/tests/test_api_amochats.py
@@ -1,0 +1,19 @@
+import pytest
+from app.store_chat import upsert_tg_link, set_conversation
+from app.api.api_amochats import resolve_links
+
+@pytest.mark.asyncio
+async def test_resolve_links_uses_client_conv_id(in_memory_db):
+    user_id = 123
+    bot_kind = "master"
+    lead_id = 20832209
+    conv_client_id = "contact:21982943"
+    chat_id = "97ddeb13-db49-4988-8160-5db861425fc2"
+
+    await upsert_tg_link(user_id, bot_kind, lead_id)
+    await set_conversation(user_id, bot_kind, conv_client_id)
+
+    links = await resolve_links(chat_id, conv_client_id, None, {}, {})
+    assert len(links) == 1
+    assert links[0].user_id == user_id
+    assert links[0].conversation_id == conv_client_id


### PR DESCRIPTION
## Summary
- Resolve AmoChats incoming messages using client conversation IDs when chat UUIDs are provided
- Add test verifying link resolution via client conversation ID

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2ade9b9fc832191bba0bf2edf7fe6