### PR TITLE
Log HH state mapping

### DIFF
--- a/app/api/amo_webhooks.py
+++ b/app/api/amo_webhooks.py
@@ -119,6 +119,13 @@ async def handle_hh_event(
                 except httpx.HTTPError:
                     logger.warning("Failed to copy refusal text")
 
+    logger.info(
+        "hh.set_state: lead=%s status=%s state=%s final=%s",
+        lead_id,
+        status_id,
+        state,
+        final_state,
+    )
     await queue_client.publish_task(
         {
             "platform": "hh",


### PR DESCRIPTION
## Summary
- log HH state mapping with lead and status context before queue publish

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3112836f48321b66c0a20723b5781