### PR TITLE
Allow using target_state in HH worker

### DIFF
--- a/app/services/worker/hh.py
+++ b/app/services/worker/hh.py
@@ -43,20 +43,22 @@ async def handle_hh_set_state(payload: dict):
     payload:
         negotiation_id (str) — ID отклика/приглашения (nid)
         external_id (str) — альтернативный ID отклика/приглашения
-        action_id (str) — действие, например 'phone_interview', 'interview'
+        action_id (str) или target_state (str) — действие, например 'phone_interview', 'interview'
         owner_id (str|None) — работодатель/менеджер
     """
     nid = payload.get("negotiation_id") or payload.get("external_id")
     if not nid:
         raise ValueError("negotiation_id or external_id is required")
-    action_id = payload["action_id"]
+    target_state = payload.get("action_id") or payload.get("target_state")
+    if not target_state:
+        raise ValueError("action_id or target_state is required")
     owner_id = payload.get("owner_id")
 
-    logger.info("hh.set_state: %s -> %s", nid, action_id)
+    logger.info("hh.set_state: %s -> %s", nid, target_state)
     client = get_http_client()
     await hh_adapt.set_employer_state(
         response_id=nid,
-        target_state=action_id,
+        target_state=target_state,
         employer_id=owner_id,
         client=client,
     )

--- a/tests/test_worker_hh.py
+++ b/tests/test_worker_hh.py
@@ -27,6 +27,29 @@ async def test_handle_hh_set_state_external_id(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_handle_hh_set_state_with_target_state(monkeypatch):
+    called = {}
+
+    async def fake_set_employer_state(response_id, target_state, employer_id, client):
+        called['args'] = (response_id, target_state, employer_id)
+        called['client'] = client
+
+    monkeypatch.setattr(worker_hh.hh_adapt, 'set_employer_state', fake_set_employer_state)
+    monkeypatch.setattr(worker_hh, 'get_http_client', lambda: 'client')
+
+    payload = {
+        'external_id': 'nid',
+        'target_state': 'interview',
+        'owner_id': 'owner',
+    }
+
+    await worker_hh.handle_hh_set_state(payload)
+
+    assert called['args'] == ('nid', 'interview', 'owner')
+    assert called['client'] == 'client'
+
+
+@pytest.mark.asyncio
 async def test_handle_hh_send_message_external_id(monkeypatch):
     called = {}
 


### PR DESCRIPTION
## Summary
- allow `handle_hh_set_state` to accept `action_id` or `target_state`
- add test for passing only `target_state`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3317297fc8321aed5d787b3767e65