### PR TITLE
refactor queue republish helper

### DIFF
--- a/app/services/queue.py
+++ b/app/services/queue.py
@@ -158,6 +158,27 @@ class RabbitMQClient:
             assert self._exch is not None
             await self._exch.publish(msg, routing_key="tasks.dlq")
 
+    async def _republish(
+        self,
+        message: amqp_abc.AbstractIncomingMessage,
+        payload: dict,
+        attempts: int,
+        max_attempts: int,
+        exc: Exception,
+    ) -> None:
+        """Acknowledge message and send it to retry or DLQ depending on attempts."""
+        await message.ack()
+        try:
+            cur_attempts = attempts + 1
+            if cur_attempts >= max_attempts:
+                await self.publish_dlq(payload, cur_attempts, str(exc))
+                logger.exception("sent to DLQ after attempts=%s", cur_attempts)
+            else:
+                await self.publish_retry(payload, cur_attempts)
+                logger.exception("requeued to retry, attempt=%s", cur_attempts)
+        except aio_exc.AMQPError:  # pragma: no cover - log only
+            logger.exception("failed to republish to retry/DLQ")
+
     async def consume(
         self, handler: Callable[..., Awaitable[None]], max_attempts: int = 10
     ) -> None:
@@ -214,39 +235,15 @@ class RabbitMQClient:
                                 aio_exc.AMQPError,
                                 RuntimeError,
                             ) as e:  # pragma: no cover - mostly network
-                                await message.ack()
-                                try:
-                                    cur_attempts = attempts + 1
-                                    if cur_attempts >= max_attempts:
-                                        await self.publish_dlq(payload, cur_attempts, str(e))
-                                        logger.exception(
-                                            "sent to DLQ after attempts=%s", cur_attempts
-                                        )
-                                    else:
-                                        await self.publish_retry(payload, cur_attempts)
-                                        logger.exception(
-                                            "requeued to retry, attempt=%s", cur_attempts
-                                        )
-                                except aio_exc.AMQPError:  # pragma: no cover - log only
-                                    logger.exception("failed to republish to retry/DLQ")
+                                await self._republish(
+                                    message, payload, attempts, max_attempts, e
+                                )
                             except asyncio.CancelledError:
                                 raise
                             except Exception as e:  # pragma: no cover - unexpected
-                                await message.ack()
-                                try:
-                                    cur_attempts = attempts + 1
-                                    if cur_attempts >= max_attempts:
-                                        await self.publish_dlq(payload, cur_attempts, str(e))
-                                        logger.exception(
-                                            "sent to DLQ after attempts=%s", cur_attempts
-                                        )
-                                    else:
-                                        await self.publish_retry(payload, cur_attempts)
-                                        logger.exception(
-                                            "requeued to retry, attempt=%s", cur_attempts
-                                        )
-                                except aio_exc.AMQPError:  # pragma: no cover - log only
-                                    logger.exception("failed to republish to retry/DLQ")
+                                await self._republish(
+                                    message, payload, attempts, max_attempts, e
+                                )
                 except asyncio.CancelledError:
                     break
                 except aio_exc.AMQPError:  # pragma: no cover - network errors


### PR DESCRIPTION
## Summary
- factor common republish logic into `_republish`
- simplify `consume` by using helper for retry/DLQ routing

## Testing
- `pytest -q` *(fails: OSError: [Errno 101] Network is unreachable; assert 200 == 401)*

------
https://chatgpt.com/codex/tasks/task_e_68c3dcce3e94832180abee79534b5211