### PR TITLE
Handle form-encoded AmoCRM status webhooks

### DIFF
--- a/app/api/amo_webhooks.py
+++ b/app/api/amo_webhooks.py
@@ -31,17 +31,24 @@ async def parse_status_events(request: Request) -> list[tuple[int, int]]:
     events: list[tuple[int, int]] = []
     try:
         data = await request.json()
-        if isinstance(data, dict) and data.get("leads", {}).get("status"):
-            for it in data["leads"]["status"]:
-                lead_id = int(it["id"])
-                status_id = int(it.get("new_status_id") or it.get("status_id"))
-                events.append((lead_id, status_id))
-    except (json.JSONDecodeError, KeyError, ValueError) as exc:
+    except json.JSONDecodeError as exc:
         body = (await request.body()).decode("utf-8", errors="replace")
         logger.warning(
             "Failed to parse AmoCRM status webhook: %s; body=%s", exc, body[:200]
         )
-        raise HTTPException(status_code=400, detail=f"Invalid payload: {exc}") from exc
+    else:
+        try:
+            if isinstance(data, dict) and data.get("leads", {}).get("status"):
+                for it in data["leads"]["status"]:
+                    lead_id = int(it["id"])
+                    status_id = int(it.get("new_status_id") or it.get("status_id"))
+                    events.append((lead_id, status_id))
+        except (KeyError, ValueError) as exc:
+            body = (await request.body()).decode("utf-8", errors="replace")
+            logger.warning(
+                "Failed to parse AmoCRM status webhook: %s; body=%s", exc, body[:200]
+            )
+            raise HTTPException(status_code=400, detail=f"Invalid payload: {exc}") from exc
 
     if not events:
         form = await request.form()

--- a/tests/test_amo_webhooks.py
+++ b/tests/test_amo_webhooks.py
@@ -49,7 +49,7 @@ async def test_parse_status_events_json():
 
 
 @pytest.mark.asyncio
-async def test_parse_status_events_form_error():
+async def test_parse_status_events_form():
     form_data = {
         "leads[status][0][id]": "3",
         "leads[status][0][status_id]": "30",
@@ -57,9 +57,8 @@ async def test_parse_status_events_form_error():
         "leads[status][1][status_id]": "40",
     }
     req = _form_request(form_data)
-    with pytest.raises(HTTPException) as exc:
-        await amo_webhooks.parse_status_events(req)
-    assert exc.value.status_code == 400
+    events = await amo_webhooks.parse_status_events(req)
+    assert events == [(3, 30), (4, 40)]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- gracefully parse `application/x-www-form-urlencoded` AmoCRM webhook payloads
- add tests for form-encoded status events

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3213863448321abcaa57bf3d8006b