### PR TITLE
Fix HH negotiation state URL path order

### DIFF
--- a/app/adapters/hh.py
+++ b/app/adapters/hh.py
@@ -51,7 +51,7 @@ async def set_employer_state(
 
     ua = getattr(s, "HH_USER_AGENT", None) or getattr(s, "APP_USER_AGENT",
                                                       None) or "hr-bridge/1.0 (support@example.com)"
-    url = f"{s.HH_API_BASE.rstrip('/')}/negotiations/{target_state}/{response_id}"
+    url = f"{s.HH_API_BASE.rstrip('/')}/negotiations/{response_id}/{target_state}"
 
     await request_with_retry(
         client,

--- a/tests/test_adapters_hh.py
+++ b/tests/test_adapters_hh.py
@@ -7,6 +7,30 @@ from app.adapters import hh
 
 
 @pytest.mark.asyncio
+async def test_hh_set_employer_state(monkeypatch, token_mock):
+    async def fake_with_retry(coro, attempts, is_retryable):
+        return await coro()
+
+    monkeypatch.setattr(hh, "with_retry", fake_with_retry)
+    token = token_mock
+
+    captured = {}
+
+    def handler(request):
+        captured["url"] = str(request.url)
+        captured["method"] = request.method
+        assert request.headers["Authorization"] == f"Bearer {token}"
+        assert request.headers["Accept"] == "application/json"
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        await hh.set_employer_state("resp1", "interview", "emp1", client)
+
+    assert captured["url"].endswith("/negotiations/resp1/interview")
+    assert captured["method"] == "PUT"
+
+
+@pytest.mark.asyncio
 async def test_hh_send_message(monkeypatch, token_mock):
     async def fake_with_retry(coro, attempts, is_retryable):
         return await coro()


### PR DESCRIPTION
## Summary
- correct HH negotiation state URL to `/negotiations/{response_id}/{target_state}`
- add unit test verifying URL path and HTTP method

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2ebfe0b288321b9e55f7c507cde4d