### PR TITLE
Mirror survey prompts to Amo chats

### DIFF
--- a/app/services/worker/mirror.py
+++ b/app/services/worker/mirror.py
@@ -163,6 +163,7 @@ async def handle_mirror_bot_to_amo(payload: dict):
     conv_id = payload.get("conversation_id")
     lead_id = payload.get("lead_id")
     status_id = payload.get("status_id")
+    bot_kind = payload.get("bot_kind")
 
     http_client = get_http_client()
     text_sent = False
@@ -196,6 +197,9 @@ async def handle_mirror_bot_to_amo(payload: dict):
         )
 
         text_sent = True
+
+        if isinstance(bot_kind, str):
+            await set_conversation(user_id, bot_kind, conv_id)
 
         if status_id is not None:
             dedup = calc_key("chat_status", f"{lead_id}:{status_id}")

--- a/app/tg_router.py
+++ b/app/tg_router.py
@@ -42,6 +42,7 @@ def make_router(bot_kind: str, queue_client: RabbitMQClient = rabbitmq) -> Dispa
                 "user_name": user.username,
                 "conversation_id": conv_id,
                 "lead_id": lead_id,
+                "bot_kind": bot_kind,
                 "msg_key": msg_key,
             }
         )

--- a/tests/test_tg_router.py
+++ b/tests/test_tg_router.py
@@ -95,6 +95,7 @@ async def test_start(monkeypatch, queue_mock):
     assert sent and "Здравствуйте" in sent[0]["text"]
     assert queue_mock[-1]["action"] == "bot_to_amo"
     assert queue_mock[-1]["lead_id"] == 777
+    assert queue_mock[-1]["bot_kind"] == "master"
 
 
 @pytest.mark.asyncio
@@ -127,6 +128,7 @@ async def test_text_step(monkeypatch, queue_mock):
     assert sent and "Опишите" in sent[0]["text"]
     assert queue_mock[0]["action"] == "tg_to_amo"
     assert queue_mock[1]["action"] == "bot_to_amo"
+    assert queue_mock[1]["bot_kind"] == "master"
     assert svc.data[1]["step"] == 1
 
 
@@ -165,6 +167,7 @@ async def test_survey_finish(monkeypatch, queue_mock):
     assert sent and "Спасибо" in sent[0]["text"]
     assert queue_mock[0]["action"] == "tg_to_amo"
     assert queue_mock[1]["action"] == "bot_to_amo"
+    assert queue_mock[1]["bot_kind"] == "master"
     # finish called with summary
     assert svc.finished and "Итоги опроса" in svc.finished[3]
 


### PR DESCRIPTION
## Summary
- include bot kind when mirroring survey prompts so Amo can track which bot sent the message
- store Amo chat conversation id after sending bot messages
- cover bot kind field in Telegram router tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2b40f3ee083219240df052f9e109a