### PR TITLE
Add HH vacancy title autofill

### DIFF
--- a/app/adapters/hh.py
+++ b/app/adapters/hh.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 import httpx
 
-from app.api.oauth2 import OAuth2Config, ensure_fresh_access
 from app.core.config import get_settings
 from app.core.retry import with_retry
 from ._requests import request_with_retry
@@ -35,6 +34,8 @@ async def set_employer_state(
         client: httpx.AsyncClient,
 ) -> None:
     """Перевести отклик в указанный этап через action."""
+    from app.api.oauth2 import OAuth2Config, ensure_fresh_access
+
     s = get_settings()
     access = await ensure_fresh_access(
         config=OAuth2Config(
@@ -79,6 +80,8 @@ async def send_message(
         client: httpx.AsyncClient,
 ) -> None:
     """Отправить сообщение в рамках переписки по отклику."""
+    from app.api.oauth2 import OAuth2Config, ensure_fresh_access
+
     s = get_settings()
     access = await ensure_fresh_access(
         config=OAuth2Config(
@@ -123,6 +126,8 @@ async def fetch_applicant_details(
         client: httpx.AsyncClient,
 ) -> dict:
     """Fetch basic applicant information such as name, city, phone and email."""
+    from app.api.oauth2 import OAuth2Config, ensure_fresh_access
+
     s = get_settings()
     access = await ensure_fresh_access(
         config=OAuth2Config(
@@ -188,7 +193,7 @@ async def fetch_vacancy_description(
         client: httpx.AsyncClient,
 ) -> str:
     """Fetch vacancy description text."""
-    from app.api.oauth2 import OAuth2Config
+    from app.api.oauth2 import OAuth2Config, ensure_fresh_access
 
     s = get_settings()
     access = await ensure_fresh_access(
@@ -212,3 +217,35 @@ async def fetch_vacancy_description(
     if resp.status_code >= 400:
         return ""
     return resp.json().get("description") or ""
+
+
+async def fetch_vacancy_title(
+        vacancy_id: str,
+        employer_id: Optional[str],
+        client: httpx.AsyncClient,
+) -> str:
+    """Fetch vacancy title."""
+    from app.api.oauth2 import OAuth2Config, ensure_fresh_access
+
+    s = get_settings()
+    access = await ensure_fresh_access(
+        config=OAuth2Config(
+            service="hh",
+            token_url=s.HH_TOKEN_URL,
+            client_id=s.HH_CLIENT_ID,
+            client_secret=s.HH_CLIENT_SECRET,
+            redirect_uri=s.HH_REDIRECT_URI,
+            use_basic_auth=False,
+            owner_id=employer_id,
+        ),
+        http_client=client,
+    )
+
+    resp = await client.get(
+        f"{s.HH_API_BASE.rstrip('/')}/vacancies/{vacancy_id}",
+        headers={"Authorization": f"Bearer {access}", "Accept": "application/json"},
+        timeout=30,
+    )
+    if resp.status_code >= 400:
+        return ""
+    return resp.json().get("name") or ""

--- a/app/services/lead_processor.py
+++ b/app/services/lead_processor.py
@@ -48,6 +48,15 @@ async def enrich_applicant(
                     payload.vacancy_desc = desc
             except (httpx.HTTPError, json.JSONDecodeError) as e:  # pragma: no cover
                 logger.warning("HH: описание вакансии %s не получено: %s", payload.vacancy_id, type(e).__name__)
+        if payload.vacancy_id and not (payload.vacancy_title or "").strip():
+            try:
+                title = await hh_adapt.fetch_vacancy_title(
+                    payload.vacancy_id, owner_id, http_client
+                )
+                if title:
+                    payload.vacancy_title = title
+            except (httpx.HTTPError, json.JSONDecodeError) as e:  # pragma: no cover
+                logger.warning("HH: название вакансии %s не получено: %s", payload.vacancy_id, type(e).__name__)
     return payload
 
 

--- a/tests/test_hh_autofill.py
+++ b/tests/test_hh_autofill.py
@@ -3,6 +3,7 @@ import pytest
 import yaml
 
 from app.services import hh_autofill
+from app.models import Applicant, IncomingPayload
 
 
 @pytest.mark.asyncio
@@ -76,4 +77,49 @@ def test_stage_name_normalization_and_mapping(monkeypatch, tmp_path, raw, normal
 
     assert hh_autofill._norm_stage_name(raw) == normalized
     assert hh_autofill._STAGE_NAME_TO_HH[normalized] == code
+
+
+@pytest.mark.asyncio
+async def test_enrich_applicant_adds_vacancy_title(monkeypatch):
+    import sys, types
+
+    api_pkg = types.ModuleType("app.api")
+    utils_mod = types.ModuleType("app.api.utils")
+
+    def route_kind(*, desc: str = "", raw: str = "") -> str:
+        return "ignore"
+
+    utils_mod.route_kind = route_kind
+    api_pkg.utils = utils_mod
+    sys.modules.setdefault("app.api", api_pkg)
+    sys.modules.setdefault("app.api.utils", utils_mod)
+
+    from app.services import lead_processor
+
+    payload = IncomingPayload(
+        platform="hh",
+        owner_id="own",
+        applicant=Applicant(id="nid", name="anon"),
+        vacancy_id="vac1",
+        vacancy_title="",
+        vacancy_desc="desc",
+    )
+
+    async def fake_fetch_applicant_details(*args, **kwargs):
+        return {}
+
+    async def fake_fetch_vacancy_title(vacancy_id, owner_id, client):
+        assert vacancy_id == "vac1"
+        assert owner_id == "own"
+        return "Название"
+
+    monkeypatch.setattr(
+        lead_processor.hh_adapt, "fetch_applicant_details", fake_fetch_applicant_details
+    )
+    monkeypatch.setattr(
+        lead_processor.hh_adapt, "fetch_vacancy_title", fake_fetch_vacancy_title
+    )
+
+    result = await lead_processor.enrich_applicant(payload, None)
+    assert result.vacancy_title == "Название"
 


### PR DESCRIPTION
## Summary
- support fetching vacancy title from HH API
- populate missing vacancy titles during applicant enrichment
- test title autofill when vacancy_id is present

## Testing
- `pytest tests/test_hh_autofill.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3414907248321980000e942958866