### PR TITLE
Bind chats to leads and include sender info

### DIFF
--- a/app/adapters/amo_client.py
+++ b/app/adapters/amo_client.py
@@ -176,3 +176,21 @@ class AmoClient:
             }
         ]
         return await self._request("POST", url, json=body)
+
+    async def bind_chat_to_lead(self, lead_id: int, chat_id: str):
+        """Bind a chat to a lead (POST /api/v4/leads/chats).
+
+        Similar to :meth:`bind_chat_to_contact`, AmoCRM expects the
+        ``scope_id`` of the custom channel to be provided when linking the
+        chat. Without it the API may respond with "Channel must be linked to
+        your client".
+        """
+        url = f"{self.base}/api/v4/leads/chats"
+        body = [
+            {
+                "entity_id": int(lead_id),
+                "chat_id": str(chat_id),
+                "scope_id": self._s.AMO_CHATS_SCOPE_ID,
+            }
+        ]
+        return await self._request("POST", url, json=body)

--- a/app/adapters/amochats.py
+++ b/app/adapters/amochats.py
@@ -44,6 +44,7 @@ class AmoChatsClient:  # pylint: disable=too-few-public-methods
         self.account_id: str = cast(str, req["AMO_CHATS_ACCOUNT_ID"])
         self.channel_id: str = cast(str, req["AMO_CHATS_CHANNEL_ID"])
         self.sender_user_amojo_id: str = cast(str, req["AMO_CHATS_SENDER_USER_AMOJO_ID"])
+        self.sender_name: str = getattr(settings, "AMO_CHATS_SENDER_NAME", "manager")
 
 
 @lru_cache(maxsize=1)
