### PR TITLE
Disable AmoChats signature verification

### DIFF
--- a/app/api/api_amochats.py
+++ b/app/api/api_amochats.py
@@ -1,12 +1,10 @@
 """Handlers for AmoChats webhooks and related helpers."""
 import datetime
 import hashlib
-import hmac
+# import hmac  # TODO: подпись
 import logging
-import secrets
-import base64
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request
 
 from app.adapters.amochats import connect_channel
 from app.core.config import get_settings
@@ -25,25 +23,18 @@ logger = logging.getLogger(__name__)
 router_amo_chats = APIRouter()
 
 
-def _md5_hex(b: bytes) -> str:
-    return hashlib.md5(b).hexdigest().lower()
-
-
 async def verify_amochats_signature(
         request: Request,
         settings=Depends(get_settings),
 ) -> None:
     raw = await request.body()
-    x_sig = request.headers.get("X-Signature")
-    if not x_sig:
-        raise HTTPException(status_code=400, detail="missing X-Signature")
-
-    calc = hmac.new(
-        settings.AMO_CHATS_SECRET.encode("utf-8"), raw, hashlib.sha1
-    ).hexdigest()
-    if not hmac.compare_digest(x_sig.lower(), calc.lower()):
-        raise HTTPException(status_code=401, detail="invalid signature")
-
+    # TODO: проверить подпись AmoChats
+    # x_sig = request.headers.get("X-Signature")
+    # calc = hmac.new(
+    #     settings.AMO_CHATS_SECRET.encode("utf-8"), raw, hashlib.sha1
+    # ).hexdigest()
+    # if not x_sig or not hmac.compare_digest(x_sig.lower(), calc.lower()):
+    #     raise HTTPException(status_code=401, detail="invalid signature")
     request.state.raw_body = raw
 
 
@@ -193,7 +184,7 @@ async def amochats_in(
         queue_client: RabbitMQClient = Depends(lambda: rabbitmq),
 ):
     """Process incoming AmoChats webhook and mirror messages to Telegram."""
-    raw = await request.body()
+    raw = getattr(request.state, "raw_body", await request.body())
 
     if await is_duplicate(raw):
         logger.info("amo-chats duplicate webhook skipped (scope_id=%s)", scope_id)

--- a/tests/test_api_amochats.py
+++ b/tests/test_api_amochats.py
@@ -69,9 +69,10 @@ def test_webhook_valid_signature(amochats_client, queue_mock):
     assert resp.json() == {"ok": True}
 
 
-def test_webhook_invalid_signature(amochats_client, queue_mock):
-    body = json.dumps(_payload()).encode("utf-8")
-    resp = amochats_client.post(
-        "/webhooks/amo-chats/in/test", content=body, headers={"X-Signature": "bad"}
-    )
-    assert resp.status_code == 401
+# TODO: вернуть проверку подписи
+# def test_webhook_invalid_signature(amochats_client, queue_mock):
+#     body = json.dumps(_payload()).encode("utf-8")
+#     resp = amochats_client.post(
+#         "/webhooks/amo-chats/in/test", content=body, headers={"X-Signature": "bad"}
+#     )
+#     assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- comment out AmoChats webhook signature validation and leave TODO
- avoid re-reading webhook body
- disable failing invalid-signature test

## Testing
- `pytest` *(fails: OSError: [Errno 101] Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c3447c0ab08321bbb6dbf0c3ba9a5f