### PR TITLE
Mirror bot questions as manager in Amo chat

### DIFF
--- a/app/services/worker/mirror.py
+++ b/app/services/worker/mirror.py
@@ -219,14 +219,13 @@ async def handle_mirror_bot_to_amo(payload: dict):
         raise RuntimeError("bot_to_amo: no conversation_id and no lead_id to create one")
 
     if not text_sent:
-        lead_for_call = int(lead_id) if lead_id is not None else 0
         await with_retry(
-            lambda: send_text_from_client(
-                lead_id=lead_for_call,
-                text=text,
-                tg_user_id=user_id,
-                tg_user_name=user_name,
+            lambda: send_text_from_manager(
                 conversation_id=conv_id,
+                user_id=user_id,
+                user_name=user_name,
+                avatar=None,
+                text=text,
                 client=http_client,
             ),
             attempts=6,


### PR DESCRIPTION
## Summary
- Send bot-generated messages to Amo chat via `send_text_from_manager`
- Drop unused lead mapping for manager messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2e79a1f8883219df01caf3a55a9b0