### PR TITLE
Catch all task exceptions in RabbitMQ consumer

### DIFF
--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -229,6 +229,24 @@ class RabbitMQClient:
                                         )
                                 except aio_exc.AMQPError:  # pragma: no cover - log only
                                     logger.exception("failed to republish to retry/DLQ")
+                            except asyncio.CancelledError:
+                                raise
+                            except Exception as e:  # pragma: no cover - unexpected
+                                await message.ack()
+                                try:
+                                    cur_attempts = attempts + 1
+                                    if cur_attempts >= max_attempts:
+                                        await self.publish_dlq(payload, cur_attempts, str(e))
+                                        logger.exception(
+                                            "sent to DLQ after attempts=%s", cur_attempts
+                                        )
+                                    else:
+                                        await self.publish_retry(payload, cur_attempts)
+                                        logger.exception(
+                                            "requeued to retry, attempt=%s", cur_attempts
+                                        )
+                                except aio_exc.AMQPError:  # pragma: no cover - log only
+                                    logger.exception("failed to republish to retry/DLQ")
                 except asyncio.CancelledError:
                     break
                 except aio_exc.AMQPError:  # pragma: no cover - network errors

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -1,5 +1,6 @@
 import json
 import types
+import asyncio
 import pytest
 
 from app.core.config import get_settings
@@ -71,4 +72,70 @@ async def test_publish_dlq(monkeypatch):
 
     await client.publish_dlq({"a": 1}, attempts=4, error="boom")
     assert published == [({"payload": {"a": 1}, "attempts": 4, "error": "boom"}, "tasks.dlq")]
+
+
+@pytest.mark.asyncio
+async def test_consume_catches_unexpected_exception(monkeypatch):
+    acked = False
+    dlq_calls = []
+
+    class DummyMessage:
+        body = json.dumps({"payload": {"foo": "bar"}, "attempts": 0}).encode()
+
+        async def ack(self):
+            nonlocal acked
+            acked = True
+
+    class DummyIterator:
+        def __init__(self, message):
+            self._message = message
+            self._yielded = False
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            pass
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._yielded:
+                raise asyncio.CancelledError
+            self._yielded = True
+            return self._message
+
+    class DummyQueue:
+        def __init__(self, message):
+            self._message = message
+
+        def iterator(self):
+            return DummyIterator(self._message)
+
+    class DummyChannel:
+        is_closed = False
+
+        async def get_queue(self, name):
+            return DummyQueue(DummyMessage())
+
+    client = RabbitMQClient()
+
+    async def fake_ensure():
+        client._conn = types.SimpleNamespace(is_closed=False)
+        client._chan = DummyChannel()
+
+    async def fake_dlq(payload, attempts, error=None):
+        dlq_calls.append((payload, attempts, error))
+
+    monkeypatch.setattr(client, "_ensure", fake_ensure)
+    monkeypatch.setattr(client, "publish_dlq", fake_dlq)
+
+    async def handler(payload):
+        raise ValueError("boom")
+
+    await client.consume(handler, max_attempts=1)
+
+    assert acked
+    assert dlq_calls == [({"foo": "bar"}, 1, "boom")]
 


### PR DESCRIPTION
## Summary
- ensure the RabbitMQ consumer catches unexpected exceptions so workers stay alive
- add a regression test that ValueError from a handler is routed to DLQ

## Testing
- `pytest` *(fails: OSError: [Errno 101] Network is unreachable)*
- `pytest tests/test_queue.py`

------
https://chatgpt.com/codex/tasks/task_e_68c3c836128c8321829844be2beb37b6