### PR TITLE
feat: persist HH mapping in DB

### DIFF
--- a/alembic/versions/0b8fc995e05c_add_hh_mapping_table.py
+++ b/alembic/versions/0b8fc995e05c_add_hh_mapping_table.py
@@ -1,0 +1,31 @@
+"""add hh_mapping table
+
+Revision ID: 0b8fc995e05c
+Revises: ee1b2ca2553f
+Create Date: 2025-08-21 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '0b8fc995e05c'
+down_revision: Union[str, Sequence[str], None] = 'ee1b2ca2553f'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'hh_mapping',
+        sa.Column('amo_status_id', sa.BigInteger(), primary_key=True, nullable=False),
+        sa.Column('hh_code', sa.Text(), nullable=False),
+        sa.Column('updated_at', sa.TIMESTAMP(timezone=True), server_default=sa.text('now()'), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('hh_mapping')

--- a/app/api/admin.py
+++ b/app/api/admin.py
@@ -46,14 +46,14 @@ async def health() -> dict[str, object]:
 async def get_hh_mapping() -> dict:
     """Return the current HeadHunter mapping."""
 
-    return {"ok": True, "mapping": hh_map_load()}
+    return {"ok": True, "mapping": await hh_map_load()}
 
 
 @admin.put("/hh-mapping")
 async def put_hh_mapping(payload: dict) -> dict:
     """Replace the HeadHunter mapping with ``payload``."""
 
-    return {"ok": True, "mapping": hh_map_set(payload)}
+    return {"ok": True, "mapping": await hh_map_set(payload)}
 
 
 @admin.post("/rmq-test")

--- a/app/api/amo_webhooks.py
+++ b/app/api/amo_webhooks.py
@@ -92,7 +92,7 @@ async def handle_hh_event(
     s = get_settings()
     ext_id = link.get("external_id")
     owner_id = link.get("owner_id")
-    state = hh_map_get(status_id)
+    state = await hh_map_get(status_id)
     if not (state and ext_id):
         return
 
@@ -157,7 +157,7 @@ async def amo_webhook(
     if not await check_and_store(key):
         return {"ok": True, "duplicate": True}
 
-    hh_map_load()
+    await hh_map_load()
     events = await parse_status_events(request)
 
     for lead_id, status_id in events:

--- a/app/db/models.py
+++ b/app/db/models.py
@@ -138,3 +138,17 @@ class Task(Base):
         onupdate=func.now(),  # pylint: disable=not-callable
     )
 
+
+class HhMapping(Base):
+    """Mapping between AmoCRM status IDs and HeadHunter state codes."""
+
+    __tablename__ = "hh_mapping"
+
+    amo_status_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
+    hh_code: Mapped[str] = mapped_column(Text, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True),
+        server_default=func.now(),  # pylint: disable=not-callable
+        onupdate=func.now(),  # pylint: disable=not-callable
+    )
+

--- a/app/services/hh_autofill.py
+++ b/app/services/hh_autofill.py
@@ -82,10 +82,10 @@ async def _fetch_pipeline_statuses(
 
 async def autofill_hh_mapping(client: httpx.AsyncClient) -> dict[str, str]:
     """
-    Строит {amo_status_id: hh_code} по названиям стадий двух воронок (master/operator)
-    и сохраняет в data/hh_mapping.json.
+    Строит {amo_status_id: hh_code} по названиям стадий двух воронок
+    (master/operator) и сохраняет их в таблицу ``hh_mapping``.
     """
-    existing = hh_map_load()
+    existing = await hh_map_load()
     result = existing.copy()
 
     s = get_settings()
@@ -120,8 +120,8 @@ async def autofill_hh_mapping(client: httpx.AsyncClient) -> dict[str, str]:
         log.info("hh-autofill: pipeline %s (%s): mapped %d statuses", label, pid, found)
 
     if result != existing:
-        hh_map_set(result)
-        log.info("hh-autofill: hh_mapping.json updated with %d keys", len(result))
+        await hh_map_set(result)
+        log.info("hh-autofill: hh_mapping table updated with %d keys", len(result))
     else:
         log.info("hh-autofill: mapping up-to-date (%d keys)", len(result))
 

--- a/app/services/hh_mapping.py
+++ b/app/services/hh_mapping.py
@@ -1,52 +1,74 @@
 """Utilities for storing and retrieving HeadHunter status mappings.
 
