### PR TITLE
Ensure survey deletion occurs only after successful publish

### DIFF
--- a/app/services/survey_service.py
+++ b/app/services/survey_service.py
@@ -6,6 +6,8 @@ queue client.  The functions wrap lower level helpers and publish messages to
 other services when the survey state changes.
 """
 
+import logging
+
 from app.core.config import get_settings
 from app.services.queue import rabbitmq, RabbitMQClient
 from app.store_survey import (
@@ -15,6 +17,9 @@ from app.store_survey import (
     delete_survey,
 )
 from app.services.survey import mark_went_to_bot_async
+
+
+logger = logging.getLogger(__name__)
 
 
 class SurveyService:
@@ -40,29 +45,49 @@ class SurveyService:
     async def finish(self, user_id: int, bot_kind: str, lead_id: int, summary: str) -> None:
         """Finalize the survey and send results to the queue client."""
         s = get_settings()
-        await self.queue_client.publish_task({
-            "platform": "amo",
-            "action": "amo_add_tags",
-            "lead_id": lead_id,
-            "tags": [s.AMO_TAG_SURVEY_DONE],
-        })
-        await self.queue_client.publish_task({
-            "platform": "amo",
-            "action": "amo_add_note",
-            "lead_id": lead_id,
-            "text": f"[{bot_kind}] {summary}",
-        })
+        try:
+            await self.queue_client.publish_task(
+                {
+                    "platform": "amo",
+                    "action": "amo_add_tags",
+                    "lead_id": lead_id,
+                    "tags": [s.AMO_TAG_SURVEY_DONE],
+                }
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("failed to publish tags lead_id=%s", lead_id)
+            return
+
+        try:
+            await self.queue_client.publish_task(
+                {
+                    "platform": "amo",
+                    "action": "amo_add_note",
+                    "lead_id": lead_id,
+                    "text": f"[{bot_kind}] {summary}",
+                }
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("failed to publish note lead_id=%s", lead_id)
+            return
+
         stage_id = (
             s.AMO_STAGE_ID_MASTER_SURVEY
             if bot_kind == "master"
             else s.AMO_STAGE_ID_OPERATOR_SURVEY
         )
-        await self.queue_client.publish_task(
-            {
-                "platform": "amo",
-                "action": "amo_update_status",
-                "lead_id": lead_id,
-                "status_id": stage_id,
-            }
-        )
+
+        try:
+            await self.queue_client.publish_task(
+                {
+                    "platform": "amo",
+                    "action": "amo_update_status",
+                    "lead_id": lead_id,
+                    "status_id": stage_id,
+                }
+            )
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("failed to update status lead_id=%s", lead_id)
+            return
+
         await delete_survey(user_id, bot_kind)


### PR DESCRIPTION
## Summary
- avoid data loss by catching `publish_task` errors in survey finalization
- log failed publishes and skip survey deletion if sending fails

## Testing
- `pytest` *(fails: OSError: [Errno 101] Network is unreachable, assert 200 == 401)*

------
https://chatgpt.com/codex/tasks/task_e_68c3df9a7b708321807790e65c2108ba