### PR TITLE
Expand HH stage name synonyms

### DIFF
--- a/app/services/hh_autofill.py
+++ b/app/services/hh_autofill.py
@@ -24,11 +24,25 @@ def _norm_stage_name(s: str) -> str:
 # Название стадии Amo (нормализованное) -> код HH
 _STAGE_NAME_TO_HH = {
     "отклик": "response",
+    "откликполучен": "response",
     "первичныйконтакт": "phone_interview",
+    "прошелопрос": "phone_interview",
+    "пройденопрос": "phone_interview",
+    "опроспройден": "phone_interview",
     "собеседование": "interview",
+    "пройденособеседование": "interview",
+    "прошелсобеседование": "interview",
     "выходнаработу": "hired",
+    "вышелнаработу": "hired",
+    "вышел": "hired",
+    "принят": "hired",
+    "нанят": "hired",
     "отказ": "discard_by_employer",
+    "отклонен": "discard_by_employer",
+    "неподходит": "discard_by_employer",
     "закрытоинереализовано": "discard_by_employer",
+    "закрыто": "discard_by_employer",
+    "неактуально": "discard_by_employer",
 }
 
 

--- a/app/services/hh_autofill.py
+++ b/app/services/hh_autofill.py
@@ -25,6 +25,7 @@ def _norm_stage_name(s: str) -> str:
 _STAGE_NAME_TO_HH = {
     "отклик": "response",
     "откликполучен": "response",
+    "новыйотклик": "response",
     "первичныйконтакт": "phone_interview",
     "прошелопрос": "phone_interview",
     "пройденопрос": "phone_interview",
@@ -43,6 +44,10 @@ _STAGE_NAME_TO_HH = {
     "закрытоинереализовано": "discard_by_employer",
     "закрыто": "discard_by_employer",
     "неактуально": "discard_by_employer",
+    "кандидатотказался": "discard_by_applicant",
+    "невыходитнасвязь": "discard_no_interaction",
+    "вакансиязакрыта": "discard_vacancy_closed",
+    "переводнадругуювакансию": "discard_to_other_vacancy",
 }
 
 

--- a/tests/test_hh_autofill.py
+++ b/tests/test_hh_autofill.py
@@ -44,6 +44,15 @@ async def test_stage_rename_updates_mapping(monkeypatch):
         ("Принят", "принят", "hired"),
         ("Прошел опрос", "прошелопрос", "phone_interview"),
         ("Отклонён", "отклонен", "discard_by_employer"),
+        ("Новый отклик", "новыйотклик", "response"),
+        ("Кандидат отказался", "кандидатотказался", "discard_by_applicant"),
+        ("Не выходит на связь", "невыходитнасвязь", "discard_no_interaction"),
+        ("Вакансия закрыта", "вакансиязакрыта", "discard_vacancy_closed"),
+        (
+            "Перевод на другую вакансию",
+            "переводнадругуювакансию",
+            "discard_to_other_vacancy",
+        ),
     ],
 )
 def test_stage_name_normalization_and_mapping(raw, normalized, code):

--- a/tests/test_hh_autofill.py
+++ b/tests/test_hh_autofill.py
@@ -37,3 +37,16 @@ async def test_stage_rename_updates_mapping(monkeypatch):
         result = await hh_autofill.autofill_hh_mapping(client)
     assert result == {}
 
+
+@pytest.mark.parametrize(
+    "raw, normalized, code",
+    [
+        ("Принят", "принят", "hired"),
+        ("Прошел опрос", "прошелопрос", "phone_interview"),
+        ("Отклонён", "отклонен", "discard_by_employer"),
+    ],
+)
+def test_stage_name_normalization_and_mapping(raw, normalized, code):
+    assert hh_autofill._norm_stage_name(raw) == normalized
+    assert hh_autofill._STAGE_NAME_TO_HH[normalized] == code
+


### PR DESCRIPTION
## Summary
- add normalized synonyms like "принят" and "прошел опрос" to HH autofill stage mapping
- test normalization and HH code selection for new stage synonyms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2eef37b70832197f4ac67facaa51f