@@ -168,6 +169,7 @@ async def send_text_from_manager(  # pylint: disable=too-many-arguments
         avatar: str | None,
         text: str,
         client: httpx.AsyncClient,
+        receiver_ref_id: str | None = None,
 ) -> None:
     """
     Сообщение 'от менеджера' — используем sender.ref_id = AMO_CHATS_SENDER_USER_AMOJO_ID,
@@ -188,11 +190,16 @@ async def send_text_from_manager(  # pylint: disable=too-many-arguments
             "timestamp": now_s,
             "msec_timestamp": now_ms,
             "conversation_id": conversation_id,
-            "sender": {"ref_id": ac.sender_user_amojo_id},
+            "sender": {
+                "id": ac.sender_user_amojo_id,
+                "name": ac.sender_name,
+                "ref_id": ac.sender_user_amojo_id,
+            },
             "receiver": {
                 "id": str(user_id),
                 **({"name": user_name} if user_name else {}),
                 **({"avatar": avatar} if avatar else {}),
+                **({"ref_id": receiver_ref_id} if receiver_ref_id else {}),
             },
             "message": {"type": "text", "text": text},
         },
@@ -212,7 +219,6 @@ async def ensure_chat_created(
         tg_user_id: int,
         tg_user_name: str | None,
         client: httpx.AsyncClient,
-        contact_id: int | None = None,
         bind_contact_id: int | None = None,
         init_text: str | None = None,
         init_as_manager: bool = False,
@@ -230,8 +236,8 @@ async def ensure_chat_created(
 
     ac = _get_client()
 
-    # стабильный ID чата на стороне интеграции
-    conv_id = f"contact:{contact_id}" if contact_id else f"lead:{lead_id}"
+    # стабильный ID чата на стороне интеграции: всегда привязываем к сделке
+    conv_id = f"lead:{lead_id}"
 
     # 1) создать/найти чат
     path_chats = f"/v2/origin/custom/{ac.scope_id}/chats"
@@ -265,18 +271,19 @@ async def ensure_chat_created(
     except Exception:  # pragma: no cover
         logger.warning("ensure_chat_created: parse chat_id failed", exc_info=True)
 
-    logger.info("ensure_chat_created: ok for %s -> conv_id=%s chat_id=%s",
-                ("contact" if contact_id else "lead"),
-                conv_id, chat_id or "-")
+    logger.info("ensure_chat_created: ok for lead conv_id=%s chat_id=%s", conv_id, chat_id or "-")
 
-    # 1.1) при желании — сразу привяжем чат к контакту
-    if bind_contact_id and chat_id:
+    # 1.1) привяжем чат к сделке и, при необходимости, к контакту
+    if chat_id:
         try:
             amo = await AmoClient.create(client)
-            await amo.bind_chat_to_contact(bind_contact_id, chat_id)
-            logger.info("chat bound to contact: contact_id=%s chat_id=%s", bind_contact_id, chat_id)
+            await amo.bind_chat_to_lead(lead_id, chat_id)
+            logger.info("chat bound to lead: lead_id=%s chat_id=%s", lead_id, chat_id)
+            if bind_contact_id:
+                await amo.bind_chat_to_contact(bind_contact_id, chat_id)
+                logger.info("chat bound to contact: contact_id=%s chat_id=%s", bind_contact_id, chat_id)
         except Exception:
-            logger.warning("bind chat to contact failed", exc_info=True)
+            logger.warning("bind chat failed", exc_info=True)
 
     # 2) опционально отправить первое сообщение
     path_msg = f"/v2/origin/custom/{ac.scope_id}"

--- a/app/services/worker/mirror.py
+++ b/app/services/worker/mirror.py
@@ -99,11 +99,10 @@ async def handle_mirror_tg_to_amo(payload: dict):
         except Exception:
             logger.warning("failed to fetch contact for lead %s", lead_id, exc_info=True)
 
-        # Создаём чат вида conversation_id="lead:<lead_id>" и ПРИВЯЗЫВАЕМ к контакту
+        # Создаём чат вида conversation_id="lead:<lead_id>" и привязываем его к сделке/контакту
         conv_id = await with_retry(
             lambda: ensure_chat_created(
                 lead_id=lead_id,
-                contact_id=contact_id,
                 bind_contact_id=contact_id,   # <-- без этого чат не появится в карточке
                 tg_user_id=tg_user_id,
                 tg_user_name=tg_user_name,
@@ -185,7 +184,6 @@ async def handle_mirror_bot_to_amo(payload: dict):
         conv_id = await with_retry(
             lambda: ensure_chat_created(
                 lead_id=int(lead_id),
-                contact_id=contact_id,
                 bind_contact_id=contact_id,
                 tg_user_id=user_id,
                 tg_user_name=user_name,

--- a/tests/test_adapters_amo_client.py
+++ b/tests/test_adapters_amo_client.py
@@ -40,3 +40,31 @@ async def test_update_status(monkeypatch):
     assert captured["method"] == "PATCH"
     assert captured["url"].path == "/api/v4/leads"
     assert captured["json"] == [{"id": 123, "status_id": 456}]
+
+
+@pytest.mark.asyncio
+async def test_bind_chat_to_lead(monkeypatch):
+    class DummySettings:
+        AMO_BASE_URL = "https://example.com"
+        AMO_CHATS_SCOPE_ID = "scid"
+
+    monkeypatch.setattr(amo_client_module, "get_settings", lambda: DummySettings())
+
+    tokens = {"access_token": "acc", "refresh_token": "ref", "expires_at": 10**10}
+    captured = {}
+
+    def handler(request):
+        captured["method"] = request.method
+        captured["url"] = request.url
+        captured["json"] = json.loads(request.content.decode())
+        assert request.headers["Authorization"] == "Bearer acc"
+        assert request.headers["Accept"] == "application/json"
+        return httpx.Response(200, json={})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
+        amo = AmoClient(tokens, DummyStore(), client)
+        await amo.bind_chat_to_lead(321, "cid")
+
+    assert captured["method"] == "POST"
+    assert captured["url"].path == "/api/v4/leads/chats"
+    assert captured["json"] == [{"entity_id": 321, "chat_id": "cid", "scope_id": "scid"}]

--- a/tests/test_worker_mirror_conversation.py
+++ b/tests/test_worker_mirror_conversation.py
@@ -4,7 +4,7 @@ from app.services.worker import mirror as worker_mirror
 
 @pytest.mark.asyncio
 async def test_tg_to_amo_sets_conversation(monkeypatch):
-    conv_id = "contact:21985897"
+    conv_id = "lead:21985897"
 
     class DummyAmo:
         async def get_lead_with_contacts(self, lead_id):


### PR DESCRIPTION
## Summary
- ensure AmoChat conversations use lead-based IDs and are linked to deals
- add method to bind chats to leads via AmoCRM API
- send manager messages with explicit sender metadata

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c309d7ea248321b261b6724a12eddd