### PR TITLE
Translate worker comments and logs to Russian

### DIFF
--- a/app/services/worker/amo.py
+++ b/app/services/worker/amo.py
@@ -21,7 +21,7 @@ async def handle_amo_create_lead(payload: dict) -> None:
         payload: Содержит ключ ``lead_body`` с описанием создаваемой сделки.
     """
 
-    logger.info("amo.create_lead")
+    logger.info("amo.создание_сделки")
     amo = await AmoClient.create(get_http_client())
     await amo.create_leads(payload["lead_body"])
 
@@ -33,13 +33,13 @@ async def handle_amo_add_note(payload: dict) -> None:
         payload: Должен содержать ``lead_id`` и ``text`` для содержимого заметки.
     """
 
-    logger.info("amo.add_note: %s", payload.get("lead_id"))
+    logger.info("amo.добавление_заметки: %s", payload.get("lead_id"))
     amo = await AmoClient.create(get_http_client())
     try:
         await amo.add_note(int(payload["lead_id"]), payload["text"])
     except HTTPStatusError as err:  # pylint: disable=broad-except
         if err.response is not None and err.response.status_code < 500:
-            logger.warning("amo.add_note: ошибка: %s", err)
+            logger.warning("amo.добавление_заметки: ошибка: %s", err)
         else:
             raise
 
@@ -51,13 +51,13 @@ async def handle_amo_add_tags(payload: dict) -> None:
         payload: Должен содержать ``lead_id`` и, при наличии, список ``tags``.
     """
 
-    logger.info("amo.add_tags: %s", payload.get("lead_id"))
+    logger.info("amo.добавление_тегов: %s", payload.get("lead_id"))
     amo = await AmoClient.create(get_http_client())
     try:
         await amo.add_tags(int(payload["lead_id"]), list(payload.get("tags") or []))
     except HTTPStatusError as err:  # pylint: disable=broad-except
         if err.response is not None and err.response.status_code < 500:
-            logger.warning("amo.add_tags: ошибка: %s", err)
+            logger.warning("amo.добавление_тегов: ошибка: %s", err)
         else:
             raise
 
@@ -69,12 +69,12 @@ async def handle_amo_update_status(payload: dict) -> None:
         payload: Должен содержать ``lead_id`` и ``status_id`` — новый этап сделки.
     """
 
-    logger.info("amo.update_status: %s", payload.get("lead_id"))
+    logger.info("amo.обновление_статуса: %s", payload.get("lead_id"))
     amo = await AmoClient.create(get_http_client())
     try:
         await amo.update_status(int(payload["lead_id"]), int(payload["status_id"]))
     except HTTPStatusError as err:  # pylint: disable=broad-except
         if err.response is not None and err.response.status_code < 500:
-            logger.warning("amo.update_status: ошибка: %s", err)
+            logger.warning("amo.обновление_статуса: ошибка: %s", err)
         else:
             raise

--- a/app/services/worker/avito.py
+++ b/app/services/worker/avito.py
@@ -23,7 +23,7 @@ async def handle_avito_send_message(payload: dict) -> None:
             опционально может содержать ``owner_id`` (ID аккаунта).
     """
 
-    logger.info("avito.send_message: %s", payload.get("external_id"))
+    logger.info("avito.отправка_сообщения: %s", payload.get("external_id"))
     await perform_request(
         avito_adapt.send_message,
         payload["external_id"],
@@ -40,7 +40,7 @@ async def handle_avito_mark_read(payload: dict) -> None:
             ``owner_id`` (ID аккаунта).
     """
 
