### PR TITLE
Set default timeout for shared HTTP client

### DIFF
--- a/app/http_client.py
+++ b/app/http_client.py
@@ -1,9 +1,10 @@
 """Utilities for a shared HTTP client.
 
 This module exposes :func:`get_http_client` to obtain a lazily created
-:class:`httpx.AsyncClient` that is reused across the application. Call
-:func:`close_http_client` on application shutdown to properly release
-resources held by the client.
+:class:`httpx.AsyncClient` that is reused across the application. The
+client is instantiated with a default timeout of 30 seconds to avoid
+hanging requests. Call :func:`close_http_client` on application shutdown
+to properly release resources held by the client.
 """
 
 import httpx
@@ -18,7 +19,7 @@ class _HttpClientFactory:
     def get_client(cls) -> httpx.AsyncClient:
         """Return the shared AsyncClient instance."""
         if cls._client is None:
-            cls._client = httpx.AsyncClient()
+            cls._client = httpx.AsyncClient(timeout=30)
         return cls._client
 
     @classmethod


### PR DESCRIPTION
## Summary
- ensure shared `httpx.AsyncClient` uses a 30s timeout
- document the HTTP client's timeout

## Testing
- `pytest` *(fails: tests/test_adapters_hh.py::test_hh_set_employer_state - OSError: [Errno 101] Network is unreachable, tests/test_adapters_hh.py::test_hh_send_message - OSError: [Errno 101] Network is unreachable, tests/test_adapters_hh.py::test_hh_send_message_error - OSError: [Errno 101] Network is unreachable, tests/test_adapters_hh.py::test_hh_fetch_applicant_details - OSError: [Errno 101] Network is unreachable, tests/test_api_amochats.py::test_webhook_invalid_signature - assert 200 == 401)`

------
https://chatgpt.com/codex/tasks/task_e_68c3deeed5588321a4f90b6d7d9adf6b