### PR TITLE
feat: verify AmoChats signature

### DIFF
--- a/app/api/api_amochats.py
+++ b/app/api/api_amochats.py
@@ -34,14 +34,15 @@ async def verify_amochats_signature(
         settings=Depends(get_settings),
 ) -> None:
     raw = await request.body()
-    # TODO: re-enable AmoChats signature verification.
-    # x_sig = request.headers.get("X-Signature")
-    # if not x_sig:
-    #     raise HTTPException(status_code=400, detail="missing X-Signature")
+    x_sig = request.headers.get("X-Signature")
+    if not x_sig:
+        raise HTTPException(status_code=400, detail="missing X-Signature")
 
-    # calc = hmac.new(settings.AMO_CHATS_SECRET.encode("utf-8"), raw, hashlib.sha1).hexdigest()
-    # if not hmac.compare_digest(x_sig.lower(), calc.lower()):
-    #     raise HTTPException(status_code=401, detail="invalid signature")
+    calc = hmac.new(
+        settings.AMO_CHATS_SECRET.encode("utf-8"), raw, hashlib.sha1
+    ).hexdigest()
+    if not hmac.compare_digest(x_sig.lower(), calc.lower()):
+        raise HTTPException(status_code=401, detail="invalid signature")
 
     request.state.raw_body = raw
 

--- a/tests/test_api_amochats.py
+++ b/tests/test_api_amochats.py
@@ -1,5 +1,13 @@
+import json
+import hmac
+import hashlib
+
 import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
 from app.store_chat import upsert_tg_link, set_conversation
+from app.api import api_amochats
 from app.api.api_amochats import resolve_links
 
 @pytest.mark.asyncio
@@ -17,3 +25,53 @@ async def test_resolve_links_uses_client_conv_id(in_memory_db):
     assert len(links) == 1
     assert links[0].user_id == user_id
     assert links[0].conversation_id == conv_client_id
+
+
+@pytest.fixture
+def amochats_client(monkeypatch):
+    app = FastAPI()
+    
+    class DummySettings:
+        AMO_CHATS_SECRET = "secret"
+
+    async def fake_check_and_store(key):
+        return True
+
+    async def fake_resolve_links(*args, **kwargs):
+        return []
+
+    monkeypatch.setattr(api_amochats, "check_and_store", fake_check_and_store)
+    monkeypatch.setattr(api_amochats, "resolve_links", fake_resolve_links)
+
+    app.dependency_overrides[api_amochats.get_settings] = lambda: DummySettings()
+    app.include_router(api_amochats.router_amo_chats)
+    return TestClient(app)
+
+
+def _payload() -> dict:
+    return {
+        "message": {
+            "conversation": {"id": "conv1"},
+            "sender": {},
+            "receiver": {},
+            "message": {"text": "hi"},
+        }
+    }
+
+
+def test_webhook_valid_signature(amochats_client, queue_mock):
+    body = json.dumps(_payload()).encode("utf-8")
+    sig = hmac.new(b"secret", body, hashlib.sha1).hexdigest()
+    resp = amochats_client.post(
+        "/webhooks/amo-chats/in/test", content=body, headers={"X-Signature": sig}
+    )
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+
+def test_webhook_invalid_signature(amochats_client, queue_mock):
+    body = json.dumps(_payload()).encode("utf-8")
+    resp = amochats_client.post(
+        "/webhooks/amo-chats/in/test", content=body, headers={"X-Signature": "bad"}
+    )
+    assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- validate AmoChats webhook signature using `X-Signature`
- add tests for valid and invalid AmoChats webhook signatures

## Testing
- `pytest tests/test_api_amochats.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3421ee7788321a4e0ba2cf94363cb