### PR TITLE
Handle errors in scheduler periodic tasks

### DIFF
--- a/app/services/scheduler.py
+++ b/app/services/scheduler.py
@@ -113,7 +113,11 @@ async def retry_overdue_tasks(limit: int = 100) -> None:
 
 async def _periodic(interval: int, coro):
     while True:
-        await coro()
+        try:
+            await coro()
+            log.info("%s completed successfully", coro.__name__)
+        except Exception:  # pylint: disable=broad-exception-caught
+            log.exception("%s failed", coro.__name__)
         await asyncio.sleep(interval)
 
 


### PR DESCRIPTION
## Summary
- ensure periodic scheduler tasks log exceptions and continue
- log success of periodic tasks for observability

## Testing
- `pytest` *(fails: Token for service=hh owner=emp1 not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c3dbdc0ff883219e77e6e8cc1aea4c