### PR TITLE
Refresh HH mapping on stage rename

### DIFF
--- a/app/services/hh_autofill.py
+++ b/app/services/hh_autofill.py
@@ -66,7 +66,7 @@ async def autofill_hh_mapping(client: httpx.AsyncClient) -> dict[str, str]:
     Строит {amo_status_id: hh_code} по названиям стадий двух воронок (master/operator)
     и сохраняет в data/hh_mapping.json.
     """
-    existing = hh_map_load().copy()
+    existing = hh_map_load()
     result = existing.copy()
 
     s = get_settings()
@@ -87,12 +87,13 @@ async def autofill_hh_mapping(client: httpx.AsyncClient) -> dict[str, str]:
 
         found = 0
         for st in statuses:
+            sid = str(st.get("id"))
+            if not sid:
+                continue
+            result.pop(sid, None)
             name = _norm_stage_name(st.get("name", ""))
             hh_code = _STAGE_NAME_TO_HH.get(name)
             if not hh_code:
-                continue
-            sid = str(st.get("id"))
-            if not sid:
                 continue
             result[sid] = hh_code
             found += 1

--- a/tests/test_hh_autofill.py
+++ b/tests/test_hh_autofill.py
@@ -1,0 +1,39 @@
+import httpx
+import pytest
+
+from app.services import hh_autofill
+
+
+@pytest.mark.asyncio
+async def test_stage_rename_updates_mapping(monkeypatch):
+    mapping_store = {"1": "response"}
+    fake_statuses = []
+
+    async def fake_fetch_pipeline_statuses(pipeline_id, client):  # pragma: no cover - simple stub
+        return fake_statuses
+
+    class DummySettings:
+        AMO_PIPELINE_ID_MASTER = 123
+        AMO_PIPELINE_ID_OPERATOR = None
+
+    monkeypatch.setattr(hh_autofill, "_fetch_pipeline_statuses", fake_fetch_pipeline_statuses)
+    monkeypatch.setattr(hh_autofill, "get_settings", lambda: DummySettings())
+    monkeypatch.setattr(hh_autofill, "hh_map_load", lambda: mapping_store.copy())
+
+    def fake_set(mapping):
+        nonlocal mapping_store
+        mapping_store = mapping.copy()
+        return mapping
+
+    monkeypatch.setattr(hh_autofill, "hh_map_set", fake_set)
+
+    fake_statuses = [{"id": 1, "name": "Собеседование"}]
+    async with httpx.AsyncClient() as client:
+        result = await hh_autofill.autofill_hh_mapping(client)
+    assert result == {"1": "interview"}
+
+    fake_statuses = [{"id": 1, "name": "Другая"}]
+    async with httpx.AsyncClient() as client:
+        result = await hh_autofill.autofill_hh_mapping(client)
+    assert result == {}
+


### PR DESCRIPTION
## Summary
- remove stale status mappings when rebuilding HH mapping
- ensure stage rename updates HH mapping

## Testing
- `pytest tests/test_hh_autofill.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2edffe5c883219190df0234647d9d