-    logger.info("avito.mark_read: %s", payload.get("external_id"))
+    logger.info("avito.пометка_прочитанным: %s", payload.get("external_id"))
     await perform_request(
         avito_adapt.mark_read,
         payload["external_id"],

--- a/app/services/worker/hh.py
+++ b/app/services/worker/hh.py
@@ -1,6 +1,6 @@
-"""Worker handlers for the HeadHunter (hh.ru) service.
+"""Обработчики воркера для сервиса HeadHunter (hh.ru).
 
-Функции-обработчики воркера. Проксируют задачи в адаптер HH.
+Функции‑обработчики воркера. Проксируют задачи в адаптер HH.
 """
 
 import logging
@@ -26,7 +26,7 @@ async def handle_hh_send_message(payload: dict):
     text = payload["text"]
     owner_id = payload.get("owner_id")
 
-    logger.info("hh.send_message: %s текст=%r", nid, text[:40])
+    logger.info("hh.отправка_сообщения: %s текст=%r", nid, text[:40])
     client = get_http_client()
     await hh_adapt.send_message(
         response_id=nid,
@@ -54,7 +54,7 @@ async def handle_hh_set_state(payload: dict):
         raise ValueError("action_id or target_state is required")
     owner_id = payload.get("owner_id")
 
-    logger.info("hh.set_state: %s -> %s", nid, target_state)
+    logger.info("hh.установка_состояния: %s -> %s", nid, target_state)
     client = get_http_client()
     await hh_adapt.set_employer_state(
         response_id=nid,

--- a/app/services/worker/mirror.py
+++ b/app/services/worker/mirror.py
@@ -1,9 +1,9 @@
-"""Handlers that mirror messages between AMO CRM and Telegram bots.
+"""Обработчики, зеркалирующие сообщения между amoCRM и ботами Telegram.
 
-This module provides asynchronous worker handlers used to forward messages
-from AMO CRM to Telegram chats, relay Telegram messages back to AMO, and send
-bot-generated messages into AMO chats. All handlers accept a ``payload``
-dictionary with details specific to the direction of the mirror.
+Модуль содержит асинхронные обработчики для пересылки сообщений из amoCRM в
+Telegram-чаты, доставки сообщений из Telegram обратно в amoCRM и отправки
+текстов, сгенерированных ботом, в чаты amoCRM. Все обработчики принимают
+словарь ``payload`` с подробностями, зависящими от направления зеркала.
 """
 
 import logging
@@ -24,26 +24,26 @@ logger = logging.getLogger(__name__)
 
 
 async def handle_mirror_amo_to_tg(payload: dict):
-    """Forward a message from AMO CRM to a Telegram user.
+    """Переслать сообщение из amoCRM пользователю в Telegram.
 
-    Args:
-        payload: Mapping containing message details. Expected keys are
-            ``bot_kind`` (``"master"`` or ``"operator"``) to choose a bot,
-            ``user_id`` for the Telegram recipient, ``text`` with the message
-            body and optional ``msg_key`` used for deduplication.
+    Аргументы:
+        payload: Содержит детали сообщения. Ожидаемые ключи:
+            ``bot_kind`` (``"master"`` или ``"operator"``) — выбор бота,
+            ``user_id`` — получатель в Telegram, ``text`` — текст сообщения,
+            опциональный ``msg_key`` для дедупликации.
 
-    Behaviour:
-        Uses the appropriate Telegram bot to deliver the text. When ``msg_key``
-        is provided and already processed, the message is skipped.
+    Поведение:
+        Использует соответствующего бота Telegram для доставки текста. Если
+        указан ``msg_key`` и он уже обработан, сообщение пропускается.
 
-    Returns:
+    Возвращает:
         None
     """
     msg_key = payload.get("msg_key") or ""
     if msg_key:
         dedup = calc_key("mirror", msg_key)
         if not await check_and_store(dedup):
-            logger.info("mirror: duplicate %s -> skip", dedup)
+            logger.info("mirror: дубликат %s -> пропуск", dedup)
             return
 
     bot_kind = payload["bot_kind"]
@@ -60,12 +60,12 @@ async def handle_mirror_amo_to_tg(payload: dict):
 
 
 async def handle_mirror_tg_to_amo(payload: dict):  # pylint: disable=too-many-locals
-    """Mirror a Telegram message into AMO CRM (как реальное сообщение в чат сделки)."""
+    """Отразить сообщение из Telegram в amoCRM (как реальное сообщение в чат сделки)."""
     msg_key = payload.get("msg_key") or ""
     if msg_key:
         dedup = calc_key("mirror", msg_key)
         if not await check_and_store(dedup):
-            logger.info("mirror: duplicate %s -> skip", dedup)
+            logger.info("mirror: дубликат %s -> пропуск", dedup)
             return
 
     lead_id = int(payload["lead_id"])
@@ -98,7 +98,7 @@ async def handle_mirror_tg_to_amo(payload: dict):  # pylint: disable=too-many-lo
             if contacts:
                 contact_id = int(contacts[0]["id"])
         except Exception:  # pylint: disable=broad-exception-caught
-            logger.warning("failed to fetch contact for lead %s", lead_id, exc_info=True)
+            logger.warning("не удалось получить контакт для сделки %s", lead_id, exc_info=True)
 
         # Создаём чат вида conversation_id="lead:<lead_id>" и ПРИВЯЗЫВАЕМ к контакту
         conv_id = await with_retry(
@@ -139,26 +139,26 @@ async def handle_mirror_tg_to_amo(payload: dict):  # pylint: disable=too-many-lo
 
 
 async def handle_mirror_bot_to_amo(payload: dict):  # pylint: disable=too-many-locals
-    """Forward a bot-generated message to AMO chat.
+    """Переслать сообщение, сгенерированное ботом, в чат amoCRM.
 
-    Args:
-        payload: Mapping that contains ``text`` and ``user_id``. Optional keys
-            are ``user_name``, ``conversation_id``, ``lead_id`` and ``msg_key``
-            used for deduplication.
+    Аргументы:
+        payload: Содержит ``text`` и ``user_id``. Необязательные ключи —
+            ``user_name``, ``conversation_id``, ``lead_id`` и ``msg_key``
+            для дедупликации.
 
-    Behaviour:
-        Ensures an AMO chat conversation exists for the Telegram user and
-        sends the text as a manager message. Duplicate payloads are ignored
-        when ``msg_key`` has already been processed.
+    Поведение:
+        Обеспечивает существование беседы amoCRM для пользователя Telegram и
+        отправляет текст как сообщение менеджера. Повторные payload игнорируются,
+        если ``msg_key`` уже обработан.
 
-    Returns:
+    Возвращает:
         None
     """
     msg_key = payload.get("msg_key") or ""
     if msg_key:
         dedup = calc_key("mirror", msg_key)
         if not await check_and_store(dedup):
-            logger.info("mirror: duplicate %s -> skip", dedup)
+            logger.info("mirror: дубликат %s -> пропуск", dedup)
             return
 
     text = payload["text"]
@@ -182,7 +182,7 @@ async def handle_mirror_bot_to_amo(payload: dict):  # pylint: disable=too-many-l
             if contacts:
                 contact_id = int(contacts[0]["id"])
         except Exception:  # pylint: disable=broad-exception-caught
-            logger.warning("failed to fetch contact for lead %s", lead_id, exc_info=True)
+            logger.warning("не удалось получить контакт для сделки %s", lead_id, exc_info=True)
 
         conv_id = await with_retry(
             lambda: ensure_chat_created(

--- a/app/services/worker/system.py
+++ b/app/services/worker/system.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 async def handle_system_hh_autofill(_payload: dict) -> None:
     """Построить сопоставление статусов HH на основе воронок AmoCRM."""
-    logger.info("system.hh_autofill")
+    logger.info("system.hh_автозаполнение")
     tok = await DbTokenStore("amo").load()
     if (
         not tok


### PR DESCRIPTION
## Summary
- localize worker service handlers' docstrings and log messages to Russian

## Testing
- `python -m pytest tests/test_worker_handlers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c428a9a0748321a371bd441c712ec6