### PR TITLE
Fix AmoCRM form webhook parsing for status updates

### DIFF
--- a/app/api/amo_webhooks.py
+++ b/app/api/amo_webhooks.py
@@ -29,14 +29,17 @@ router = APIRouter()
 async def parse_status_events(request: Request) -> list[tuple[int, int]]:
     """Return list of (lead_id, status_id) pairs from Amo webhook payload."""
     events: list[tuple[int, int]] = []
-    try:
-        data = await request.json()
-    except json.JSONDecodeError as exc:
-        body = (await request.body()).decode("utf-8", errors="replace")
-        logger.warning(
-            "Failed to parse AmoCRM status webhook: %s; body=%s", exc, body[:200]
-        )
-    else:
+    data: Any | None = None
+    ctype = request.headers.get("content-type", "")
+    if "json" in ctype:
+        try:
+            data = await request.json()
+        except json.JSONDecodeError as exc:
+            body = (await request.body()).decode("utf-8", errors="replace")
+            logger.warning(
+                "Failed to parse AmoCRM status webhook: %s; body=%s", exc, body[:200]
+            )
+    if data is not None:
         try:
             if isinstance(data, dict) and data.get("leads", {}).get("status"):
                 for it in data["leads"]["status"]:

--- a/app/api/utils.py
+++ b/app/api/utils.py
@@ -26,7 +26,11 @@ def events_from_form(form: Mapping[str, str]) -> list[tuple[int, int]]:
     events: list[tuple[int, int]] = []
     for i in sorted(idxs):
         lead_id = int(form.get(f"leads[status][{i}][id]", 0) or 0)
-        status_id = int(form.get(f"leads[status][{i}][status_id]", 0) or 0)
+        status_id = int(
+            form.get(f"leads[status][{i}][new_status_id]")
+            or form.get(f"leads[status][{i}][status_id]")
+            or 0
+        )
         if lead_id and status_id:
             events.append((lead_id, status_id))
     return events

--- a/tests/test_amo_webhooks.py
+++ b/tests/test_amo_webhooks.py
@@ -62,6 +62,17 @@ async def test_parse_status_events_form():
 
 
 @pytest.mark.asyncio
+async def test_parse_status_events_form_new_status_id():
+    form_data = {
+        "leads[status][0][id]": "5",
+        "leads[status][0][new_status_id]": "50",
+    }
+    req = _form_request(form_data)
+    events = await amo_webhooks.parse_status_events(req)
+    assert events == [(5, 50)]
+
+
+@pytest.mark.asyncio
 async def test_handle_hh_event_unknown_status(monkeypatch, caplog):
     async def fake_map_get(_):
         return None


### PR DESCRIPTION
## Summary
- parse AmoCRM form webhooks that use `new_status_id`
- skip JSON parsing for non-JSON payloads to avoid noisy warnings
- add regression test for `new_status_id` form payloads

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c32af21b0c832195bdaad60516b563