### PR TITLE
Mirror survey prompts to Amo chat

### DIFF
--- a/app/services/worker/mirror.py
+++ b/app/services/worker/mirror.py
@@ -168,7 +168,6 @@ async def handle_mirror_bot_to_amo(payload: dict):
     bot_kind = payload.get("bot_kind")
 
     http_client = get_http_client()
-    text_sent = False
 
     if not conv_id and lead_id:
 
@@ -191,14 +190,10 @@ async def handle_mirror_bot_to_amo(payload: dict):
                 tg_user_id=user_id,
                 tg_user_name=user_name,
                 client=http_client,
-                init_text=text,
-                init_as_manager=True,
             ),
             attempts=6,
             is_retryable=lambda e: True,
         )
-
-        text_sent = True
 
         if isinstance(bot_kind, str):
             await set_conversation(user_id, bot_kind, conv_id)
@@ -218,16 +213,15 @@ async def handle_mirror_bot_to_amo(payload: dict):
     if not conv_id:
         raise RuntimeError("bot_to_amo: no conversation_id and no lead_id to create one")
 
-    if not text_sent:
-        await with_retry(
-            lambda: send_text_from_manager(
-                conversation_id=conv_id,
-                user_id=user_id,
-                user_name=user_name,
-                avatar=None,
-                text=text,
-                client=http_client,
-            ),
-            attempts=6,
-            is_retryable=lambda e: True,
-        )
+    await with_retry(
+        lambda: send_text_from_manager(
+            conversation_id=conv_id,
+            user_id=user_id,
+            user_name=user_name,
+            avatar=None,
+            text=text,
+            client=http_client,
+        ),
+        attempts=6,
+        is_retryable=lambda e: True,
+    )

--- a/tests/test_worker_mirror_status.py
+++ b/tests/test_worker_mirror_status.py
@@ -16,8 +16,26 @@ async def test_status_update_on_chat_creation(monkeypatch, queue_mock):
         keys.add(key)
         return True
 
+    async def fake_send_text_from_manager(**kwargs):
+        return None
+
+    async def fake_with_retry(func, attempts, is_retryable):
+        return await func()
+
+    class DummyAmo:
+        async def get_lead_with_contacts(self, lead_id):
+            return {}
+
+    class DummyAmoClient:
+        @staticmethod
+        async def create(client):
+            return DummyAmo()
+
     monkeypatch.setattr(worker_mirror, "ensure_chat_created", fake_ensure_chat_created)
     monkeypatch.setattr(worker_mirror, "check_and_store", fake_check_and_store)
+    monkeypatch.setattr(worker_mirror, "send_text_from_manager", fake_send_text_from_manager)
+    monkeypatch.setattr(worker_mirror, "with_retry", fake_with_retry)
+    monkeypatch.setattr(worker_mirror, "AmoClient", DummyAmoClient)
 
     payload = {
         "text": "hi",
@@ -38,3 +56,54 @@ async def test_status_update_on_chat_creation(monkeypatch, queue_mock):
             "status_id": 777,
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_bot_message_sent(monkeypatch):
+    conv_id = "lead:123"
+
+    async def fake_ensure_chat_created(**kwargs):
+        return conv_id
+
+    called = {}
+
+    async def fake_send_text_from_manager(**kwargs):
+        called["args"] = kwargs
+
+    async def fake_with_retry(func, attempts, is_retryable):
+        return await func()
+
+    class DummyAmo:
+        async def get_lead_with_contacts(self, lead_id):
+            return {}
+
+    class DummyAmoClient:
+        @staticmethod
+        async def create(client):
+            return DummyAmo()
+
+    async def fake_check_and_store(key):
+        return True
+
+    async def fake_set_conversation(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(worker_mirror, "ensure_chat_created", fake_ensure_chat_created)
+    monkeypatch.setattr(worker_mirror, "send_text_from_manager", fake_send_text_from_manager)
+    monkeypatch.setattr(worker_mirror, "with_retry", fake_with_retry)
+    monkeypatch.setattr(worker_mirror, "AmoClient", DummyAmoClient)
+    monkeypatch.setattr(worker_mirror, "check_and_store", fake_check_and_store)
+    monkeypatch.setattr(worker_mirror, "set_conversation", fake_set_conversation)
+
+    payload = {
+        "text": "hello",
+        "user_id": "1",
+        "user_name": "u",
+        "lead_id": "123",
+        "bot_kind": "master",
+    }
+
+    await worker_mirror.handle_mirror_bot_to_amo(payload)
+
+    assert called["args"]["text"] == "hello"
+    assert called["args"]["conversation_id"] == conv_id


### PR DESCRIPTION
## Summary
- ensure bot survey messages are always mirrored to Amo chat by sending as manager messages
- cover bot-to-amo mirroring with additional tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c2f42343f88321905dee967282dd09