-The mappings are kept in a JSON file on disk and mirrored in an in-memory
-cache for faster access. Helper functions provide safe concurrent reads and
-writes to this data.
+The mappings are stored in the ``hh_mapping`` database table and mirrored in
+an in-memory cache for fast access.  The cache has a simple TTL to avoid
+frequent database hits.
 """
 
-import json
-import os
-from threading import Lock
+from __future__ import annotations
+
+import asyncio
+import time
 from typing import Optional
 
-PATH = "data/hh_mapping.json"
+from sqlalchemy import delete, insert, select
+
+from app.db.db import get_session
+from app.db.models import HhMapping
+
+# Cache settings
+_CACHE_TTL = 60  # seconds
 _cache: dict[str, str] = {}
-_lock = Lock()
+_cache_expire: float = 0
+_lock = asyncio.Lock()
 
 
-def _ensure_dir() -> None:
-    """Create the directory that stores the mapping file if needed."""
-    os.makedirs("data", exist_ok=True)
+async def load() -> dict[str, str]:
+    """Load mappings from the database and refresh the cache."""
 
+    async with get_session() as s:
+        rows = (await s.execute(select(HhMapping))).scalars().all()
+    mapping = {str(row.amo_status_id): row.hh_code for row in rows}
 
-def load() -> dict[str, str]:
-    """Load mappings from disk.
-
-    Returns an empty dictionary when no data file is present.
-    """
-    _ensure_dir()
-    if os.path.exists(PATH):
-        with open(PATH, "r", encoding="utf-8") as f:
-            return json.load(f) or {}
-    return {}
-
-
-def get(status_id: int) -> Optional[str]:
-    """Return the mapped value for ``status_id`` if it exists."""
-    with _lock:
-        if not _cache:
-            _cache.update(load())
-        return _cache.get(str(status_id))
-
-
-def set_all(mapping: dict[str, str]) -> dict[str, str]:
-    """Persist a new mapping to disk and refresh the in-memory cache."""
-    _ensure_dir()
-    with open(PATH, "w", encoding="utf-8") as f:
-        json.dump(mapping, f, ensure_ascii=False, indent=2)
-    new_data = mapping.copy()
-    with _lock:
+    async with _lock:
+        global _cache_expire
         _cache.clear()
-        _cache.update(new_data)
-    return new_data
+        _cache.update(mapping)
+        _cache_expire = time.time() + _CACHE_TTL
+    return mapping
+
+
+async def get(status_id: int) -> Optional[str]:
+    """Return the mapped value for ``status_id`` if present."""
+
+    async with _lock:
+        if _cache and time.time() < _cache_expire:
+            return _cache.get(str(status_id))
+
+    mapping = await load()
+    return mapping.get(str(status_id))
+
+
+async def set_all(mapping: dict[str, str]) -> dict[str, str]:
+    """Replace mapping in the database and refresh the cache."""
+
+    async with get_session() as s:
+        await s.execute(delete(HhMapping))
+        if mapping:
+            rows = [
+                {"amo_status_id": int(k), "hh_code": v}
+                for k, v in mapping.items()
+            ]
+            await s.execute(insert(HhMapping), rows)
+        await s.commit()
+
+    async with _lock:
+        global _cache_expire
+        _cache.clear()
+        _cache.update(mapping)
+        _cache_expire = time.time() + _CACHE_TTL
+    return mapping
+
+
+__all__ = ["load", "get", "set_all"]
+

--- a/main.py
+++ b/main.py
@@ -127,7 +127,7 @@ async def on_startup():
 
         amo_tok = await DbTokenStore("amo").load()
         if amo_tok and amo_tok.get("access_token") and int(amo_tok.get("expires_at", 0)) > int(time.time()) + 30:
-            if not load_hh_mapping():
+            if not await load_hh_mapping():
                 await rabbitmq.publish_task({"platform": "system", "action": "hh_autofill"})
                 log.info("Queued hh_autofill on startup")
     except Exception:

--- a/tests/test_hh_autofill.py
+++ b/tests/test_hh_autofill.py
@@ -18,13 +18,16 @@ async def test_stage_rename_updates_mapping(monkeypatch):
 
     monkeypatch.setattr(hh_autofill, "_fetch_pipeline_statuses", fake_fetch_pipeline_statuses)
     monkeypatch.setattr(hh_autofill, "get_settings", lambda: DummySettings())
-    monkeypatch.setattr(hh_autofill, "hh_map_load", lambda: mapping_store.copy())
 
-    def fake_set(mapping):
+    async def fake_load():
+        return mapping_store.copy()
+
+    async def fake_set(mapping):
         nonlocal mapping_store
         mapping_store = mapping.copy()
         return mapping
 
+    monkeypatch.setattr(hh_autofill, "hh_map_load", fake_load)
     monkeypatch.setattr(hh_autofill, "hh_map_set", fake_set)
 
     fake_statuses = [{"id": 1, "name": "Собеседование"}]


### PR DESCRIPTION
## Summary
- store HH status mapping in new `hh_mapping` table
- serve HH mapping via async ORM service with TTL cache
- update consumers and tests to await database-backed mapping

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c303cce27c8321943049a00683d6f0