### PR TITLE
Support external_id in HH worker handlers

### DIFF
--- a/app/services/worker/hh.py
+++ b/app/services/worker/hh.py
@@ -16,10 +16,13 @@ async def handle_hh_send_message(payload: dict):
 
     payload:
         negotiation_id (str) — ID отклика/приглашения (nid)
+        external_id (str) — альтернативный ID отклика/приглашения
         text (str) — текст сообщения
         owner_id (str|None) — работодатель/менеджер
     """
-    nid = payload["negotiation_id"]
+    nid = payload.get("negotiation_id") or payload.get("external_id")
+    if not nid:
+        raise ValueError("negotiation_id or external_id is required")
     text = payload["text"]
     owner_id = payload.get("owner_id")
 
@@ -33,15 +36,19 @@ async def handle_hh_send_message(payload: dict):
     )
 
 
+
 async def handle_hh_set_state(payload: dict):
     """Перевести отклик на следующий этап.
 
     payload:
         negotiation_id (str) — ID отклика/приглашения (nid)
+        external_id (str) — альтернативный ID отклика/приглашения
         action_id (str) — действие, например 'phone_interview', 'interview'
         owner_id (str|None) — работодатель/менеджер
     """
-    nid = payload["negotiation_id"]
+    nid = payload.get("negotiation_id") or payload.get("external_id")
+    if not nid:
+        raise ValueError("negotiation_id or external_id is required")
     action_id = payload["action_id"]
     owner_id = payload.get("owner_id")
 

--- a/tests/test_worker_hh.py
+++ b/tests/test_worker_hh.py
@@ -1,0 +1,49 @@
+import pytest
+
+from app.services.worker import hh as worker_hh
+
+
+@pytest.mark.asyncio
+async def test_handle_hh_set_state_external_id(monkeypatch):
+    called = {}
+
+    async def fake_set_employer_state(response_id, target_state, employer_id, client):
+        called['args'] = (response_id, target_state, employer_id)
+        called['client'] = client
+
+    monkeypatch.setattr(worker_hh.hh_adapt, 'set_employer_state', fake_set_employer_state)
+    monkeypatch.setattr(worker_hh, 'get_http_client', lambda: 'client')
+
+    payload = {
+        'external_id': 'nid',
+        'action_id': 'interview',
+        'owner_id': 'owner',
+    }
+
+    await worker_hh.handle_hh_set_state(payload)
+
+    assert called['args'] == ('nid', 'interview', 'owner')
+    assert called['client'] == 'client'
+
+
+@pytest.mark.asyncio
+async def test_handle_hh_send_message_external_id(monkeypatch):
+    called = {}
+
+    async def fake_send_message(response_id, text, employer_id, client):
+        called['args'] = (response_id, text, employer_id)
+        called['client'] = client
+
+    monkeypatch.setattr(worker_hh.hh_adapt, 'send_message', fake_send_message)
+    monkeypatch.setattr(worker_hh, 'get_http_client', lambda: 'client')
+
+    payload = {
+        'external_id': 'nid',
+        'text': 'hello',
+        'owner_id': 'owner',
+    }
+
+    await worker_hh.handle_hh_send_message(payload)
+
+    assert called['args'] == ('nid', 'hello', 'owner')
+    assert called['client'] == 'client'


### PR DESCRIPTION
## Summary
- allow `handle_hh_send_message` and `handle_hh_set_state` to accept `external_id`
- raise `ValueError` when no identifier provided
- add regression tests for `external_id` usage

## Testing
- `pytest tests/test_worker_hh.py`


------
https://chatgpt.com/codex/tasks/task_e_68c32ef95bb88321bfe81fdc2509b753