### PR TITLE
Stub AmoChats signature check

### DIFF
--- a/app/api/api_amochats.py
+++ b/app/api/api_amochats.py
@@ -3,10 +3,8 @@ import datetime
 import hashlib
 import hmac
 import logging
-import secrets
-import base64
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, Request, HTTPException
 
 from app.adapters.amochats import connect_channel
 from app.core.config import get_settings
@@ -25,26 +23,19 @@ logger = logging.getLogger(__name__)
 router_amo_chats = APIRouter()
 
 
-def _md5_hex(b: bytes) -> str:
-    return hashlib.md5(b).hexdigest().lower()
-
-
 async def verify_amochats_signature(
         request: Request,
         settings=Depends(get_settings),
 ) -> None:
     raw = await request.body()
-    x_sig = request.headers.get("X-Signature")
-    if not x_sig:
-        raise HTTPException(status_code=400, detail="missing X-Signature")
-
-    calc = hmac.new(
-        settings.AMO_CHATS_SECRET.encode("utf-8"), raw, hashlib.sha1
-    ).hexdigest()
-    if not hmac.compare_digest(x_sig.lower(), calc.lower()):
-        raise HTTPException(status_code=401, detail="invalid signature")
-
     request.state.raw_body = raw
+    # TODO: подпись
+    # x_sig = request.headers.get("X-Signature")
+    # calc = hmac.new(
+    #     settings.AMO_CHATS_SECRET.encode("utf-8"), raw, hashlib.sha1
+    # ).hexdigest()
+    # if not x_sig or not hmac.compare_digest(x_sig.lower(), calc.lower()):
+    #     raise HTTPException(status_code=401)
 
 
 def parse_lead_id(client_id: str) -> int | None:
@@ -193,7 +184,7 @@ async def amochats_in(
         queue_client: RabbitMQClient = Depends(lambda: rabbitmq),
 ):
     """Process incoming AmoChats webhook and mirror messages to Telegram."""
-    raw = await request.body()
+    raw = getattr(request.state, "raw_body", await request.body())
 
     if await is_duplicate(raw):
         logger.info("amo-chats duplicate webhook skipped (scope_id=%s)", scope_id)

--- a/tests/test_api_amochats.py
+++ b/tests/test_api_amochats.py
@@ -68,10 +68,10 @@ def test_webhook_valid_signature(amochats_client, queue_mock):
     assert resp.status_code == 200
     assert resp.json() == {"ok": True}
 
-
-def test_webhook_invalid_signature(amochats_client, queue_mock):
-    body = json.dumps(_payload()).encode("utf-8")
-    resp = amochats_client.post(
-        "/webhooks/amo-chats/in/test", content=body, headers={"X-Signature": "bad"}
-    )
-    assert resp.status_code == 401
+# TODO: подпись
+# def test_webhook_invalid_signature(amochats_client, queue_mock):
+#     body = json.dumps(_payload()).encode("utf-8")
+#     resp = amochats_client.post(
+#         "/webhooks/amo-chats/in/test", content=body, headers={"X-Signature": "bad"}
+#     )
+#     assert resp.status_code == 401


### PR DESCRIPTION
## Summary
- comment out AmoChats webhook HMAC verification and leave a Russian TODO
- disable invalid-signature test with a TODO placeholder

## Testing
- `pytest` *(fails: OSError: [Errno 101] Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c3447c0ab08321bbb6dbf0c3ba9a5f