### PR TITLE
Fix HeadHunter state change endpoint order

### DIFF
--- a/app/adapters/hh.py
+++ b/app/adapters/hh.py
@@ -51,7 +51,9 @@ async def set_employer_state(
 
     ua = getattr(s, "HH_USER_AGENT", None) or getattr(s, "APP_USER_AGENT",
                                                       None) or "hr-bridge/1.0 (support@example.com)"
-    url = f"{s.HH_API_BASE.rstrip('/')}/negotiations/{response_id}/{target_state}"
+    # Вызов HeadHunter API требует, чтобы действие (state) стояло перед идентификатором
+    # отклика. Ранее аргументы в URL были перепутаны местами, что приводило к 404.
+    url = f"{s.HH_API_BASE.rstrip('/')}/negotiations/{target_state}/{response_id}"
 
     await request_with_retry(
         client,

--- a/tests/test_adapters_hh.py
+++ b/tests/test_adapters_hh.py
@@ -26,7 +26,8 @@ async def test_hh_set_employer_state(monkeypatch, token_mock):
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         await hh.set_employer_state("resp1", "interview", "emp1", client)
 
-    assert captured["url"].endswith("/negotiations/resp1/interview")
+    # URL должен содержать действие перед идентификатором отклика
+    assert captured["url"].endswith("/negotiations/interview/resp1")
     assert captured["method"] == "PUT"
 
 


### PR DESCRIPTION
## Summary
- correct order of negotiation id and action in HH set state URL
- adjust HH adapter test accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2f9dc1ebc832181ddfc4a077a3783